### PR TITLE
Add static return annotations

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -109,6 +109,9 @@ class Factory
         return $this->many($number)->create($attributes);
     }
 
+    /**
+     * @return static
+     */
     public function withoutPersisting(): self
     {
         $cloned = clone $this;
@@ -119,6 +122,8 @@ class Factory
 
     /**
      * @param array|callable $attributes
+     *
+     * @return static
      */
     final public function withAttributes($attributes = []): self
     {
@@ -130,6 +135,8 @@ class Factory
 
     /**
      * @param callable $callback (array $attributes): array
+     *
+     * @return static
      */
     final public function beforeInstantiate(callable $callback): self
     {
@@ -141,6 +148,8 @@ class Factory
 
     /**
      * @param callable $callback (object $object, array $attributes): void
+     *
+     * @return static
      */
     final public function afterInstantiate(callable $callback): self
     {
@@ -152,6 +161,8 @@ class Factory
 
     /**
      * @param callable $callback (object|Proxy $object, array $attributes): void
+     *
+     * @return static
      */
     final public function afterPersist(callable $callback): self
     {
@@ -163,6 +174,8 @@ class Factory
 
     /**
      * @param callable $instantiator (array $attributes, string $class): object
+     *
+     * @return static
      */
     final public function instantiateWith(callable $instantiator): self
     {

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -15,6 +15,8 @@ abstract class ModelFactory extends Factory
     /**
      * @param array|callable|string $defaultAttributes If string, assumes state
      * @param string                ...$states         Optionally pass default states (these must be methods on your ObjectFactory with no arguments)
+     *
+     * @return static
      */
     final public static function new($defaultAttributes = [], string ...$states): self
     {
@@ -102,6 +104,8 @@ abstract class ModelFactory extends Factory
 
     /**
      * @param array|callable $attributes
+     *
+     * @return static
      */
     final protected function addState($attributes = []): self
     {

--- a/src/Story.php
+++ b/src/Story.php
@@ -20,11 +20,17 @@ abstract class Story
         return static::load()->get($name);
     }
 
+    /**
+     * @return static
+     */
     final public static function load(): self
     {
         return Factory::configuration()->stories()->load(static::class);
     }
 
+    /**
+     * @return static
+     */
     final public function add(string $name, object $object): self
     {
         // ensure factories are persisted


### PR DESCRIPTION
Currently the factories and the Story are using the `self` native return type to enable the fluid interface, which can confuse static analyzers and PHPStorm.

This pull request adds the `@return static` annotation for those methods, to further specify that those methods return the actual class in the inheritance hierarchy and not the abstract class itself.