### PR TITLE
Ensure kernel shutdown after ResetDatabase::_resetSchema()

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,8 +950,30 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 class MyTest extends WebTestCase
 {
     use Factories;
-    
-    // ...
+
+    public function test_1(): void
+    {
+        // if using the test client, create before creating factories
+        // (creating the client requires the kernel be shutdown and creating
+        // factories boots the kernel)
+        $client = self::createClient();
+
+        $post = PostFactory::new()->create();
+
+        // ...
+    }
+
+    public function test_2(): void
+    {
+        $post = PostFactory::new()->create();
+
+        // if you want to create your factories before creating the client,
+        // you will need to shut down the kernel first.
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+
+        // ...
+    }
 }
 ```
 

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -8,6 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\Factory;
 
 /**
  * @internal
@@ -75,7 +76,10 @@ final class DatabaseResetter
             ]);
         }
 
-        TestState::bootFromContainer($application->getKernel()->getContainer());
+        if (!Factory::isBooted()) {
+            TestState::bootFromContainer($application->getKernel()->getContainer());
+        }
+
         TestState::flushGlobalState();
     }
 

--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -24,11 +24,10 @@ trait Factories
             return;
         }
 
-        if (!static::$booted) {
-            static::bootKernel();
-        }
+        $kernel = static::createKernel();
+        $kernel->boot();
 
-        TestState::bootFromContainer(static::$kernel->getContainer());
+        TestState::bootFromContainer($kernel->getContainer());
         Factory::configuration()->setManagerRegistry(
             new LazyManagerRegistry(static function() {
                 if (!static::$booted) {
@@ -39,7 +38,7 @@ trait Factories
             })
         );
 
-        self::ensureKernelShutdown();
+        $kernel->shutdown();
     }
 
     /**

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -63,5 +63,7 @@ trait ResetDatabase
         }
 
         DatabaseResetter::resetSchema(static::$kernel);
+
+        static::ensureKernelShutdown();
     }
 }

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -26,21 +26,22 @@ trait ResetDatabase
             throw new \RuntimeException(\sprintf('The "%s" trait can only be used on TestCases that extend "%s".', __TRAIT__, KernelTestCase::class));
         }
 
-        static::ensureKernelShutdown();
-
         if ($isDAMADoctrineTestBundleEnabled = DatabaseResetter::isDAMADoctrineTestBundleEnabled()) {
             // disable static connections for this operation
             StaticDriver::setKeepStaticConnections(false);
         }
 
-        DatabaseResetter::resetDatabase(static::bootKernel());
+        $kernel = static::createKernel();
+        $kernel->boot();
+
+        DatabaseResetter::resetDatabase($kernel);
 
         if ($isDAMADoctrineTestBundleEnabled) {
             // re-enable static connections
             StaticDriver::setKeepStaticConnections(true);
         }
 
-        static::ensureKernelShutdown();
+        $kernel->shutdown();
     }
 
     /**
@@ -58,12 +59,11 @@ trait ResetDatabase
             throw new \RuntimeException(\sprintf('The "%s" trait can only be used on TestCases that extend "%s".', __TRAIT__, KernelTestCase::class));
         }
 
-        if (!static::$booted) {
-            static::bootKernel();
-        }
+        $kernel = static::createKernel();
+        $kernel->boot();
 
-        DatabaseResetter::resetSchema(static::$kernel);
+        DatabaseResetter::resetSchema($kernel);
 
-        static::ensureKernelShutdown();
+        $kernel->shutdown();
     }
 }


### PR DESCRIPTION
This ensure that at the start of a test, the kernel is shutdown (0d01120). A bug was also fixed where depending on the order the traits are used, a non-predictable foundry configuration could have been used (48f3ee5). I switched to having the test traits use a local `$kernel` instead of the static one provided by `KernelTestCase` (ad74cdc). This avoids the traits shutting down an already created kernel.

Documented the need to create your test client before creating factories (5247e28). Creating the client requires the kernel not be booted and the process of creating factories in your test boots the kernel. Alternatively, you can ensure the kernel shutdown before creating the client.