### PR TITLE
[POC] add integration with Doctrine DataFixtures

### DIFF
--- a/src/Bridge/FoundryDataFixture.php
+++ b/src/Bridge/FoundryDataFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zenstruck\Foundry\Bridge;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Zenstruck\Foundry\PersistenceManager;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+trait FoundryDataFixture
+{
+    /**
+     * @required
+     */
+    public function register(ManagerRegistry $registry): void
+    {
+        PersistenceManager::register($registry);
+    }
+}


### PR DESCRIPTION
Can use Foundry factories/stories within your Doctrine DataFixtures:

```php
namespace App\DataFixtures;

use App\Tests\Factories\PostFactory;
use App\Tests\Stories\DefaultCategoriesStory;
use Doctrine\Bundle\FixturesBundle\Fixture;
use Doctrine\Persistence\ObjectManager;
use Zenstruck\Foundry\Bridge\FoundryDataFixture;

class AppFixtures extends Fixture
{
    use FoundryDataFixture;

    public function load(ObjectManager $manager)
    {
        DefaultCategoriesStory::load();

        PostFactory::new()->createMany(10);
    }
}
```

Some potential issues:

1. Autowiring your fixtures is required because of the `@required` flag on `FoundryDataFixture::register()` (probably not a big deal as this is the default)
2. Leaks `tests/` objects into your `src/` directory. I'm not sure the best way to deal with this or even if it is a major problem. One solution could be to default the `make:factory`/`make:story` commands to create the objects in `src/Stories`/`src/Factories`.

**Major issue:** There are several "global" options that can be set in Foundry:

  - `Factory::registerDefaultInstantiator()`
  - `Factory::registerFaker()`
  - `Factory::proxyByDefault()`
  - `Proxy::autoRefreshByDefault()`

Currently, in the docs, it is advised to set these in `tests/bootstrap.php` as I never intended for factories/stories to be used outside the `test` env.

One solution could be to allow setting these options in your `.env` file:

```
# .env/.env.test etc

FOUNDRY_WITHOUT_CONSTRUCTOR=true
FOUNDRY_ALLOW_EXTRA_ATTRIBUTES=true
FOUNDRY_ALWAYS_FORCE_PROPERTIES=true
FOUNDRY_FAKER_LOCALE=fr_FR
FOUNDRY_PROXY_BY_DEFAULT=false
FOUNDRY_PROXY_AUTO_REFRESH=false
```

I could check the `$_SERVER` variables when determining defaults.