### PR TITLE
Add `Factory::delayFlush()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -865,6 +865,22 @@ Foundry can be used to create factories for entities that you don't have model f
     $entity = create(Post::class, ['field' => 'value']);
     $entities = create_many(Post::class, 5, ['field' => 'value']);
 
+Delay Flush
+~~~~~~~~~~~
+
+When creating/persisting many factories at once, it can be improve performance
+to instantiate them all without saving to the database, then flush them all at
+once. To do this, wrap the operations in a ``Factory::delayFlush()`` callback:
+
+.. code-block:: php
+
+    use Zenstruck\Foundry\Factory;
+
+    Factory::delayFlush(function() {
+        CategoryFactory::createMany(100); // instantiated/persisted but not flushed
+        TagFactory::createMany(200); // instantiated/persisted but not flushed
+    }); // single flush
+
 .. _without-persisting:
 
 Without Persisting

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -32,6 +32,9 @@ final class Configuration
     /** @var bool|null */
     private $defaultProxyAutoRefresh;
 
+    /** @var bool */
+    private $flushEnabled = true;
+
     public function __construct()
     {
         $this->stories = new StoryManager([]);
@@ -122,6 +125,24 @@ final class Configuration
         $this->defaultProxyAutoRefresh = false;
 
         return $this;
+    }
+
+    public function isFlushingEnabled(): bool
+    {
+        return $this->flushEnabled;
+    }
+
+    public function delayFlush(callable $callback): void
+    {
+        $this->flushEnabled = false;
+
+        $callback();
+
+        foreach ($this->managerRegistry()->getManagers() as $manager) {
+            $manager->flush();
+        }
+
+        $this->flushEnabled = true;
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -255,6 +255,11 @@ class Factory
         return self::configuration()->faker();
     }
 
+    final public static function delayFlush(callable $callback): void
+    {
+        self::configuration()->delayFlush($callback);
+    }
+
     /**
      * @internal
      *

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -110,7 +110,7 @@ final class Proxy
      */
     public function object(): object
     {
-        if (!$this->autoRefresh || !$this->persisted) {
+        if (!$this->autoRefresh || !$this->persisted || !Factory::configuration()->isFlushingEnabled()) {
             return $this->object;
         }
 
@@ -139,7 +139,11 @@ final class Proxy
     public function save(): self
     {
         $this->objectManager()->persist($this->object);
-        $this->objectManager()->flush();
+
+        if (Factory::configuration()->isFlushingEnabled()) {
+            $this->objectManager()->flush();
+        }
+
         $this->persisted = true;
 
         return $this;

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -89,9 +89,19 @@ class Post
         return $this->title;
     }
 
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
     public function getBody(): ?string
     {
         return $this->body;
+    }
+
+    public function setBody(string $body): void
+    {
+        $this->body = $body;
     }
 
     public function getShortDescription(): ?string


### PR DESCRIPTION
Closes #37. Closes #265.

Using this in a data fixture to create 1000 objects that each creates a related object has a significant performance improvement (~20x).

```php
Factory::delayFlush(function() {
    PostFactory::createMany(10000);

    // etc...
});
```