### PR TITLE
Re-enable Psalm and fixed annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,27 +281,27 @@ jobs:
       - name: Check CS
         run: php php-cs-fixer.phar fix --dry-run --diff --diff-format=udiff
 
-#  static-analysis:
-#    name: Psalm Static Analysis
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2.3.3
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@2.7.0
-#        with:
-#          php-version: 7.4
-#          coverage: none
-#
-#      - name: Cache dependencies
-#        uses: actions/cache@v2.1.2
-#        with:
-#          path: ~/.composer/cache/files
-#          key: dependencies-7.4-prefer-stable-${{ hashFiles('composer.json') }}
-#
-#      - name: Install dependencies
-#        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
-#
-#      - name: Run static analysis
-#        run: vendor/bin/psalm --output-format=github
+  static-analysis:
+    name: Psalm Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.7.0
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Cache dependencies
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-7.4-prefer-stable-${{ hashFiles('composer.json') }}
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
+
+      - name: Run static analysis
+        run: vendor/bin/psalm --output-format=github

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/maker-bundle": "^1.13",
         "symfony/phpunit-bridge": "^5.2",
-        "vimeo/psalm": "^3.18|^4.0",
-        "weirdan/doctrine-psalm-plugin": "^0.11.3|^1.0@dev"
+        "vimeo/psalm": "^3.18|^4.0"
     },
     "config": {
         "preferred-install": "dist",

--- a/psalm.xml
+++ b/psalm.xml
@@ -28,6 +28,5 @@
 
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>
     </plugins>
 </psalm>

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -285,7 +285,12 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             }
         }
 
-        return $this->proxyResult($this->repository->findOneBy(self::normalizeCriteria($criteria), $orderBy));
+        $result = $this->repository->findOneBy(self::normalizeCriteria($criteria), $orderBy);
+        if (null === $result) {
+            return null;
+        }
+
+        return $this->proxyResult($result);
     }
 
     /**
@@ -303,8 +308,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      *
      * @psalm-suppress InvalidReturnStatement
      * @psalm-suppress InvalidReturnType
-     * @psalm-param TProxiedObject|list<TProxiedObject> $result
-     * @psalm-return ($result is array ? list<Proxy<TProxiedObject>> : Proxy<TProxiedObject>)
+     * @template TResult of object
+     * @psalm-param TResult|list<TResult> $result
+     * @psalm-return ($result is array ? list<Proxy<TResult>> : Proxy<TResult>)
      */
     private function proxyResult($result)
     {

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -17,7 +17,7 @@ use function Zenstruck\Foundry\factory;
  */
 final class FactoryTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -13,7 +13,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Stories\TagStory;
  */
 final class GlobalStateTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -13,7 +13,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryServiceFactory;
  */
 final class ModelFactoryServiceTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -19,7 +19,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
  */
 final class ModelFactoryTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/ProxyTest.php
+++ b/tests/Functional/ProxyTest.php
@@ -15,7 +15,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
  */
 final class ProxyTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -19,7 +19,7 @@ use function Zenstruck\Foundry\repository;
  */
 final class RepositoryProxyTest extends KernelTestCase
 {
-    use ResetDatabase, Factories, ExpectDeprecationTrait;
+    use ExpectDeprecationTrait, Factories, ResetDatabase;
 
     /**
      * @test

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -15,7 +15,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Stories\ServiceStory;
  */
 final class StoryTest extends KernelTestCase
 {
-    use ResetDatabase, Factories;
+    use Factories, ResetDatabase;
 
     /**
      * @test


### PR DESCRIPTION
Not entirely sure why I needed a function-scope template for `proxyResult()`, but it did the trick. It makes a some sense, as nothing forbids you to pass a non-`TProxiedObject` object as argument.

Meanwhile, I removed the weirdan doctrine plugin as it's no longer needed (Doctrine added Psalm annotations in doctrine/orm#8289 ).