### PR TITLE
[minor] refactor Proxy auto-refresh methods

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -52,13 +52,13 @@ class Factory
             return $proxy;
         }
 
-        $proxy->save()->withoutAutoRefresh();
+        $proxy->save()->disableAutoRefresh();
 
         foreach ($this->afterPersist as $callback) {
-            $this->callAfterPersist($callback, $proxy, $attributes);
+            $proxy->executeCallback($callback, $attributes);
         }
 
-        return $proxy->withAutoRefresh();
+        return $proxy->enableAutoRefresh();
     }
 
     /**
@@ -157,18 +157,6 @@ class Factory
     final public static function faker(): Faker\Generator
     {
         return self::configuration()->faker();
-    }
-
-    private function callAfterPersist(callable $callback, Proxy $proxy, array $attributes): void
-    {
-        $object = $proxy;
-        $parameters = (new \ReflectionFunction($callback))->getParameters();
-
-        if (isset($parameters[0]) && $parameters[0]->getType() && $this->class === $parameters[0]->getType()->getName()) {
-            $object = $object->object();
-        }
-
-        $callback($object, $attributes);
     }
 
     /**

--- a/tests/Functional/ProxyTest.php
+++ b/tests/Functional/ProxyTest.php
@@ -119,7 +119,7 @@ final class ProxyTest extends FunctionalTestCase
         $this->assertSame('old body', $post->getBody());
 
         $post
-            ->withoutAutoRefresh()
+            ->disableAutoRefresh()
             ->forceSet('title', 'new title')
             ->forceSet('body', 'new body')
             ->save()

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -255,7 +255,7 @@ final class FactoryTest extends UnitTestCase
         $object = (new Factory(Post::class))->create(['title' => 'title', 'body' => 'body']);
 
         $this->assertInstanceOf(Proxy::class, $object);
-        $this->assertSame('title', $object->withoutAutoRefresh()->getTitle());
+        $this->assertSame('title', $object->disableAutoRefresh()->getTitle());
     }
 
     /**
@@ -279,9 +279,9 @@ final class FactoryTest extends UnitTestCase
         $this->assertInstanceOf(Proxy::class, $objects[0]);
         $this->assertInstanceOf(Proxy::class, $objects[1]);
         $this->assertInstanceOf(Proxy::class, $objects[2]);
-        $this->assertSame('title', $objects[0]->withoutAutoRefresh()->getTitle());
-        $this->assertSame('title', $objects[1]->withoutAutoRefresh()->getTitle());
-        $this->assertSame('title', $objects[2]->withoutAutoRefresh()->getTitle());
+        $this->assertSame('title', $objects[0]->disableAutoRefresh()->getTitle());
+        $this->assertSame('title', $objects[1]->disableAutoRefresh()->getTitle());
+        $this->assertSame('title', $objects[2]->disableAutoRefresh()->getTitle());
     }
 
     /**
@@ -322,13 +322,18 @@ final class FactoryTest extends UnitTestCase
                 $post->increaseViewCount();
                 ++$calls;
             })
+            ->afterPersist(function($post) use (&$calls) {
+                $this->assertInstanceOf(Proxy::class, $post);
+
+                ++$calls;
+            })
             ->afterPersist(static function() use (&$calls) {
                 ++$calls;
             })
             ->create($attributesArray)
         ;
 
-        $this->assertSame(3, $object->withoutAutoRefresh()->getViewCount());
-        $this->assertSame(4, $calls);
+        $this->assertSame(3, $object->disableAutoRefresh()->getViewCount());
+        $this->assertSame(5, $calls);
     }
 }

--- a/tests/Unit/ProxyTest.php
+++ b/tests/Unit/ProxyTest.php
@@ -83,4 +83,31 @@ final class ProxyTest extends UnitTestCase
 
         $this->assertTrue($category->isPersisted());
     }
+
+    /**
+     * @test
+     */
+    public function can_use_without_auto_refresh_with_proxy_or_object_typehint(): void
+    {
+        $proxy = new Proxy(new Category());
+        $calls = 0;
+
+        $proxy
+            ->withoutAutoRefresh(static function(Proxy $proxy) use (&$calls) {
+                ++$calls;
+            })
+            ->withoutAutoRefresh(static function(Category $category) use (&$calls) {
+                ++$calls;
+            })
+            ->withoutAutoRefresh(function($proxy) use (&$calls) {
+                $this->assertInstanceOf(Proxy::class, $proxy);
+                ++$calls;
+            })
+            ->withoutAutoRefresh(static function() use (&$calls) {
+                ++$calls;
+            })
+        ;
+
+        $this->assertSame(4, $calls);
+    }
 }


### PR DESCRIPTION
- rename `withAutoRefresh()` to `enableAutoRefresh()`
- rename `withoutAutoRefresh()` to `disableAutoRefresh()`
- add `withoutAutoRefresh(callable)` to disable before executing callback and re-enable after
- `withoutAutoRefresh`'s closure takes the `Proxy` by default, but if its type-hint is the wrapped object, it is passed