### PR TITLE
[minor] Default makers to generate in src/

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,15 +640,15 @@ Create a model factory for one of your entities with the maker command:
 
 **NOTES**:
 
-1. Creates `PostFactory.php` in `src/Factories`, add `--test` flag to create in `tests/Factories`.
+1. Creates `PostFactory.php` in `src/Factory`, add `--test` flag to create in `tests/Factory`.
 2. Calling `make:factory` without arguments displays a list of registered entities in your app to choose from.
 
 Customize the generated model factory (if not using the maker command, this is what you will need to create manually):
 
 ```php
-// src/Factories/PostFactory.php
+// src/Factory/PostFactory.php
 
-namespace App\Factories;
+namespace App\Factory;
 
 use App\Entity\Post;
 use App\Repository\PostRepository;
@@ -692,7 +692,7 @@ Model factories extend `Zenstruck/Foundry/Factory` so all [methods and functiona
 available.
 
 ```php
-use App\Factories\PostFactory;
+use App\Factory\PostFactory;
 
 $post = PostFactory::new()->create(); // Proxy with random data from `getDefaults()`
 
@@ -729,7 +729,7 @@ You can add any methods you want to your model factories (ie static methods that
 you can add "states":
 
 ```php
-namespace App\Factories;
+namespace App\Factory;
 
 use App\Entity\Post;
 use Zenstruck\Foundry\ModelFactory;
@@ -790,7 +790,7 @@ $post = PostFactory::new('published', 'withViewCount')->create();
 You can override your model factory's `initialize()` method to add default state/logic:
 
 ```php
-namespace App\Factories;
+namespace App\Factory;
 
 use App\Entity\Post;
 use Zenstruck\Foundry\ModelFactory;
@@ -822,16 +822,16 @@ Create a story using the maker command:
 
     $ bin/console make:story Post
 
-**NOTE**: Creates `PostStory.php` in `src/Stories`, add `--test` flag to create in `tests/Stories`.
+**NOTE**: Creates `PostStory.php` in `src/Story`, add `--test` flag to create in `tests/Story`.
 
 Modify the *build* method to set the state for this story:
 
 ```php
-// src/Stories/PostStory.php
+// src/Story/PostStory.php
 
-namespace App\Stories;
+namespace App\Story;
 
-use App\Factories\PostFactory;
+use App\Factory\PostFactory;
 use Zenstruck\Foundry\Story;
 
 final class PostStory extends Story

--- a/README.md
+++ b/README.md
@@ -638,12 +638,17 @@ Create a model factory for one of your entities with the maker command:
 
     $ bin/console make:factory Post
 
-**NOTE**: Calling `make:factory` without arguments displays a list of registered entities in your app to choose from.
+**NOTES**:
+
+1. Creates `PostFactory.php` in `src/Factories`, add `--test` flag to create in `tests/Factories`.
+2. Calling `make:factory` without arguments displays a list of registered entities in your app to choose from.
 
 Customize the generated model factory (if not using the maker command, this is what you will need to create manually):
 
 ```php
-namespace App\Tests\Factories;
+// src/Factories/PostFactory.php
+
+namespace App\Factories;
 
 use App\Entity\Post;
 use App\Repository\PostRepository;
@@ -687,7 +692,7 @@ Model factories extend `Zenstruck/Foundry/Factory` so all [methods and functiona
 available.
 
 ```php
-use App\Tests\Factories\PostFactory;
+use App\Factories\PostFactory;
 
 $post = PostFactory::new()->create(); // Proxy with random data from `getDefaults()`
 
@@ -724,7 +729,7 @@ You can add any methods you want to your model factories (ie static methods that
 you can add "states":
 
 ```php
-namespace App\Tests\Factories;
+namespace App\Factories;
 
 use App\Entity\Post;
 use Zenstruck\Foundry\ModelFactory;
@@ -785,7 +790,7 @@ $post = PostFactory::new('published', 'withViewCount')->create();
 You can override your model factory's `initialize()` method to add default state/logic:
 
 ```php
-namespace App\Tests\Factories;
+namespace App\Factories;
 
 use App\Entity\Post;
 use Zenstruck\Foundry\ModelFactory;
@@ -817,17 +822,21 @@ Create a story using the maker command:
 
     $ bin/console make:story Post
 
-This creates a *Story* object in `tests/Stories`. Modify the *build* method to set the state for this story:
+**NOTE**: Creates `PostStory.php` in `src/Stories`, add `--test` flag to create in `tests/Stories`.
+
+Modify the *build* method to set the state for this story:
 
 ```php
-namespace App\Tests\Stories;
+// src/Stories/PostStory.php
 
-use App\Tests\Factories\PostFactory;
+namespace App\Stories;
+
+use App\Factories\PostFactory;
 use Zenstruck\Foundry\Story;
 
 final class PostStory extends Story
 {
-    protected function build(): void
+    public function build(): void
     {
         // use "add" to have the object managed by the story and can be accessed in
         // tests and other stories via PostStory::postA()

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -35,6 +36,7 @@ final class MakeFactory extends AbstractMaker
         $command
             ->setDescription('Creates a custom factory for a Doctrine entity class')
             ->addArgument('entity', InputArgument::OPTIONAL, 'Entity class to create a factory for')
+            ->addOption('test', null, InputOption::VALUE_NONE, 'Create in <fg=yellow>tests/</> instead of <fg=yellow>src/</>')
         ;
 
         $inputConfig->setArgumentAsNonInteractive('entity');
@@ -67,7 +69,7 @@ final class MakeFactory extends AbstractMaker
         $entity = new \ReflectionClass($class);
         $factory = $generator->createClassNameDetails(
             $entity->getShortName(),
-            'Tests\\Factories\\',
+            $input->getOption('test') ? 'Tests\\Factories' : 'Factories',
             'Factory'
         );
 

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -56,6 +56,11 @@ final class MakeFactory extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        if (!$input->getOption('test')) {
+            $io->text('// Note: pass <fg=yellow>--test</> if you want to generate factories in your <fg=yellow>tests/</> directory');
+            $io->newLine();
+        }
+
         $class = $input->getArgument('entity');
 
         if (!\class_exists($class)) {

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -69,7 +69,7 @@ final class MakeFactory extends AbstractMaker
         $entity = new \ReflectionClass($class);
         $factory = $generator->createClassNameDetails(
             $entity->getShortName(),
-            $input->getOption('test') ? 'Tests\\Factories' : 'Factories',
+            $input->getOption('test') ? 'Tests\\Factory' : 'Factory',
             'Factory'
         );
 

--- a/src/Bundle/Maker/MakeStory.php
+++ b/src/Bundle/Maker/MakeStory.php
@@ -10,6 +10,7 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -26,6 +27,7 @@ final class MakeStory extends AbstractMaker
         $command
             ->setDescription('Creates a factory story')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the story class (e.g. <fg=yellow>DefaultCategoriesStory</>)')
+            ->addOption('test', null, InputOption::VALUE_NONE, 'Create in <fg=yellow>tests/</> instead of <fg=yellow>src/</>')
         ;
     }
 
@@ -33,7 +35,7 @@ final class MakeStory extends AbstractMaker
     {
         $storyClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Tests\\Stories\\',
+            $input->getOption('test') ? 'Tests\\Stories' : 'Stories',
             'Story'
         );
 

--- a/src/Bundle/Maker/MakeStory.php
+++ b/src/Bundle/Maker/MakeStory.php
@@ -35,7 +35,7 @@ final class MakeStory extends AbstractMaker
     {
         $storyClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            $input->getOption('test') ? 'Tests\\Stories' : 'Stories',
+            $input->getOption('test') ? 'Tests\\Story' : 'Story',
             'Story'
         );
 

--- a/src/Bundle/Maker/MakeStory.php
+++ b/src/Bundle/Maker/MakeStory.php
@@ -33,6 +33,11 @@ final class MakeStory extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        if (!$input->getOption('test')) {
+            $io->text('// Note: pass <fg=yellow>--test</> if you want to generate stories in your <fg=yellow>tests/</> directory');
+            $io->newLine();
+        }
+
         $storyClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
             $input->getOption('test') ? 'Tests\\Story' : 'Story',


### PR DESCRIPTION
- Add `--test` option to generate in `tests/`

**Questions:** 

1. Should `--test` be interactive?
2. Should the folders be plural (current) or singular? `src/Stories` or `src/Story`, `src/Factories` or `src/Factory`. Mostly, it seems the standard is singular (with the exception of `Migrations`).