### PR TITLE
Add psalm static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,3 +280,28 @@ jobs:
 
       - name: Check CS
         run: php php-cs-fixer.phar fix --dry-run --diff --diff-format=udiff
+
+  static-analysis:
+    name: Psalm Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.7.0
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Cache dependencies
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-7.4-prefer-stable-${{ hashFiles('composer.json') }}
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
+
+      - name: Run static analysis
+        run: vendor/bin/psalm --output-format=github

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -38,6 +38,7 @@ return PhpCsFixer\Config::create()
             'allow_unused_params' => true,
             'remove_inheritdoc' => true,
         ],
+        'phpdoc_to_comment' => false,
         'function_declaration' => ['closure_function_spacing' => 'none'],
         'nullable_type_declaration_for_default_null_value' => true,
     ))

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/maker-bundle": "^1.13",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1",
+        "vimeo/psalm": "^4.1"
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,12 @@
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "psalm/plugin-symfony": "^1.5|^2.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/maker-bundle": "^1.13",
         "symfony/phpunit-bridge": "^5.1",
-        "vimeo/psalm": "^4.1"
+        "vimeo/psalm": "^3.18|^4.0",
+        "weirdan/doctrine-psalm-plugin": "^0.11.3"
     },
     "config": {
         "preferred-install": "dist",

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorLevel="5"
+    errorLevel="4"
 >
     <projectFiles>
         <directory name="src"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="6"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="src/Bundle/Resources"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <plugins>
+        <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorLevel="6"
+    errorLevel="5"
 >
     <projectFiles>
         <directory name="src"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,20 @@
         </ignoreFiles>
     </projectFiles>
 
+    <issueHandlers>
+        <InvalidCatch>
+            <errorLevel type="suppress">
+                <!-- this interface does not extend from a throwable -->
+                <referencedClass name="Psr\Container\NotFoundExceptionInterface"/>
+            </errorLevel>
+        </InvalidCatch>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="PHPUnit\Framework\Assert"/>
+            </errorLevel>
+        </UndefinedClass>
+    </issueHandlers>
+
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
         <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -109,6 +109,12 @@ final class Configuration
 
     /**
      * @param object|string $objectOrClass
+     *
+     * @psalm-suppress InvalidReturnType
+     * @psalm-suppress InvalidReturnStatement
+     * @template TObject of object
+     * @psalm-param Proxy<TObject>|TObject|class-string<TObject> $objectOrClass
+     * @psalm-return RepositoryProxy<TObject>
      */
     public function repositoryFor($objectOrClass): RepositoryProxy
     {
@@ -137,6 +143,7 @@ final class Configuration
         return $objectManager;
     }
 
+    /** @psalm-assert !null $this->managerRegistry */
     public function hasManagerRegistry(): bool
     {
         return null !== $this->managerRegistry;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -152,6 +152,7 @@ final class Configuration
     private function managerRegistry(): ManagerRegistry
     {
         if (!$this->hasManagerRegistry()) {
+            /** @psalm-suppress MissingDependency */
             throw new \RuntimeException('Foundry was booted without doctrine. Ensure your TestCase extends '.KernelTestCase::class);
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -221,6 +221,8 @@ class Factory
 
     /**
      * @internal
+     * @psalm-suppress InvalidNullableReturnType
+     * @psalm-suppress NullableReturnStatement
      */
     final public static function configuration(): Configuration
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -5,6 +5,8 @@ namespace Zenstruck\Foundry;
 use Faker;
 
 /**
+ * @template TObject as object
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 class Factory
@@ -12,7 +14,10 @@ class Factory
     /** @var Configuration|null */
     private static $configuration;
 
-    /** @var string */
+    /**
+     * @var string
+     * @psalm-var class-string<TObject>
+     */
     private $class;
 
     /** @var callable|null */
@@ -35,6 +40,8 @@ class Factory
 
     /**
      * @param array|callable $defaultAttributes
+     *
+     * @psalm-param class-string<TObject> $class
      */
     public function __construct(string $class, $defaultAttributes = [])
     {
@@ -46,6 +53,8 @@ class Factory
      * @param array|callable $attributes
      *
      * @return Proxy|object
+     *
+     * @psalm-return Proxy<TObject>
      */
     final public function create($attributes = []): Proxy
     {
@@ -93,6 +102,8 @@ class Factory
 
     /**
      * @see FactoryCollection::__construct()
+     *
+     * @psalm-return FactoryCollection<TObject>
      */
     final public function many(int $min, ?int $max = null): FactoryCollection
     {
@@ -103,6 +114,8 @@ class Factory
      * @param array|callable $attributes
      *
      * @return Proxy[]|object[]
+     *
+     * @psalm-return list<Proxy<TObject>>
      */
     final public function createMany(int $number, $attributes = []): array
     {

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -39,6 +39,7 @@ final class FactoryCollection
      *
      * @return Proxy[]|object[]
      *
+     * @psalm-suppress InvalidReturnType
      * @psalm-return list<Proxy<TObject>>
      */
     public function create($attributes = []): array
@@ -58,6 +59,7 @@ final class FactoryCollection
      */
     public function all(): array
     {
+        /** @psalm-suppress TooManyArguments */
         return \array_map(
             function() {
                 return clone $this->factory;

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -3,11 +3,13 @@
 namespace Zenstruck\Foundry;
 
 /**
+ * @template TObject as object
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class FactoryCollection
 {
-    /** @var Factory */
+    /** @var Factory<TObject> */
     private $factory;
 
     /** @var int */
@@ -18,6 +20,8 @@ final class FactoryCollection
 
     /**
      * @param int|null $max If set, when created, the collection will be a random size between $min and $max
+     *
+     * @psalm-param Factory<TObject> $factory
      */
     public function __construct(Factory $factory, int $min, ?int $max = null)
     {
@@ -34,6 +38,8 @@ final class FactoryCollection
      * @param array|callable $attributes
      *
      * @return Proxy[]|object[]
+     *
+     * @psalm-return list<Proxy<TObject>>
      */
     public function create($attributes = []): array
     {
@@ -47,6 +53,8 @@ final class FactoryCollection
 
     /**
      * @return Factory[]
+     *
+     * @psalm-return list<Factory<TObject>>
      */
     public function all(): array
     {

--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -221,7 +221,7 @@ final class Instantiator
      */
     private static function camel(string $string): string
     {
-        return \str_replace(' ', '', \preg_replace_callback('/\b./u', static function($m) use (&$i) {
+        return \str_replace(' ', '', \preg_replace_callback('/\b./u', static function($m) use (&$i): string {
             return 1 === ++$i ? ('İ' === $m[0] ? 'i̇' : \mb_strtolower($m[0], 'UTF-8')) : \mb_convert_case($m[0], MB_CASE_TITLE, 'UTF-8');
         }, \preg_replace('/[^\pL0-9]++/u', ' ', $string)));
     }

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -3,6 +3,9 @@
 namespace Zenstruck\Foundry;
 
 /**
+ * @template TModel of object
+ * @template-extends Factory<TModel>
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 abstract class ModelFactory extends Factory
@@ -53,6 +56,8 @@ abstract class ModelFactory extends Factory
      * instantiate and persist.
      *
      * @return Proxy|object
+     *
+     * @psalm-return Proxy<TModel>
      */
     final public static function findOrCreate(array $attributes): Proxy
     {
@@ -87,6 +92,7 @@ abstract class ModelFactory extends Factory
         return static::repository()->randomRange($min, $max);
     }
 
+    /** @psalm-return RepositoryProxy<TModel> */
     final public static function repository(): RepositoryProxy
     {
         return static::configuration()->repositoryFor(static::getClass());
@@ -112,6 +118,7 @@ abstract class ModelFactory extends Factory
         return $this->withAttributes($attributes);
     }
 
+    /** @psalm-return class-string<TModel> */
     abstract protected static function getClass(): string;
 
     abstract protected function getDefaults(): array;

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -62,7 +62,7 @@ abstract class ModelFactory extends Factory
     final public static function findOrCreate(array $attributes): Proxy
     {
         if ($found = static::repository()->find($attributes)) {
-            return $found;
+            return \is_array($found) ? $found[0] : $found;
         }
 
         return static::new()->create($attributes);

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -6,14 +6,23 @@ use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Assert;
 
 /**
+ * @template TProxiedObject of object
+ * @mixin TProxiedObject
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class Proxy
 {
-    /** @var object */
+    /**
+     * @var object
+     * @psalm-var TProxiedObject
+     */
     private $object;
 
-    /** @var string */
+    /**
+     * @var string
+     * @psalm-var class-string<TProxiedObject>
+     */
     private $class;
 
     /** @var bool */
@@ -24,6 +33,8 @@ final class Proxy
 
     /**
      * @internal
+     *
+     * @psalm-param TProxiedObject $object
      */
     public function __construct(object $object)
     {
@@ -72,6 +83,10 @@ final class Proxy
 
     /**
      * @internal
+     *
+     * @template TObject as object
+     * @psalm-param TObject $object
+     * @psalm-return Proxy<TObject>
      */
     public static function createFromPersisted(object $object): self
     {
@@ -86,6 +101,9 @@ final class Proxy
         return $this->persisted;
     }
 
+    /**
+     * @psalm-return TProxiedObject
+     */
     public function object(): object
     {
         if ($this->autoRefresh && $this->persisted) {
@@ -231,6 +249,9 @@ final class Proxy
         $callback($object, ...$arguments);
     }
 
+    /**
+     * @psalm-return TProxiedObject|null
+     */
     private function fetchObject(): ?object
     {
         $id = $this->objectManager()->getClassMetadata($this->class)->getIdentifierValues($this->object);

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -8,13 +8,14 @@ use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\Assert;
 
 /**
- * @mixin EntityRepository
+ * @mixin EntityRepository<TProxiedObject>
+ * @template TProxiedObject of object
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Countable
 {
-    /** @var ObjectRepository */
+    /** @var ObjectRepository<TProxiedObject> */
     private $repository;
 
     public function __construct(ObjectRepository $repository)
@@ -122,6 +123,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
     /**
      * @return Proxy|object|null
+     *
+     * @psalm-return Proxy<TProxiedObject>|null
      */
     public function first(string $sortedField = 'id'): ?Proxy
     {
@@ -130,6 +133,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
     /**
      * @return Proxy|object|null
+     *
+     * @psalm-return Proxy<TProxiedObject>|null
      */
     public function last(string $sortedField = 'id'): ?Proxy
     {
@@ -162,6 +167,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      * @return Proxy|object
      *
      * @throws \RuntimeException if no objects are persisted
+     *
+     * @psalm-return Proxy<TProxiedObject>
      */
     public function random(): Proxy
     {
@@ -224,6 +231,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      * @param object|array|mixed $criteria
      *
      * @return Proxy|object|null
+     *
+     * @psalm-param Proxy<TProxiedObject>|array|mixed $criteria
+     * @psalm-return Proxy<TProxiedObject>|list<Proxy<TProxiedObject>>|null
      */
     public function find($criteria): ?Proxy
     {
@@ -260,6 +270,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      * @return Proxy|object|null
      *
      * @throws \RuntimeException if the wrapped ObjectRepository does not have the $orderBy parameter
+     *
+     * @psalm-return Proxy<TProxiedObject>|null
      */
     public function findOneBy(array $criteria, ?array $orderBy = null): ?Proxy
     {
@@ -274,6 +286,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
         return $this->proxyResult($this->repository->findOneBy(self::normalizeCriteria($criteria), $orderBy));
     }
 
+    /**
+     * @psalm-return class-string<TProxiedObject>
+     */
     public function getClassName(): string
     {
         return $this->repository->getClassName();
@@ -283,6 +298,11 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      * @param mixed $result
      *
      * @return Proxy|Proxy[]|object|object[]|mixed
+     *
+     * @psalm-suppress InvalidReturnStatement
+     * @psalm-suppress InvalidReturnType
+     * @psalm-param TProxiedObject|list<TProxiedObject> $result
+     * @psalm-return ($result is array ? list<Proxy<TProxiedObject>> : Proxy<TProxiedObject>)
      */
     private function proxyResult($result)
     {

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -44,6 +44,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
     public function getIterator(): \Traversable
     {
+        // TODO: $this->repository is set to ObjectRepository, which is not
+        //       iterable. Can this every be another RepositoryProxy?
         if (\is_iterable($this->repository)) {
             return yield from $this->repository;
         }
@@ -235,7 +237,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      * @psalm-param Proxy<TProxiedObject>|array|mixed $criteria
      * @psalm-return Proxy<TProxiedObject>|list<Proxy<TProxiedObject>>|null
      */
-    public function find($criteria): ?Proxy
+    public function find($criteria)
     {
         if ($criteria instanceof Proxy) {
             $criteria = $criteria->object();

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Assert;
  */
 final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Countable
 {
-    /** @var ObjectRepository<TProxiedObject> */
+    /** @var ObjectRepository<TProxiedObject>|EntityRepository<TProxiedObject> */
     private $repository;
 
     public function __construct(ObjectRepository $repository)

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,6 +6,10 @@ use Faker;
 
 /**
  * @see Factory::__construct()
+ *
+ * @template TObject as object
+ * @psalm-param class-string<TObject> $class
+ * @psalm-return Factory<TObject>
  */
 function factory(string $class, $defaultAttributes = []): Factory
 {
@@ -16,6 +20,10 @@ function factory(string $class, $defaultAttributes = []): Factory
  * @see Factory::create()
  *
  * @return Proxy|object
+ *
+ * @template TObject of object
+ * @psalm-param class-string<TObject> $class
+ * @psalm-return Proxy<TObject>
  */
 function create(string $class, $attributes = []): Proxy
 {
@@ -26,6 +34,10 @@ function create(string $class, $attributes = []): Proxy
  * @see Factory::createMany()
  *
  * @return Proxy[]|object[]
+ *
+ * @template TObject of object
+ * @psalm-param class-string<TObject> $class
+ * @psalm-return list<Proxy<TObject>>
  */
 function create_many(int $number, string $class, $attributes = []): array
 {
@@ -36,6 +48,10 @@ function create_many(int $number, string $class, $attributes = []): array
  * Instantiate object without persisting.
  *
  * @return Proxy|object "unpersisted" Proxy wrapping the instantiated object
+ *
+ * @template TObject of object
+ * @psalm-param class-string<TObject> $class
+ * @psalm-return Proxy<TObject>
  */
 function instantiate(string $class, $attributes = []): Proxy
 {
@@ -46,6 +62,10 @@ function instantiate(string $class, $attributes = []): Proxy
  * Instantiate X objects without persisting.
  *
  * @return Proxy[]|object[] "unpersisted" Proxy's wrapping the instantiated objects
+ *
+ * @template TObject of object
+ * @psalm-param class-string<TObject> $class
+ * @psalm-return list<Proxy<TObject>>
  */
 function instantiate_many(int $number, string $class, $attributes = []): array
 {


### PR DESCRIPTION
As promised in https://github.com/zenstruck/foundry/pull/79#issuecomment-724091511 , this is a PR introducing Psalm analysis to this package.

I've split this into multiple commits:

* de928ff adds (mostly) [templated annotations](https://psalm.dev/docs/annotating_code/templated_annotations/) to make Psalm understand the magic in `Proxy` and `RepositoryProxy`. E.g. `@psalm-var Proxy<User> $userProxy` is now understood by Psalm as a User proxy (so all methods of `User` are now allowed in `$userProxy`).
* e9f1fe6 and 11457c7 fixes issues found by Psalm (level 6 and 5) by changing PHP code.

I tried running level 4, but at that level all errors were "invalid" and I wasn't able to explain the logic to Psalm using annotations. I've asked about this and if I get a solution, we can continue to go down the error levels. In total there are 61 more "errors" found by Psalm at this point (which are ignored because of the set level).

> Semi related notes:
> - This PR is still using Psalm 3.x, as Psalm 4 is not yet supported by the Doctrine plugin: https://github.com/weirdan/doctrine-psalm-plugin/pull/78
> - I have some outstanding questions about Psalm in Slack related to this package. I've suppressed these issues for now, hopefully it's either a bug that can be fixed or something that I did wrong.