### PR TITLE
Change faker lib used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.2.5",
         "doctrine/persistence": "^1.3.3|^2.0",
-        "fzaninotto/faker": "^1.5",
+        "fakerphp/faker": "^1.5",
         "symfony/property-access": "^3.4|^4.4|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
`fzaninotto/faker` has been abandoned and `fakerphp/faker` seems to be the defacto replacement. It is now being used by Laravel and maintained by members of the Laravel team.

~`fakerphp/faker` conflicts with `fzaninotto/faker` so this could be a BC break for some projects if using PHP 8 and:~

1. ~Your project requires `fzaninotto/faker` directly (switch to `fakerphp/faker` to solve)~
2. ~Your project depends on a library requiring `fzaninotto/faker` (push for these libraries to upgrade to `fakerphp/faker` if possible)~

(the conflict would only happen on PHP8 and `fzaninotto/faker` doesn't support PHP8 anyway)