### PR TITLE
[bug] refactor ModelFactory::initialize()

### DIFF
--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -33,6 +33,10 @@ abstract class ModelFactory extends Factory
             ->initialize()
         ;
 
+        if (!$factory instanceof static) {
+            throw new \TypeError(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', static::class));
+        }
+
         foreach ($states as $state) {
             $factory = $factory->{$state}();
         }
@@ -65,8 +69,10 @@ abstract class ModelFactory extends Factory
 
     /**
      * Override to add default instantiator and default afterInstantiate/afterPersist events.
+     *
+     * @return static
      */
-    protected function initialize(): self
+    protected function initialize()
     {
         return $this;
     }

--- a/tests/Fixtures/Factories/PostFactory.php
+++ b/tests/Fixtures/Factories/PostFactory.php
@@ -8,7 +8,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class PostFactory extends ModelFactory
+class PostFactory extends ModelFactory
 {
     public function published(): self
     {

--- a/tests/Fixtures/Factories/PostFactoryWithInvalidInitialize.php
+++ b/tests/Fixtures/Factories/PostFactoryWithInvalidInitialize.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class PostFactoryWithInvalidInitialize extends PostFactory
+{
+    protected function initialize()
+    {
+        return PostFactory::new();
+    }
+}

--- a/tests/Fixtures/Factories/PostFactoryWithNullInitialize.php
+++ b/tests/Fixtures/Factories/PostFactoryWithNullInitialize.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class PostFactoryWithNullInitialize extends PostFactory
+{
+    protected function initialize()
+    {
+    }
+}

--- a/tests/Fixtures/Factories/PostFactoryWithValidInitialize.php
+++ b/tests/Fixtures/Factories/PostFactoryWithValidInitialize.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class PostFactoryWithValidInitialize extends PostFactory
+{
+    protected function initialize(): self
+    {
+        return $this->published();
+    }
+}

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -3,6 +3,10 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
 use Zenstruck\Foundry\Tests\FunctionalTestCase;
 
 /**
@@ -20,5 +24,36 @@ final class ModelFactoryTest extends FunctionalTestCase
         CategoryFactory::repository()->assertCount(1);
         CategoryFactory::findOrCreate(['name' => 'php']);
         CategoryFactory::repository()->assertCount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_initialize(): void
+    {
+        $this->assertFalse(PostFactory::new()->create()->isPublished());
+        $this->assertTrue(PostFactoryWithValidInitialize::new()->create()->isPublished());
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_an_instance_of_the_current_factory(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithInvalidInitialize::class));
+
+        PostFactoryWithInvalidInitialize::new();
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_a_value(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithNullInitialize::class));
+
+        PostFactoryWithNullInitialize::new();
     }
 }


### PR DESCRIPTION
When overriding this method with phpstorm's override dialog, it would set the return type to `ModelFactory` which was wrong.

- remove `self` return type, add `@return static` to docblock
- ensure instance of current factory is returned

(PHP 8 allows for `static` return type, should be able to switch to that in the future)