### PR TITLE
Allow factories to be defined as services

### DIFF
--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Story;
 
 /**
@@ -22,6 +23,10 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
 
         $container->registerForAutoconfiguration(Story::class)
             ->addTag('foundry.story')
+        ;
+
+        $container->registerForAutoconfiguration(ModelFactory::class)
+            ->addTag('foundry.factory')
         ;
 
         $this->configureFaker($mergedConfig['faker'], $container);

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -13,6 +13,7 @@
         <service id="Zenstruck\Foundry\Configuration" public="true">
             <argument type="service" id="doctrine" />
             <argument type="service" id="Zenstruck\Foundry\StoryManager" />
+            <argument type="service" id="Zenstruck\Foundry\ModelFactoryManager" />
             <call method="setInstantiator">
                 <argument type="service" id="zenstruck_foundry.default_instantiator" />
             </call>
@@ -23,6 +24,10 @@
 
         <service id="Zenstruck\Foundry\StoryManager">
             <argument type="tagged_iterator" tag="foundry.story" />
+        </service>
+
+        <service id="Zenstruck\Foundry\ModelFactoryManager">
+            <argument type="tagged_iterator" tag="foundry.factory" />
         </service>
 
         <service id="Zenstruck\Foundry\Bundle\Maker\MakeFactory">

--- a/src/Bundle/Resources/skeleton/Factory.tpl.php
+++ b/src/Bundle/Resources/skeleton/Factory.tpl.php
@@ -21,6 +21,13 @@ use Zenstruck\Foundry\Proxy;
  */
 final class <?= $class_name ?> extends ModelFactory
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // TODO inject services if required (https://github.com/zenstruck/foundry#factories-as-services)
+    }
+
     protected function getDefaults(): array
     {
         return [

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -19,6 +19,9 @@ final class Configuration
     /** @var StoryManager */
     private $stories;
 
+    /** @var ModelFactoryManager */
+    private $factories;
+
     /** @var Faker\Generator */
     private $faker;
 
@@ -28,10 +31,11 @@ final class Configuration
     /** @var bool */
     private $defaultProxyAutoRefresh = false;
 
-    public function __construct(ManagerRegistry $managerRegistry, StoryManager $storyManager)
+    public function __construct(ManagerRegistry $managerRegistry, StoryManager $storyManager, ModelFactoryManager $factories)
     {
         $this->managerRegistry = $managerRegistry;
         $this->stories = $storyManager;
+        $this->factories = $factories;
         $this->faker = Faker\Factory::create();
         $this->instantiator = new Instantiator();
     }
@@ -39,6 +43,11 @@ final class Configuration
     public function stories(): StoryManager
     {
         return $this->stories;
+    }
+
+    public function factories(): ModelFactoryManager
+    {
+        return $this->factories;
     }
 
     public function faker(): Faker\Generator

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -7,7 +7,7 @@ namespace Zenstruck\Foundry;
  */
 abstract class ModelFactory extends Factory
 {
-    private function __construct()
+    public function __construct()
     {
         parent::__construct(static::getClass());
     }
@@ -23,7 +23,7 @@ abstract class ModelFactory extends Factory
             $defaultAttributes = [];
         }
 
-        $factory = new static();
+        $factory = self::configuration()->factories()->create(static::class);
         $factory = $factory
             ->withAttributes([$factory, 'getDefaults'])
             ->withAttributes($defaultAttributes)

--- a/src/ModelFactoryManager.php
+++ b/src/ModelFactoryManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+/**
+ * @internal
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ModelFactoryManager
+{
+    private $factories;
+
+    /**
+     * @param ModelFactory[] $factories
+     */
+    public function __construct(iterable $factories)
+    {
+        $this->factories = $factories;
+    }
+
+    public function create(string $class): ModelFactory
+    {
+        foreach ($this->factories as $factory) {
+            if ($class === \get_class($factory)) {
+                return $factory;
+            }
+        }
+
+        return new $class();
+    }
+}

--- a/src/Test/TestState.php
+++ b/src/Test/TestState.php
@@ -7,6 +7,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\ModelFactoryManager;
 use Zenstruck\Foundry\StoryManager;
 
 /**
@@ -87,7 +88,7 @@ final class TestState
         }
 
         try {
-            return self::bootFactory(new Configuration($container->get('doctrine'), new StoryManager([])));
+            return self::bootFactory(new Configuration($container->get('doctrine'), new StoryManager([]), new ModelFactoryManager([])));
         } catch (NotFoundExceptionInterface $e) {
             throw new \LogicException('Could not boot Foundry, is the DoctrineBundle installed/configured?', 0, $e);
         }

--- a/tests/Fixtures/Factories/CategoryServiceFactory.php
+++ b/tests/Fixtures/Factories/CategoryServiceFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Service;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CategoryServiceFactory extends ModelFactory
+{
+    private $service;
+
+    public function __construct(Service $service)
+    {
+        parent::__construct();
+
+        $this->service = $service;
+    }
+
+    protected static function getClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return ['name' => $this->service->name];
+    }
+}

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -12,6 +12,8 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryServiceFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\ServiceStory;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
@@ -53,6 +55,14 @@ class Kernel extends BaseKernel
 
         $c->register(Service::class);
         $c->register(ServiceStory::class)
+            ->setAutoconfigured(true)
+            ->setAutowired(true)
+        ;
+        $c->register(CategoryFactory::class)
+            ->setAutoconfigured(true)
+            ->setAutowired(true)
+        ;
+        $c->register(CategoryServiceFactory::class)
             ->setAutoconfigured(true)
             ->setAutowired(true)
         ;

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -43,6 +43,13 @@ use Zenstruck\\Foundry\\Proxy;
  */
 final class CategoryFactory extends ModelFactory
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // TODO inject services if required (https://github.com/zenstruck/foundry#factories-as-services)
+    }
+
     protected function getDefaults(): array
     {
         return [
@@ -103,6 +110,13 @@ use Zenstruck\\Foundry\\Proxy;
  */
 final class CategoryFactory extends ModelFactory
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // TODO inject services if required (https://github.com/zenstruck/foundry#factories-as-services)
+    }
+
     protected function getDefaults(): array
     {
         return [
@@ -160,6 +174,13 @@ use Zenstruck\\Foundry\\Proxy;
  */
 final class CategoryFactory extends ModelFactory
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // TODO inject services if required (https://github.com/zenstruck/foundry#factories-as-services)
+    }
+
     protected function getDefaults(): array
     {
         return [
@@ -220,6 +241,13 @@ use Zenstruck\\Foundry\\Proxy;
  */
 final class CategoryFactory extends ModelFactory
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // TODO inject services if required (https://github.com/zenstruck/foundry#factories-as-services)
+    }
+
     protected function getDefaults(): array
     {
         return [

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryServiceFactory;
+use Zenstruck\Foundry\Tests\FunctionalTestCase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ModelFactoryServiceTest extends FunctionalTestCase
+{
+    /**
+     * @before
+     */
+    public function skipIfNotUsingFoundryBundle(): void
+    {
+        if (!\getenv('USE_FOUNDRY_BUNDLE')) {
+            $this->markTestSkipped('ZenstruckFoundryBundle not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_service_factory(): void
+    {
+        $factory = CategoryServiceFactory::new();
+
+        $this->assertSame('From Service', $factory->create()->getName());
+        $this->assertSame('From Factory Create', $factory->create(['name' => 'From Factory Create'])->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function service_factories_are_not_the_same_object(): void
+    {
+        $this->assertNotSame(CategoryServiceFactory::new(), CategoryServiceFactory::new());
+    }
+}

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\ModelFactoryManager;
 use Zenstruck\Foundry\StoryManager;
 
 /**
@@ -21,7 +22,7 @@ abstract class UnitTestCase extends TestCase
      */
     public function setUpFoundry(): void
     {
-        $this->configuration = new Configuration($this->createMock(ManagerRegistry::class), new StoryManager([]));
+        $this->configuration = new Configuration($this->createMock(ManagerRegistry::class), new StoryManager([]), new ModelFactoryManager([]));
 
         Factory::boot($this->configuration);
     }


### PR DESCRIPTION
This feature enables your ModelFactories to be defined as and use services from the DI container. A very common use-case would be to inject the password encoder into your `UserFactory`:

```php
final class UserFactory extends ModelFactory
{
    private $passwordEncoder;

    public function __construct(UserPasswordEncoderInterface $passwordEncoder)
    {
        parent::__construct();

        $this->passwordEncoder = $passwordEncoder;
    }

    protected function getDefaults(): array
    {
        return [
            'email' => self::faker()->unique()->safeEmail,
            'password' => '1234',
        ];
    }

    protected function initialize(): self
    {
        return $this
            ->afterInstantiate(function(User $user) {
                $user->setPassword($this->passwordEncoder->encodePassword($user, $user->getPassword()));
            })
        ;
    }

    protected static function getClass(): string
    {
        return User::class;
    }
}
```

This factory can be used as normal and the password will be encoded:

```php
UserFactory::new()->create(['password' => 'mypass'])->getPassword(); // "mypass" encoded
UserFactory::new()->create()->getPassword(); // "1234" encoded (because "1234" is set as the default password)
```

All factories created in a standard flex app (in `src/Factory` via the `make:factory` command) that have a public constructor are registered as services. Factories without a public constructor are not services.

**Some outstanding questions:**
1. ~I made `ModelFactory::__construct()` protected so concrete ModelFactory's can extend and make public to inject services. The reason I didn't make this method public is an attempt to restrict users from creating non-service ModelFactory's with `new PostFactory()` which causes problems. I was unable to find a way to throw a helpful error if ModelFactory's are created this way and not the proper way with `PostFactory::new()`.~ *I just made the constructor public with a warning in the docs to not instantiate factories with it.*
2. ~For the `make:factory` command: I think the vast majority of factory's will not require services. I'm thinking a `--service` flag to the command, that when added, stubs out a public constructor.~ *Opted not to do this and simply added a constructor stub.*

Fixes #32, Fixes #36

**TODO**
- [x] Add docs
- [x] Update `make:factory` command
