### PR TITLE
Add FactoryCollection

### DIFF
--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class FactoryCollection
+{
+    /** @var Factory */
+    private $factory;
+
+    /** @var int */
+    private $min;
+
+    /** @var int */
+    private $max;
+
+    /**
+     * @param int|null $max If set, when created, the collection will be a random size between $min and $max
+     */
+    public function __construct(Factory $factory, int $min, ?int $max = null)
+    {
+        if ($max && $min > $max) {
+            throw new \InvalidArgumentException('Min must be less than max.');
+        }
+
+        $this->factory = $factory;
+        $this->min = $min;
+        $this->max = $max ?? $min;
+    }
+
+    /**
+     * @param array|callable $attributes
+     *
+     * @return Proxy[]|object[]
+     */
+    public function create($attributes = []): array
+    {
+        return \array_map(
+            static function(Factory $factory) use ($attributes) {
+                return $factory->create($attributes);
+            },
+            $this->all()
+        );
+    }
+
+    /**
+     * @return Factory[]
+     */
+    public function all(): array
+    {
+        return \array_map(
+            function() {
+                return clone $this->factory;
+            },
+            \array_fill(0, \random_int($this->min, $this->max), null)
+        );
+    }
+
+    public function factory(): Factory
+    {
+        return $this->factory;
+    }
+}

--- a/tests/Fixtures/Entity/Comment.php
+++ b/tests/Fixtures/Entity/Comment.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Comment
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=User::class)
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $user;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    private $body;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Post::class, inversedBy="comments")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private $post;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $approved = false;
+
+    public function __construct(User $user, string $body)
+    {
+        $this->user = $user;
+        $this->body = $body;
+        $this->createdAt = new \DateTime('now');
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(string $body): self
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getPost(): ?Post
+    {
+        return $this->post;
+    }
+
+    public function setPost(?Post $post): self
+    {
+        $this->post = $post;
+
+        return $this;
+    }
+
+    public function getApproved(): ?bool
+    {
+        return $this->approved;
+    }
+
+    public function setApproved(bool $approved): self
+    {
+        $this->approved = $approved;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -58,6 +58,11 @@ class Post
      */
     private $tags;
 
+    /**
+     * @ORM\OneToMany(targetEntity=Comment::class, mappedBy="post")
+     */
+    private $comments;
+
     public function __construct(string $title, string $body, ?string $shortDescription = null)
     {
         $this->title = $title;
@@ -65,6 +70,7 @@ class Post
         $this->shortDescription = $shortDescription;
         $this->createdAt = new \DateTime('now');
         $this->tags = new ArrayCollection();
+        $this->comments = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -139,5 +145,33 @@ class Post
         if ($this->tags->contains($tag)) {
             $this->tags->removeElement($tag);
         }
+    }
+
+    public function getComments()
+    {
+        return $this->comments;
+    }
+
+    public function addComment(Comment $comment): self
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments[] = $comment;
+            $comment->setPost($this);
+        }
+
+        return $this;
+    }
+
+    public function removeComment(Comment $comment): self
+    {
+        if ($this->comments->contains($comment)) {
+            $this->comments->removeElement($comment);
+            // set the owning side to null (unless already changed)
+            if ($comment->getPost() === $this) {
+                $comment->setPost(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/tests/Fixtures/Entity/User.php
+++ b/tests/Fixtures/Entity/User.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Factories/CommentFactory.php
+++ b/tests/Fixtures/Factories/CommentFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Comment;
+
+final class CommentFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'user' => UserFactory::new(),
+            'body' => self::faker()->sentence,
+            'created_at' => self::faker()->dateTime,
+            'post' => PostFactory::new(),
+        ];
+    }
+
+    protected static function getClass(): string
+    {
+        return Comment::class;
+    }
+}

--- a/tests/Fixtures/Factories/UserFactory.php
+++ b/tests/Fixtures/Factories/UserFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\User;
+
+final class UserFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'name' => self::faker()->name,
+        ];
+    }
+
+    protected static function getClass(): string
+    {
+        return User::class;
+    }
+}

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -3,10 +3,12 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 use Zenstruck\Foundry\Tests\FunctionalTestCase;
 
 /**
@@ -106,5 +108,24 @@ final class ModelFactoryTest extends FunctionalTestCase
         $this->assertContains(3, $counts);
         $this->assertNotContains(4, $counts);
         $this->assertNotContains(5, $counts);
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_many_with_nested_relationship(): void
+    {
+        $post = PostFactory::new()->create([
+            'comments' => [
+                CommentFactory::new(),
+                CommentFactory::new(),
+                CommentFactory::new(),
+                CommentFactory::new(),
+            ],
+        ]);
+
+        $this->assertCount(4, $post->getComments());
+        UserFactory::repository()->assertCount(4);
+        PostFactory::repository()->assertCount(1); // fails (count=5, 1 primary, 1 for each comment)
     }
 }

--- a/tests/Unit/FactoryCollectionTest.php
+++ b/tests/Unit/FactoryCollectionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Unit;
+
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\UnitTestCase;
+use function Zenstruck\Foundry\factory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class FactoryCollectionTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function can_create_with_static_size(): void
+    {
+        $collection = new FactoryCollection(factory(Category::class)->withoutPersisting(), 2);
+
+        $this->assertCount(2, $collection->create());
+        $this->assertCount(2, $collection->create());
+        $this->assertCount(2, $collection->create());
+        $this->assertCount(2, $collection->create());
+        $this->assertCount(2, $collection->create());
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_with_random_range(): void
+    {
+        $collection = new FactoryCollection(factory(Category::class)->withoutPersisting(), 0, 3);
+        $counts = [];
+
+        while (4 !== \count(\array_unique($counts))) {
+            $counts[] = \count($collection->create());
+        }
+
+        $this->assertCount(4, \array_unique($counts));
+        $this->assertContains(0, $counts);
+        $this->assertContains(1, $counts);
+        $this->assertContains(2, $counts);
+        $this->assertContains(3, $counts);
+        $this->assertNotContains(4, $counts);
+        $this->assertNotContains(5, $counts);
+    }
+
+    /**
+     * @test
+     */
+    public function min_must_be_less_than_or_equal_to_max(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectDeprecationMessage('Min must be less than max.');
+
+        new FactoryCollection(factory(Category::class)->withoutPersisting(), 4, 3);
+    }
+}


### PR DESCRIPTION
Adds a `Factory::many()` method that returns a `FactoryCollection` object to help with *lazily* creating factories with *-many relationships. This really helps the DX of one-to-many relationships.

#### Examples:

```php
// create 10 Post's
PostFactory::new()->createMany(10, [
    'comments' => CommentFactory::new()->many(3), // each post will have 3 Comment's
]);

// create 10 Post's
PostFactory::new()->createMany(10, [
    'comments' => CommentFactory::new()->many(0, 5), // each post will have between 0 and 5 Comment's
]);
```

#### TODO:

- [x] update docs