### PR TITLE
[RepositoryProxy] Add a last() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,7 +1135,10 @@ $repository = repository(Post::class);
 
 // helpful methods - all returned object(s) are proxied
 $repository->getCount(); // number of rows in the database table
-$repository->first(); // get the first object (wrapped in a object proxy)
+$repository->first(); // get the first object (assumes an auto-incremented "id" column)
+$repository->first('createdAt'); // assuming "createdAt" is a datetime column, this will return latest object
+$repository->last(); // get the last object (assumes an auto-incremented "id" column)
+$repository->last('createdAt'); // assuming "createdAt" is a datetime column, this will return oldest object
 $repository->truncate(); // delete all rows in the database table
 $repository->random(); // get a random object
 $repository->randomSet(5); // get 5 random objects

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -99,9 +99,17 @@ final class RepositoryProxy implements ObjectRepository
     /**
      * @return Proxy|object|null
      */
-    public function first(): ?Proxy
+    public function first(string $sortedField = 'id'): ?Proxy
     {
-        return $this->findOneBy([]);
+        return $this->findBy([], [$sortedField => 'ASC'], 1)[0] ?? null;
+    }
+
+    /**
+     * @return Proxy|object|null
+     */
+    public function last(string $sortedField = 'id'): ?Proxy
+    {
+        return $this->findBy([], [$sortedField => 'DESC'], 1)[0] ?? null;
     }
 
     /**

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -55,10 +55,6 @@ final class RepositoryProxyTest extends KernelTestCase
 
         CategoryFactory::new()->createMany(2);
 
-        $object = $repository->first();
-
-        $this->assertInstanceOf(Proxy::class, $object);
-
         $objects = $repository->findAll();
 
         $this->assertCount(2, $objects);
@@ -237,5 +233,32 @@ final class RepositoryProxyTest extends KernelTestCase
         $categoryC = CategoryFactory::new()->create();
 
         $this->assertSame($categoryC->getId(), CategoryFactory::repository()->findOneBy([], ['id' => 'DESC'])->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function first_and_last_return_the_correct_object(): void
+    {
+        $categoryA = CategoryFactory::new()->create(['name' => '3']);
+        $categoryB = CategoryFactory::new()->create(['name' => '2']);
+        $categoryC = CategoryFactory::new()->create(['name' => '1']);
+        $repository = CategoryFactory::repository();
+
+        $this->assertSame($categoryA->getId(), $repository->first()->getId());
+        $this->assertSame($categoryC->getId(), $repository->first('name')->getId());
+        $this->assertSame($categoryC->getId(), $repository->last()->getId());
+        $this->assertSame($categoryA->getId(), $repository->last('name')->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function first_and_last_return_null_if_empty(): void
+    {
+        $this->assertNull(CategoryFactory::repository()->first());
+        $this->assertNull(CategoryFactory::repository()->first('name'));
+        $this->assertNull(CategoryFactory::repository()->last());
+        $this->assertNull(CategoryFactory::repository()->last('name'));
     }
 }


### PR DESCRIPTION
As mentioned in PR #63 about the sample of issue #62, this PR add a `->last()` method and update the `->first()` method. I'm not sure about the update, but maybe it's better to be sure of the order.

Sometimes with postgres, it's not really ordered: https://www.postgresql.org/docs/9.1/queries-order.html

> After a query has produced an output table (after the select list has been processed) it can optionally be sorted. If sorting is not chosen, the rows will be returned **in an unspecified order**. The actual order in that case will depend on the scan and join plan types and the order on disk, but it must not be relied on. A particular output ordering can only be guaranteed if the sort step is explicitly chosen.