### PR TITLE
Added docs for ModelFactory::new()

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,15 +267,11 @@ $title = $post->getTitle(); // getTitle() can be autocompleted by your IDE!
 
 // if you need the actual Post object, use ->object()
 $realPost = $post->object();
-
-PostFactory::new()->create(['title' => 'My Title']); // override defaults 
-PostFactory::new(['title' => 'My Title'])->create(); // alternative to above
+PostFactory::new()->create(['title' => 'My Title']);
 
 // create/persist 5 Posts with random data from getDefaults()
 PostFactory::new()->createMany(5); // returns Post[]|Proxy[]
-
-PostFactory::new()->createMany(5, ['title' => 'My Title']); // override defaults 
-PostFactory::new(['title' => 'My Title'])->createMany(5); // alternative to above
+PostFactory::new()->createMany(5, ['title' => 'My Title']);
 
 // find a persisted object for the given attributes, if not found, create with the attributes
 PostFactory::findOrCreate(['title' => 'My Title']); // returns Post|Proxy
@@ -290,8 +286,20 @@ $posts = PostFactory::randomSet(4); // array containing 4 "Post|Proxy" objects
 $posts = PostFactory::randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
 ```
 
-**WARNING**: Never instantiate your `ModelFactory` with the constructor (ie `new PostFactory()`). This will
+### Instantiate your `ModelFactory`
+
+One should never instantiate your `ModelFactory` with the constructor (ie `new PostFactory()`). This will
 cause the factory to not be instantiated properly. Always instantiate with `PostFactory::new()`.
+
+The first argument to `PostFactory::new()` will allow you to overwrite the default
+values that are defined in the `PostFactory::getDefaults()`.
+
+```php
+use App\Factory\PostFactory;
+
+PostFactory::new(['title' => 'My Title'])->create();
+PostFactory::new(['title' => 'My Title'])->createMany(5);
+```
 
 ### Reusable Model Factory "States"
 

--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ values that are defined in the `PostFactory::getDefaults()`.
 ```php
 use App\Factory\PostFactory;
 
-PostFactory::new(['title' => 'My Title'])->create();
-PostFactory::new(['title' => 'My Title'])->createMany(5);
+$factory = PostFactory::new(['title' => 'My Title']);
+$factory->create();
+$factory->createMany(5);
 ```
 
 ### Reusable Model Factory "States"


### PR DESCRIPTION
When I first started to use this library, I had a hard time understanding why there were two very similar ways doing the same thing: 

```php
PostFactory::new()->create(['title' => 'My Title']); // A
PostFactory::new(['title' => 'My Title'])->create(); // B
```

Of course I put my bets on the wrong horse and used B all over.. That is not what one should do.. 
I've added some config that will make it more clear that there is a difference and that one (most of the time) should use A. 

-----

Is this clear enough? Should I expand on my example by doing `$postFactory = PostFactory::new([...]);`?
