### PR TITLE
Add support for OneToMany/ManyToOne/ManyToMany relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ public function test_can_post_a_comment(): void
     1. [Instantiate](#instantiate)
     2. [Persist](#persist)
     3. [Attributes](#attributes)
-    4. [Events](#events)
-    5. [Instantiator](#instantiator)
-    6. [Immutable](#immutable)
-    7. [Object Proxy](#object-proxy)
-    8. [Repository Proxy](#repository-proxy)
+    4. [Doctrine Relationships](#doctrine-relationships)
+    5. [Events](#events)
+    6. [Instantiator](#instantiator)
+    7. [Immutable](#immutable)
+    8. [Object Proxy](#object-proxy)
+    9. [Repository Proxy](#repository-proxy)
 6. [Model Factories](#model-factories)
     1. [Generate](#generate)
     2. [Usage](#usage)
@@ -362,6 +363,56 @@ $post->getBody(); // "Post A Body..."
 $post->getCategory()->getName(); // "symfony"
 $post->getPublishedAt(); // \DateTime('last week')
 $post->getCreatedAt(); // random \DateTime
+```
+
+#### Doctrine Relationships
+
+Assuming your entites follow the
+[best practices for Doctrine Relationships](https://symfony.com/doc/current/doctrine/associations.html) and you are
+using the [default instantiator](#instantiator), Foundry *just works* with doctrine relationships:
+
+```php
+use function Zenstruck\Foundry\create;
+use function Zenstruck\Foundry\factory;
+
+// ManyToOne
+create(Post::class, [
+    'category' => $category, // $category is instance of Category
+]);
+create(Post::class, [
+    // Proxy objects are converted to object before calling Post::setCategory()
+    'category' => create(Category::class, ['name' => 'My Category']),
+]);
+create(Post::class, [
+    // Factory objects are persisted before calling Post::setCategory()
+    'category' => factory(Category::class, ['name' => 'My Category']),
+]);
+
+// OneToMany
+create(Category::class, [
+    'posts' => [
+        $post, // $post is instance of Post, Category::addPost($post) will be called during instantiation
+
+        // Proxy objects are converted to object before calling Category::addPost()
+        create(Post::class, ['title' => 'Post B', 'body' => 'body']),
+
+        // Factory objects are persisted before calling Category::addPost()
+        factory(Post::class, ['title' => 'Post A', 'body' => 'body']),
+    ],
+]);
+
+// ManyToMany
+create(Post::class, [
+    'tags' => [
+        $tag, // $tag is instance of Tag, Post::addTag($tag) will be called during instantiation
+
+        // Proxy objects are converted to object before calling Post::addTag()
+        create(Tag::class, ['name' => 'My Tag']),
+
+        // Factory objects are persisted before calling Post::addTag()
+        factory(Tag::class, ['name' => 'My Tag']),
+    ],
+]);
 ```
 
 #### Events

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -220,6 +220,11 @@ class Factory
             return $value->object();
         }
 
+        if (\is_array($value)) {
+            // possible OneToMany/ManyToMany relationship
+            return \array_map(fn($value) => self::filterNormalizedProperty($value, $persist), $value);
+        }
+
         if (!$value instanceof self) {
             return $value;
         }

--- a/tests/Fixtures/Entity/Category.php
+++ b/tests/Fixtures/Entity/Category.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -21,6 +22,16 @@ class Category
      */
     private $name;
 
+    /**
+     * @ORM\OneToMany(targetEntity=Post::class, mappedBy="category")
+     */
+    private $posts;
+
+    public function __construct()
+    {
+        $this->posts = new ArrayCollection();
+    }
+
     public function getId()
     {
         return $this->id;
@@ -34,5 +45,29 @@ class Category
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function getPosts()
+    {
+        return $this->posts;
+    }
+
+    public function addPost(Post $post)
+    {
+        if (!$this->posts->contains($post)) {
+            $this->posts[] = $post;
+            $post->setCategory($this);
+        }
+    }
+
+    public function removePost(Post $post)
+    {
+        if ($this->posts->contains($post)) {
+            $this->posts->removeElement($post);
+            // set the owning side to null (unless already changed)
+            if ($post->getCategory() === $this) {
+                $post->setCategory(null);
+            }
+        }
     }
 }

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -47,10 +48,15 @@ class Post
     private $publishedAt;
 
     /**
-     * @ORM\ManyToOne(targetEntity=Category::class)
+     * @ORM\ManyToOne(targetEntity=Category::class, inversedBy="posts")
      * @ORM\JoinColumn
      */
     private $category;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=Tag::class, inversedBy="posts")
+     */
+    private $tags;
 
     public function __construct(string $title, string $body, string $shortDescription = null)
     {
@@ -58,6 +64,7 @@ class Post
         $this->body = $body;
         $this->shortDescription = $shortDescription;
         $this->createdAt = new \DateTime('now');
+        $this->tags = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -100,7 +107,7 @@ class Post
         return $this->category;
     }
 
-    public function setCategory(Category $category)
+    public function setCategory(?Category $category)
     {
         $this->category = $category;
     }
@@ -113,5 +120,24 @@ class Post
     public function setPublishedAt(\DateTime $timestamp)
     {
         $this->publishedAt = $timestamp;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag)
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags[] = $tag;
+        }
+    }
+
+    public function removeTag(Tag $tag)
+    {
+        if ($this->tags->contains($tag)) {
+            $this->tags->removeElement($tag);
+        }
     }
 }

--- a/tests/Fixtures/Entity/Tag.php
+++ b/tests/Fixtures/Entity/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -21,6 +22,16 @@ class Tag
      */
     private $name;
 
+    /**
+     * @ORM\ManyToMany(targetEntity=Post::class, mappedBy="tags")
+     */
+    private $posts;
+
+    public function __construct()
+    {
+        $this->posts = new ArrayCollection();
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -29,5 +40,26 @@ class Tag
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function getPosts()
+    {
+        return $this->posts;
+    }
+
+    public function addPost(Post $post)
+    {
+        if (!$this->posts->contains($post)) {
+            $this->posts[] = $post;
+            $post->addTag($this);
+        }
+    }
+
+    public function removePost(Post $post)
+    {
+        if ($this->posts->contains($post)) {
+            $this->posts->removeElement($post);
+            $post->removeTag($this);
+        }
     }
 }

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
+use Zenstruck\Foundry\Tests\FunctionalTestCase;
+use function Zenstruck\Foundry\create;
+use function Zenstruck\Foundry\factory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class FactoryTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function many_to_one_relationship(): void
+    {
+        $categoryFactory = factory(Category::class, ['name' => 'foo']);
+        $category = create(Category::class, ['name' => 'bar']);
+        $postA = create(Post::class, ['title' => 'title', 'body' => 'body', 'category' => $categoryFactory]);
+        $postB = create(Post::class, ['title' => 'title', 'body' => 'body', 'category' => $category]);
+
+        $this->assertSame('foo', $postA->getCategory()->getName());
+        $this->assertSame('bar', $postB->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_many_relationship(): void
+    {
+        $category = create(Category::class, [
+            'name' => 'bar',
+            'posts' => [
+                factory(Post::class, ['title' => 'Post A', 'body' => 'body']),
+                create(Post::class, ['title' => 'Post B', 'body' => 'body']),
+            ],
+        ]);
+
+        $posts = \array_map(fn($post) => $post->getTitle(), $category->getPosts()->toArray());
+
+        $this->assertCount(2, $posts);
+        $this->assertContains('Post A', $posts);
+        $this->assertContains('Post B', $posts);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_many_relationship(): void
+    {
+        $post = create(Post::class, [
+            'title' => 'title',
+            'body' => 'body',
+            'tags' => [
+                factory(Tag::class, ['name' => 'Tag A']),
+                create(Tag::class, ['name' => 'Tag B']),
+            ],
+        ]);
+
+        $tags = \array_map(fn($tag) => $tag->getName(), $post->getTags()->toArray());
+
+        $this->assertCount(2, $tags);
+        $this->assertContains('Tag A', $tags);
+        $this->assertContains('Tag B', $tags);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_many_reverse_relationship(): void
+    {
+        $tag = create(Tag::class, [
+            'name' => 'bar',
+            'posts' => [
+                factory(Post::class, ['title' => 'Post A', 'body' => 'body']),
+                create(Post::class, ['title' => 'Post B', 'body' => 'body']),
+            ],
+        ]);
+
+        $posts = \array_map(fn($post) => $post->getTitle(), $tag->getPosts()->toArray());
+
+        $this->assertCount(2, $posts);
+        $this->assertContains('Post A', $posts);
+        $this->assertContains('Post B', $posts);
+    }
+}


### PR DESCRIPTION
```php
use function Zenstruck\Foundry\create;
use function Zenstruck\Foundry\factory;

// ManyToOne
create(Post::class, [
    'category' => $category, // $category is instance of Category
]);
create(Post::class, [
    // Proxy objects are converted to object before calling Post::setCategory()
    'category' => create(Category::class, ['name' => 'My Category']),
]);
create(Post::class, [
    // Factory objects are persisted before calling Post::setCategory()
    'category' => factory(Category::class, ['name' => 'My Category']),
]);

// OneToMany
create(Category::class, [
    'posts' => [
        $post, // $post is instance of Post, Category::addPost($post) will be called during instantiation

        // Proxy objects are converted to object before calling Category::addPost()
        create(Post::class, ['title' => 'Post B', 'body' => 'body']),

        // Factory objects are persisted before calling Category::addPost()
        factory(Post::class, ['title' => 'Post A', 'body' => 'body']),
    ],
]);

// ManyToMany
create(Post::class, [
    'tags' => [
        $tag, // $tag is instance of Tag, Post::addTag($tag) will be called during instantiation

        // Proxy objects are converted to object before calling Post::addTag()
        create(Tag::class, ['name' => 'My Tag']),

        // Factory objects are persisted before calling Post::addTag()
        factory(Tag::class, ['name' => 'My Tag']),
    ],
]);
```