### PR TITLE
Instantiator improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,67 +54,67 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: 'Test: MySQL'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Test: MySQL, FoundryBundle'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Test: MySQL, DAMABundle'
-        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
         env:
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Test: MySQL, FoundryBundle, DAMABundle'
-        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Test: PostgreSQL'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
       - name: 'Test: PostgreSQL, FoundryBundle'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
 #      - name: 'Test: PostgreSQL, DAMABundle'
-#        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+#        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
 #        env:
 #          DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
 #      - name: 'Test: PostgreSQL, FoundryBundle, DAMABundle'
-#        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+#        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
 #        env:
 #          USE_FOUNDRY_BUNDLE: 1
 #          DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
       - name: 'Test: SQLite'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Test: SQLite, FoundryBundle'
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/simple-phpunit -v
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Test: SQLite, DAMABundle'
-        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
         env:
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Test: SQLite, FoundryBundle, DAMABundle'
-        run: vendor/bin/phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
         env:
 #          USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
@@ -162,67 +162,67 @@ jobs:
         run: composer update --prefer-dist --no-interaction --no-suggest
 
       - name: 'Coverage: MySQL'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=mysql.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql.clover
         env:
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Coverage: MySQL, FoundryBundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=mysql-foundry.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-foundry.clover
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Coverage: MySQL, DAMABundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=mysql-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-dama.clover --configuration phpunit-dama-doctrine.xml.dist
         env:
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Coverage: MySQL, FoundryBundle, DAMABundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=mysql-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Coverage: PostgreSQL'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=postgres.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=postgres.clover
         env:
           DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
       - name: 'Coverage: PostgreSQL, FoundryBundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=postgres-foundry.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=postgres-foundry.clover
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
 #      - name: 'Coverage: PostgreSQL, DAMABundle'
-#        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=postgres-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+#        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=postgres-dama.clover --configuration phpunit-dama-doctrine.xml.dist
 #        env:
 #          DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
 #      - name: 'Coverage: PostgreSQL, FoundryBundle, DAMABundle'
-#        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=postgres-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+#        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=postgres-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
 #        env:
 #          USE_FOUNDRY_BUNDLE: 1
 #          DATABASE_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry?charset=utf8
 
       - name: 'Coverage: SQLite'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=sqlite.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=sqlite.clover
         env:
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Coverage: SQLite, FoundryBundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=sqlite-foundry.clover
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=sqlite-foundry.clover
         env:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Coverage: SQLite, DAMABundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=sqlite-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=sqlite-dama.clover --configuration phpunit-dama-doctrine.xml.dist
         env:
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
       - name: 'Coverage: SQLite, FoundryBundle, DAMABundle'
-        run: vendor/bin/phpunit -v --coverage-text --coverage-clover=sqlite-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=sqlite-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
         env:
 #          USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db

--- a/README.md
+++ b/README.md
@@ -394,22 +394,6 @@ $post[1]->getPublishedAt(); // \DateTime('last week')
 $post[1]->getCreatedAt(); // random \DateTime (different than above)
 ```
 
-When using the [default instantiator](#instantiation), there are two attribute key prefixes to change
-behavior:
-
-```php
-$post = PostFactory::new()->create([
-    // "force set" the body property (even private/protected, does not use setter)
-    'force:body' => 'some body', 
-
-    // attributes that can't be mapped to object properties/constructor arguments cause
-    // an exception to be thrown when instantiating the object.
-    // attributes prefixed with "optional:" are ignored
-    // these "optional" attributes can be used in factory "events/hooks" (the prefix is not removed)
-    'optional:extra' => 'value', // attributes prefixed with "optional:" do not cause an exception
-]);
-```
-
 ### Faker
 
 This library provides a wrapper for [fzaninotto/faker](https://github.com/fzaninotto/Faker) to help with generating

--- a/README.md
+++ b/README.md
@@ -362,16 +362,10 @@ $posts = PostFactory::new(['title' => 'Post A'])
     ->withAttributes([
         'body' => 'Post Body...',
 
-        // can use snake case
-        'published_at' => new \DateTime('now'), 
-
         // CategoryFactory will be used to create a new Category for each Post
         'category' => CategoryFactory::new(['name' => 'php']), 
     ])
     ->withAttributes([
-        // can use kebab case
-        'published-at' => new \DateTime('last week'),
-
         // Proxies are automatically converted to their wrapped object
         'category' => CategoryFactory::new()->create(),
     ])
@@ -1012,14 +1006,10 @@ Object proxies have helper methods to access non-public properties of the object
 
 ```php
 // set private/protected properties
-$post->forceSet('createdAt', new \DateTime()); 
-$post->forceSet('created_at', new \DateTime()); // can use snake case
-$post->forceSet('created-at', new \DateTime()); // can use kebab case
+$post->forceSet('createdAt', new \DateTime());
 
 // get private/protected properties
 $post->forceGet('createdAt');
-$post->forceGet('created_at'); // can use snake case
-$post->forceGet('created-at'); // can use kebab case
 ```
 
 #### Auto-Refresh

--- a/README.md
+++ b/README.md
@@ -538,8 +538,14 @@ PostFactory::new()
     // instantiate the object without calling the constructor
     ->instantiateWith((new Instantiator())->withoutConstructor())
 
-    // extra attributes are ignored
+    // "foo" and "bar" attributes are ignored when instantiating
+    ->instantiateWith((new Instantiator())->allowExtraAttributes(['foo', 'bar']))
+
+    // all extra attributes are ignored when instantiating
     ->instantiateWith((new Instantiator())->allowExtraAttributes())
+
+    // force set "title" and "body" when instantiating
+    ->instantiateWith((new Instantiator())->alwaysForceProperties(['title', 'body']))
 
     // never use setters, always "force set" properties (even private/protected, does not use setter)
     ->instantiateWith((new Instantiator())->alwaysForceProperties())

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": ">=7.2.5",
         "doctrine/persistence": "^1.3.3|^2.0",
         "fakerphp/faker": "^1.5",
+        "symfony/deprecation-contracts": "^2.2",
         "symfony/property-access": "^3.4|^4.4|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "phpunit/phpunit": "^8.5",
         "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/maker-bundle": "^1.5"
+        "symfony/maker-bundle": "^1.5",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/maker-bundle": "^1.5",
+        "symfony/maker-bundle": "^1.13",
         "symfony/phpunit-bridge": "^5.1"
     },
     "config": {

--- a/phpunit-dama-doctrine.xml.dist
+++ b/phpunit-dama-doctrine.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel" />
         <env name="USE_DAMA_DOCTRINE_TEST_BUNDLE" value="1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <testsuites>

--- a/run-tests
+++ b/run-tests
@@ -3,21 +3,21 @@
 echo "Running without FoundryBundle and without DamaDoctrineTestBundle"
 echo "================================================================"
 echo ""
-USE_FOUNDRY_BUNDLE=0 vendor/bin/phpunit
+USE_FOUNDRY_BUNDLE=0 vendor/bin/simple-phpunit
 
 echo ""
 echo "Running with FoundryBundle and without DamaDoctrineTestBundle"
 echo "============================================================="
 echo ""
-USE_FOUNDRY_BUNDLE=1 vendor/bin/phpunit
+USE_FOUNDRY_BUNDLE=1 vendor/bin/simple-phpunit
 
 echo "Running without FoundryBundle and with DamaDoctrineTestBundle"
 echo "============================================================="
 echo ""
-USE_FOUNDRY_BUNDLE=0 vendor/bin/phpunit -c phpunit-dama-doctrine.xml
+USE_FOUNDRY_BUNDLE=0 vendor/bin/simple-phpunit -c phpunit-dama-doctrine.xml
 
 echo ""
 echo "Running with FoundryBundle and with DamaDoctrineTestBundle"
 echo "=========================================================="
 echo ""
-USE_FOUNDRY_BUNDLE=1 vendor/bin/phpunit -c phpunit-dama-doctrine.xml
+USE_FOUNDRY_BUNDLE=1 vendor/bin/simple-phpunit -c phpunit-dama-doctrine.xml

--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -69,6 +69,7 @@ final class Instantiator
                 // see if attribute was snake/kebab cased
                 try {
                     self::propertyAccessor()->setValue($object, self::camel($attribute), $value);
+                    trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using a differently cased attribute is deprecated, use the same case as the object property instead.');
                 } catch (NoSuchPropertyException $e) {
                     if (!$this->allowExtraAttributes) {
                         throw new \InvalidArgumentException(\sprintf('Cannot set attribute "%s" for object "%s" (not public and no setter).', $attribute, $class), 0, $e);
@@ -150,8 +151,10 @@ final class Instantiator
         $class = new \ReflectionClass($object);
 
         // try fetching first by exact name, if not found, try camel-case
-        if (!$property = self::reflectionProperty($class, $name)) {
-            $property = self::reflectionProperty($class, self::camel($name));
+        $property = self::reflectionProperty($class, $name);
+
+        if (!$property && $property = self::reflectionProperty($class, self::camel($name))) {
+            trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using a differently cased attribute is deprecated, use the same case as the object property instead.');
         }
 
         if (!$property) {
@@ -194,6 +197,8 @@ final class Instantiator
         $name = self::snake($name);
 
         if (\array_key_exists($name, $attributes)) {
+            trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
             return $name;
         }
 
@@ -201,6 +206,8 @@ final class Instantiator
         $name = \str_replace('_', '-', $name);
 
         if (\array_key_exists($name, $attributes)) {
+            trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
             return $name;
         }
 

--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -34,7 +34,12 @@ final class Instantiator
         $object = $this->instantiate($class, $attributes);
 
         foreach ($attributes as $attribute => $value) {
-            if (0 === \mb_strpos($attribute, 'optional:') || \in_array($attribute, $this->extraAttributes, true)) {
+            if (0 === \mb_strpos($attribute, 'optional:')) {
+                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtraAttributes() instead (https://github.com/zenstruck/foundry#instantiation).');
+                continue;
+            }
+
+            if (\in_array($attribute, $this->extraAttributes, true)) {
                 continue;
             }
 
@@ -51,6 +56,8 @@ final class Instantiator
             }
 
             if (0 === \mb_strpos($attribute, 'force:')) {
+                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://github.com/zenstruck/foundry#instantiation).');
+
                 self::forceSet($object, \mb_substr($attribute, 6), $value);
 
                 continue;

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -51,10 +51,12 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
     }
 
     /**
-     * @deprecated use Repository::count()
+     * @deprecated use RepositoryProxy::count()
      */
     public function getCount(): int
     {
+        trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using RepositoryProxy::getCount() is deprecated, use RepositoryProxy::count() (it is now Countable).');
+
         return $this->count();
     }
 

--- a/src/Test/TestState.php
+++ b/src/Test/TestState.php
@@ -46,6 +46,7 @@ final class TestState
      */
     public static function withoutBundle(): void
     {
+        trigger_deprecation('zenstruck\foundry', '1.4.0', 'TestState::withoutBundle() is deprecated, the bundle is now auto-detected.');
     }
 
     public static function addGlobalState(callable $callback): void
@@ -83,6 +84,8 @@ final class TestState
      */
     public static function bootFactory(Configuration $configuration): Configuration
     {
+        trigger_deprecation('zenstruck\foundry', '1.4.0', 'TestState::bootFactory() is deprecated, use TestState::bootFoundry().');
+
         self::bootFoundry($configuration);
 
         return Factory::configuration();

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -273,5 +273,6 @@ final class RepositoryProxyTest extends KernelTestCase
 
         $this->assertCount(4, $repository);
         $this->assertCount(4, \iterator_to_array($repository));
+        $this->assertSame(4, $repository->getCount());
     }
 }

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Doctrine\Common\Proxy\Proxy as DoctrineProxy;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Test\Factories;
@@ -18,7 +19,7 @@ use function Zenstruck\Foundry\repository;
  */
 final class RepositoryProxyTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use ResetDatabase, Factories, ExpectDeprecationTrait;
 
     /**
      * @test
@@ -273,6 +274,18 @@ final class RepositoryProxyTest extends KernelTestCase
 
         $this->assertCount(4, $repository);
         $this->assertCount(4, \iterator_to_array($repository));
-        $this->assertSame(4, $repository->getCount());
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function can_use_get_count(): void
+    {
+        CategoryFactory::new()->createMany(4);
+
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using RepositoryProxy::getCount() is deprecated, use RepositoryProxy::count() (it is now Countable).');
+
+        $this->assertSame(4, CategoryFactory::repository()->getCount());
     }
 }

--- a/tests/Unit/FactoryCollectionTest.php
+++ b/tests/Unit/FactoryCollectionTest.php
@@ -56,7 +56,7 @@ final class FactoryCollectionTest extends TestCase
     public function min_must_be_less_than_or_equal_to_max(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectDeprecationMessage('Min must be less than max.');
+        $this->expectExceptionMessage('Min must be less than max.');
 
         new FactoryCollection(factory(Category::class), 4, 3);
     }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -304,10 +304,10 @@ final class FactoryTest extends TestCase
 
         Factory::configuration()->setManagerRegistry($registry);
 
-        $expectedAttributes = ['short_description' => 'short desc', 'title' => 'title', 'body' => 'body'];
+        $expectedAttributes = ['shortDescription' => 'short desc', 'title' => 'title', 'body' => 'body'];
         $calls = 0;
 
-        $object = (new Factory(Post::class, ['short_description' => 'short desc']))
+        $object = (new Factory(Post::class, ['shortDescription' => 'short desc']))
             ->afterPersist(function(Proxy $post, array $attributes) use ($expectedAttributes, &$calls) {
                 /* @var Post $post */
                 $this->assertSame($expectedAttributes, $attributes);

--- a/tests/Unit/InstantiatorTest.php
+++ b/tests/Unit/InstantiatorTest.php
@@ -127,6 +127,34 @@ final class InstantiatorTest extends TestCase
     /**
      * @test
      */
+    public function can_set_attributes_that_should_be_optional(): void
+    {
+        $object = (new Instantiator())->allowExtraAttributes(['extra'])([
+            'propB' => 'B',
+            'extra' => 'foo',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('constructor B', $object->getPropB());
+    }
+
+    /**
+     * @test
+     */
+    public function extra_attributes_not_defined_throws_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set attribute "extra2" for object "Zenstruck\Foundry\Tests\Unit\InstantiatorDummy" (not public and no setter).');
+
+        (new Instantiator())->allowExtraAttributes(['extra1'])([
+            'propB' => 'B',
+            'extra1' => 'foo',
+            'extra2' => 'bar',
+        ], InstantiatorDummy::class);
+    }
+
+    /**
+     * @test
+     */
     public function can_prefix_extra_attribute_key_with_optional_to_avoid_exception(): void
     {
         $object = (new Instantiator())([
@@ -167,6 +195,20 @@ final class InstantiatorTest extends TestCase
         $this->assertSame('setter B', $object->getPropB());
         $this->assertSame('setter C', $object->getPropC());
         $this->assertSame('setter D', $object->getPropD());
+    }
+
+    /**
+     * @test
+     */
+    public function can_set_attributes_that_should_be_force_set(): void
+    {
+        $object = (new Instantiator())->withoutConstructor()->alwaysForceProperties(['propD'])([
+            'propB' => 'B',
+            'propD' => 'D',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('setter B', $object->getPropB());
+        $this->assertSame('D', $object->getPropD());
     }
 
     /**

--- a/tests/Unit/InstantiatorTest.php
+++ b/tests/Unit/InstantiatorTest.php
@@ -34,9 +34,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_use_snake_case_attributes(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
         $object = (new Instantiator())([
             'prop_a' => 'A',
             'prop_b' => 'B',
@@ -53,9 +56,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_use_kebab_case_attributes(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
         $object = (new Instantiator())([
             'prop-a' => 'A',
             'prop-b' => 'B',
@@ -307,6 +313,23 @@ final class InstantiatorTest extends TestCase
         $object = new InstantiatorDummy('B');
 
         $this->assertNull(Instantiator::forceGet($object, 'propE'));
+
+        Instantiator::forceSet($object, 'propE', 'value');
+
+        $this->assertSame('value', Instantiator::forceGet($object, 'propE'));
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function can_use_force_set_and_get_with_kebab_and_snake_case(): void
+    {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
+        $object = new InstantiatorDummy('B');
+
+        $this->assertNull(Instantiator::forceGet($object, 'propE'));
         $this->assertNull(Instantiator::forceGet($object, 'prop_e'));
         $this->assertNull(Instantiator::forceGet($object, 'prop-e'));
 
@@ -372,9 +395,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_use_always_force_mode_allows_snake_case(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
         $object = (new Instantiator())->alwaysForceProperties()([
             'prop_a' => 'A',
             'prop_b' => 'B',
@@ -391,9 +417,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_use_always_force_mode_allows_kebab_case(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using a differently cased attribute is deprecated, use the same case as the object property instead.');
+
         $object = (new Instantiator())->alwaysForceProperties()([
             'prop-a' => 'A',
             'prop-b' => 'B',

--- a/tests/Unit/InstantiatorTest.php
+++ b/tests/Unit/InstantiatorTest.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Zenstruck\Foundry\Instantiator;
 
 /**
@@ -10,6 +11,8 @@ use Zenstruck\Foundry\Instantiator;
  */
 final class InstantiatorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @test
      */
@@ -154,9 +157,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_prefix_extra_attribute_key_with_optional_to_avoid_exception(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtraAttributes() instead (https://github.com/zenstruck/foundry#instantiation).');
+
         $object = (new Instantiator())([
             'propB' => 'B',
             'optional:extra' => 'foo',
@@ -213,9 +219,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function prefixing_attribute_key_with_force_sets_the_property_directly(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://github.com/zenstruck/foundry#instantiation).');
+
         $object = (new Instantiator())([
             'propA' => 'A',
             'propB' => 'B',
@@ -232,9 +241,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function prefixing_snake_case_attribute_key_with_force_sets_the_property_directly(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://github.com/zenstruck/foundry#instantiation).');
+
         $object = (new Instantiator())([
             'prop_a' => 'A',
             'prop_b' => 'B',
@@ -251,9 +263,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function prefixing_kebab_case_attribute_key_with_force_sets_the_property_directly(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://github.com/zenstruck/foundry#instantiation).');
+
         $object = (new Instantiator())([
             'prop-a' => 'A',
             'prop-b' => 'B',
@@ -270,9 +285,11 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function prefixing_invalid_attribute_key_with_force_throws_exception(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://github.com/zenstruck/foundry#instantiation).');
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Class "Zenstruck\Foundry\Tests\Unit\InstantiatorDummy" does not have property "extra".');
 
@@ -407,9 +424,12 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function always_force_mode_allows_optional_attribute_name_prefix(): void
     {
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtraAttributes() instead (https://github.com/zenstruck/foundry#instantiation).');
+
         $object = (new Instantiator())->alwaysForceProperties()([
             'propB' => 'B',
             'propD' => 'D',


### PR DESCRIPTION
Fixes #75, Alternate to #77.

1. This deprecates the usage of the "force:" and "extra:" attribute prefixes. There were several problems (ref: #75 & https://github.com/zenstruck/foundry/pull/77#issuecomment-723344210).

    The new way of using is to define them on the `Instantiator` itself:

    ```php
    $factory->instantiateWith(
        (new Instantiator())->allowExtraAttributes(['extra1', 'extra2'])->alwaysForceProperties(['title', 'body'])
    );
    ```
2. This also deprecates using snake/kebab-case for attribute names for the same reasons as above.