### PR TITLE
Remove attribute prefixes in findOrCreate()

### DIFF
--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -115,6 +115,21 @@ final class Instantiator
         return self::accessibleProperty($object, $property)->getValue($object);
     }
 
+    public static function getFindCriteriaFromAttributes(array $attributes): array
+    {
+        $criteria = [];
+        foreach ($attributes as $key => $value) {
+            if (0 === \mb_strpos($key, 'optional:')) {
+                continue;
+            }
+
+            $normalizedKey = false !== \mb_strpos($key, ':') ? \mb_substr($key, \mb_strpos($key, ':') + 1) : $key;
+            $criteria[$normalizedKey] = $value;
+        }
+
+        return $criteria;
+    }
+
     private static function propertyAccessor(): PropertyAccessor
     {
         return self::$propertyAccessor ?: self::$propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -54,7 +54,7 @@ abstract class ModelFactory extends Factory
      */
     final public static function findOrCreate(array $attributes): Proxy
     {
-        if ($found = static::repository()->find($attributes)) {
+        if ($found = static::repository()->find(Instantiator::getFindCriteriaFromAttributes($attributes))) {
             return $found;
         }
 

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -36,6 +36,17 @@ final class ModelFactoryTest extends KernelTestCase
     /**
      * @test
      */
+    public function can_find_or_create_using_prefixed_fields(): void
+    {
+        CategoryFactory::findOrCreate(['force:name' => 'php', 'optional:version' => 7.4]);
+        CategoryFactory::repository()->assertCount(1);
+        CategoryFactory::findOrCreate(['force:name' => 'php', 'optional:version' => 7.4]);
+        CategoryFactory::repository()->assertCount(1);
+    }
+
+    /**
+     * @test
+     */
     public function can_override_initialize(): void
     {
         $this->assertFalse(PostFactory::new()->create()->isPublished());


### PR DESCRIPTION
Fixes #75 

Btw, do you have an easy way to run the tests locally? I couldn't really figure out how to do it, so I rely quite heavily on the CI.