### PR TITLE
[RFC] Remove "visual duplication" of ModelFactory::new()->create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 
 /**
+ * @method static Post|Proxy createOne(array $attributes = [])
  * @method static Post|Proxy findOrCreate(array $attributes)
  * @method static Post|Proxy random()
  * @method static Post[]|Proxy[] randomSet(int $number)
@@ -257,17 +258,20 @@ protected function getDefaults(): array
 ```php
 use App\Factory\PostFactory;
 
-PostFactory::new()->create(); // create/persist Post with random data from `getDefaults()`
+// create/persist Post with random data from `getDefaults()`
+PostFactory::createOne();
 
-// create() returns the persisted Post object wrapped in a Proxy object
-$post = PostFactory::new()->create();
+// or provide values for some properties (others will be random)
+PostFactory::createOne(['title' => 'My Title']);
+
+// createOne() returns the persisted Post object wrapped in a Proxy object
+$post = PostFactory::createOne();
 
 // the "Proxy" magically calls the underlying Post methods and is type-hinted to "Post"
 $title = $post->getTitle(); // getTitle() can be autocompleted by your IDE!
 
 // if you need the actual Post object, use ->object()
 $realPost = $post->object();
-PostFactory::new()->create(['title' => 'My Title']);
 
 // create/persist 5 Posts with random data from getDefaults()
 PostFactory::new()->createMany(5); // returns Post[]|Proxy[]
@@ -284,22 +288,6 @@ $posts = PostFactory::randomSet(4); // array containing 4 "Post|Proxy" objects
 
 // random range of persisted objects
 $posts = PostFactory::randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
-```
-
-### Instantiate your `ModelFactory`
-
-One should never instantiate your `ModelFactory` with the constructor (ie `new PostFactory()`). This will
-cause the factory to not be instantiated properly. Always instantiate with `PostFactory::new()`.
-
-The first argument to `PostFactory::new()` will allow you to overwrite the default
-values that are defined in the `PostFactory::getDefaults()`.
-
-```php
-use App\Factory\PostFactory;
-
-$factory = PostFactory::new(['title' => 'My Title']);
-$factory->create();
-$factory->createMany(5);
 ```
 
 ### Reusable Model Factory "States"
@@ -340,6 +328,9 @@ final class PostFactory extends ModelFactory
 You can use states to make your tests very explicit to improve readability:
 
 ```php
+// never use the constructor (i.e. "new PostFactory()"), but use the
+// "new()" method. After defining the states, call "create()" to create
+// and persist the model.
 $post = PostFactory::new()->unpublished()->create();
 $post = PostFactory::new()->withViewCount(3)->create();
 
@@ -367,6 +358,8 @@ use App\Factory\CategoryFactory;
 use App\Factory\PostFactory;
 use function Zenstruck\Foundry\faker;
 
+// The first argument to "new()" allows you to overwrite the default
+// values that are defined in the `PostFactory::getDefaults()`
 $posts = PostFactory::new(['title' => 'Post A'])
     ->withAttributes([
         'body' => 'Post Body...',
@@ -376,7 +369,7 @@ $posts = PostFactory::new(['title' => 'Post A'])
     ])
     ->withAttributes([
         // Proxies are automatically converted to their wrapped object
-        'category' => CategoryFactory::new()->create(),
+        'category' => CategoryFactory::createOne(),
     ])
     ->withAttributes(function() { return ['createdAt' => faker()->dateTime]; }) // see faker section below
 
@@ -593,15 +586,15 @@ use App\Factory\CommentFactory;
 use App\Factory\PostFactory;
 
 // Example 1: pre-create Post and attach to Comment
-$post = PostFactory::new()->create(); // instance of Proxy
+$post = PostFactory::createOne(); // instance of Proxy
 
-CommentFactory::new()->create(['post' => $post]);
-CommentFactory::new()->create(['post' => $post->object()]); // functionally the same as above
+CommentFactory::createOne(['post' => $post]);
+CommentFactory::createOne(['post' => $post->object()]); // functionally the same as above
 
 // Example 2: pre-create Posts and choose a random one
 PostFactory::new()->many(5)->create(); // create 5 Posts
 
-CommentFactory::new()->create(['post' => PostFactory::random()]);
+CommentFactory::createOne(['post' => PostFactory::random()]);
 
 // or create many, each with a different random Post
 CommentFactory::new()->many(5) // create 5 comments
@@ -618,7 +611,7 @@ CommentFactory::new()->many(5)->create([
 
 // Example 4: create multiple Comments with the same Post
 CommentFactory::new()->many(5)->create([
-    'post' => PostFactory::new()->create(), // note the "->create" here
+    'post' => PostFactory::createOne(), // note the "createOne()" here
 ]);
 ```
 
@@ -631,9 +624,13 @@ Many-to-One's.
 protected function getDefaults(): array
 {
     return [
-        'post' => PostFactory::new(), // RECOMMENDED
+        // RECOMMENDED
+        'post' => PostFactory::new(),
+        'post' => PostFactory::new()->published(),
 
-        'post' => PostFactory::new()->create(), // NOT RECOMMENDED - will potentially result in extra unintended Posts
+        // NOT RECOMMENDED - will potentially result in extra unintended Posts
+        'post' => PostFactory::createOne(), 
+        'post' => PostFactory::new()->published()->create(),
     ];
 }
 ```
@@ -647,7 +644,7 @@ use App\Factory\CommentFactory;
 use App\Factory\PostFactory;
 
 // Example 1: Create a Post with 6 Comments
-PostFactory::new()->create(['comments' => CommentFactory::new()->many(6)]);
+PostFactory::createOne(['comments' => CommentFactory::new()->many(6)]);
 
 // Example 2: Create 6 Posts each with 4 Comments (24 Comments total)
 PostFactory::new()->many(6)->create(['comments' => CommentFactory::new()->many(4)]);
@@ -667,7 +664,7 @@ use App\Factory\TagFactory;
 // Example 1: pre-create Tags and attach to Post
 $tags = TagFactory::new()->many(3)->create();
 
-PostFactory::new()->create(['tags' => $tags]);
+PostFactory::createOne(['tags' => $tags]);
 
 // Example 2: pre-create Tags and choose a random set
 TagFactory::new()->many(10)->create();
@@ -751,8 +748,8 @@ with `foundry.factory`.
 Use the factory as normal:
 
 ```php
-UserFactory::new()->create(['password' => 'mypass'])->getPassword(); // "mypass" encoded
-UserFactory::new()->create()->getPassword(); // "1234" encoded (because "1234" is set as the default password)
+UserFactory::createOne(['password' => 'mypass'])->getPassword(); // "mypass" encoded
+UserFactory::createOne()->getPassword(); // "1234" encoded (because "1234" is set as the default password)
 ```
 
 **NOTES**:
@@ -958,14 +955,14 @@ class MyTest extends WebTestCase
         // factories boots the kernel)
         $client = self::createClient();
 
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         // ...
     }
 
     public function test_2(): void
     {
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         // if you want to create your factories before creating the client,
         // you will need to shut down the kernel first.
@@ -1017,7 +1014,7 @@ to have [Active Record](https://en.wikipedia.org/wiki/Active_record_pattern) *li
 ```php
 use App\Factory\PostFactory;
 
-$post = PostFactory::new()->create(['title' => 'My Title']); // instance of Zenstruck\Foundry\Proxy
+$post = PostFactory::createOne()->create(['title' => 'My Title']); // instance of Zenstruck\Foundry\Proxy
 
 // get the wrapped object
 $realPost = $post->object(); // instance of Post
@@ -1182,7 +1179,7 @@ Both object and repository proxy's have helpful PHPUnit assertions:
 ```php
 use App\Factory\PostFactory;
 
-$post = PostFactory::new()->create();
+$post = PostFactory::createOne();
 
 $post->assertPersisted();
 $post->assertNotPersisted();
@@ -1208,8 +1205,8 @@ If you have an initial database state you want for all tests, you can set this i
 // ...
 
 Zenstruck\Foundry\Test\TestState::addGlobalState(function () {
-    CategoryFactory::new()->create(['name' => 'php']);
-    CategoryFactory::new()->create(['name' => 'symfony']);
+    CategoryFactory::createOne(['name' => 'php']);
+    CategoryFactory::createOne(['name' => 'symfony']);
 });
 ```
 
@@ -1349,7 +1346,7 @@ class MyUnitTest extends TestCase
 
     public function some_test(): void
     {
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         // $post is not persisted to the database
     }
@@ -1506,7 +1503,7 @@ final class CategoryStory extends Story
 {
     public function build(): void
     {
-        $this->add('php', CategoryFactory::new()->create(['name' => 'php']));
+        $this->add('php', CategoryFactory::createOne(['name' => 'php']));
 
         // factories are created when added as state
         $this->add('symfony', CategoryFactory::new(['name' => 'symfony']));
@@ -1517,10 +1514,10 @@ final class CategoryStory extends Story
 Later, you can access the story's state when creating other fixtures:
 
 ```php
-PostFactory::new()->create(['category' => CategoryStory::load()->get('php')]);
+PostFactory::createOne(['category' => CategoryStory::load()->get('php')]);
 
 // or use the magic method (functionally equivalent to above)
-PostFactory::new()->create(['category' => CategoryStory::php()]);
+PostFactory::createOne(['category' => CategoryStory::php()]);
 ```
 
 **NOTE**: Story state is cleared after each test (unless it is a ["Global State Story"](#global-state)).

--- a/src/Bundle/Resources/skeleton/Factory.tpl.php
+++ b/src/Bundle/Resources/skeleton/Factory.tpl.php
@@ -11,6 +11,7 @@ use Zenstruck\Foundry\Proxy;
 
 /**
  * @method static <?= $entity->getShortName() ?>|Proxy createOne(array $attributes = [])
+ * @method static <?= $entity->getShortName() ?>[]|Proxy[] createMany(int $number, $attributes = [])
  * @method static <?= $entity->getShortName() ?>|Proxy findOrCreate(array $attributes)
  * @method static <?= $entity->getShortName() ?>|Proxy random()
  * @method static <?= $entity->getShortName() ?>[]|Proxy[] randomSet(int $number)
@@ -18,7 +19,6 @@ use Zenstruck\Foundry\Proxy;
 <?php if ($repository): ?> * @method static <?= $repository->getShortName() ?>|RepositoryProxy repository()
 <?php endif ?>
  * @method <?= $entity->getShortName() ?>|Proxy create($attributes = [])
- * @method <?= $entity->getShortName() ?>[]|Proxy[] createMany(int $number, $attributes = [])
  */
 final class <?= $class_name ?> extends ModelFactory
 {

--- a/src/Bundle/Resources/skeleton/Factory.tpl.php
+++ b/src/Bundle/Resources/skeleton/Factory.tpl.php
@@ -10,6 +10,7 @@ use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 
 /**
+ * @method static <?= $entity->getShortName() ?>|Proxy createOne(array $attributes = [])
  * @method static <?= $entity->getShortName() ?>|Proxy findOrCreate(array $attributes)
  * @method static <?= $entity->getShortName() ?>|Proxy random()
  * @method static <?= $entity->getShortName() ?>[]|Proxy[] randomSet(int $number)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -49,6 +49,17 @@ class Factory
         $this->attributeSet[] = $defaultAttributes;
     }
 
+    public function __call(string $name, array $arguments)
+    {
+        if ('createMany' !== $name) {
+            throw new \BadMethodCallException(\sprintf('Call to undefined method "%s::%s".', static::class, $name));
+        }
+
+        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s:createMany()" method instead.', static::class);
+
+        return $this->many($arguments[0])->create($arguments[1] ?? []);
+    }
+
     /**
      * @param array|callable $attributes
      *
@@ -108,18 +119,6 @@ class Factory
     final public function many(int $min, ?int $max = null): FactoryCollection
     {
         return new FactoryCollection($this, $min, $max);
-    }
-
-    /**
-     * @param array|callable $attributes
-     *
-     * @return Proxy[]|object[]
-     *
-     * @psalm-return list<Proxy<TObject>>
-     */
-    final public function createMany(int $number, $attributes = []): array
-    {
-        return $this->many($number)->create($attributes);
     }
 
     /**

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -6,6 +6,9 @@ namespace Zenstruck\Foundry;
  * @template TModel of object
  * @template-extends Factory<TModel>
  *
+ * @method static Proxy[]|object[] createMany(int $number, array|callable $attributes = [])
+ * @psalm-method static list<Proxy<TModel>> createMany(int $number, array|callable $attributes = [])
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 abstract class ModelFactory extends Factory
@@ -13,6 +16,15 @@ abstract class ModelFactory extends Factory
     public function __construct()
     {
         parent::__construct(static::getClass());
+    }
+
+    public static function __callStatic(string $name, array $arguments)
+    {
+        if ('createMany' !== $name) {
+            throw new \BadMethodCallException(\sprintf('Call to undefined static method "%s::%s".', static::class, __METHOD__));
+        }
+
+        return static::new()->many($arguments[0])->create($arguments[1] ?? []);
     }
 
     /**

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -52,6 +52,18 @@ abstract class ModelFactory extends Factory
     }
 
     /**
+     * A shortcut to create a single model without states.
+     *
+     * @return Proxy|object
+     *
+     * @psalm-return Proxy<TModel>
+     */
+    final public static function createOne(array $attributes = []): Proxy
+    {
+        return static::new()->create($attributes);
+    }
+
+    /**
      * Try and find existing object for the given $attributes. If not found,
      * instantiate and persist.
      *

--- a/src/functions.php
+++ b/src/functions.php
@@ -41,7 +41,7 @@ function create(string $class, $attributes = []): Proxy
  */
 function create_many(int $number, string $class, $attributes = []): array
 {
-    return factory($class)->createMany($number, $attributes);
+    return factory($class)->many($number)->create($attributes);
 }
 
 /**
@@ -69,7 +69,7 @@ function instantiate(string $class, $attributes = []): Proxy
  */
 function instantiate_many(int $number, string $class, $attributes = []): array
 {
-    return factory($class)->withoutPersisting()->createMany($number, $attributes);
+    return factory($class)->withoutPersisting()->many($number)->create($attributes);
 }
 
 /**

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -34,6 +34,7 @@ use Zenstruck\\Foundry\\ModelFactory;
 use Zenstruck\\Foundry\\Proxy;
 
 /**
+ * @method static Category|Proxy createOne(array \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
@@ -101,6 +102,7 @@ use Zenstruck\\Foundry\\ModelFactory;
 use Zenstruck\\Foundry\\Proxy;
 
 /**
+ * @method static Category|Proxy createOne(array \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
@@ -165,6 +167,7 @@ use Zenstruck\\Foundry\\ModelFactory;
 use Zenstruck\\Foundry\\Proxy;
 
 /**
+ * @method static Category|Proxy createOne(array \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
@@ -232,6 +235,7 @@ use Zenstruck\\Foundry\\ModelFactory;
 use Zenstruck\\Foundry\\Proxy;
 
 /**
+ * @method static Category|Proxy createOne(array \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -35,12 +35,12 @@ use Zenstruck\\Foundry\\Proxy;
 
 /**
  * @method static Category|Proxy createOne(array \$attributes = [])
+ * @method static Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
  * @method static Category[]|Proxy[] randomRange(int \$min, int \$max)
  * @method Category|Proxy create(\$attributes = [])
- * @method Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {
@@ -103,12 +103,12 @@ use Zenstruck\\Foundry\\Proxy;
 
 /**
  * @method static Category|Proxy createOne(array \$attributes = [])
+ * @method static Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
  * @method static Category[]|Proxy[] randomRange(int \$min, int \$max)
  * @method Category|Proxy create(\$attributes = [])
- * @method Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {
@@ -168,12 +168,12 @@ use Zenstruck\\Foundry\\Proxy;
 
 /**
  * @method static Category|Proxy createOne(array \$attributes = [])
+ * @method static Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
  * @method static Category[]|Proxy[] randomRange(int \$min, int \$max)
  * @method Category|Proxy create(\$attributes = [])
- * @method Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {
@@ -236,12 +236,12 @@ use Zenstruck\\Foundry\\Proxy;
 
 /**
  * @method static Category|Proxy createOne(array \$attributes = [])
+ * @method static Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  * @method static Category|Proxy findOrCreate(array \$attributes)
  * @method static Category|Proxy random()
  * @method static Category[]|Proxy[] randomSet(int \$number)
  * @method static Category[]|Proxy[] randomRange(int \$min, int \$max)
  * @method Category|Proxy create(\$attributes = [])
- * @method Category[]|Proxy[] createMany(int \$number, \$attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -38,8 +38,8 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_override_initialize(): void
     {
-        $this->assertFalse(PostFactory::new()->create()->isPublished());
-        $this->assertTrue(PostFactoryWithValidInitialize::new()->create()->isPublished());
+        $this->assertFalse(PostFactory::createOne()->isPublished());
+        $this->assertTrue(PostFactoryWithValidInitialize::createOne()->isPublished());
     }
 
     /**
@@ -120,7 +120,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function one_to_many_with_nested_collection_relationship(): void
     {
-        $post = PostFactory::new()->create([
+        $post = PostFactory::createOne([
             'comments' => CommentFactory::new()->many(4),
         ]);
 
@@ -135,7 +135,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function create_multiple_one_to_many_with_nested_collection_relationship(): void
     {
-        $user = UserFactory::new()->create();
+        $user = UserFactory::createOne();
         $posts = PostFactory::new()->createMany(2, [
             'comments' => CommentFactory::new(['user' => $user])->many(4),
         ]);
@@ -152,7 +152,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function many_to_many_with_nested_collection_relationship(): void
     {
-        $post = PostFactory::new()->create([
+        $post = PostFactory::createOne([
             'tags' => TagFactory::new()->many(3),
         ]);
 
@@ -166,7 +166,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function inverse_many_to_many_with_nested_collection_relationship(): void
     {
-        $tag = TagFactory::new()->create([
+        $tag = TagFactory::createOne([
             'posts' => PostFactory::new()->many(3),
         ]);
 

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -69,7 +69,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $ids = [];
 
@@ -85,7 +85,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $objects = CategoryFactory::randomSet(3);
 
@@ -98,7 +98,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $counts = [];
 
@@ -136,7 +136,7 @@ final class ModelFactoryTest extends KernelTestCase
     public function create_multiple_one_to_many_with_nested_collection_relationship(): void
     {
         $user = UserFactory::createOne();
-        $posts = PostFactory::new()->createMany(2, [
+        $posts = PostFactory::createMany(2, [
             'comments' => CommentFactory::new(['user' => $user])->many(4),
         ]);
 
@@ -180,7 +180,7 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function create_multiple_many_to_many_with_nested_collection_relationship(): void
     {
-        $posts = PostFactory::new()->createMany(2, [
+        $posts = PostFactory::createMany(2, [
             'tags' => TagFactory::new()->many(3),
         ]);
 

--- a/tests/Functional/ProxyTest.php
+++ b/tests/Functional/ProxyTest.php
@@ -22,7 +22,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_assert_persisted(): void
     {
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         $post->assertPersisted();
     }
@@ -32,7 +32,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_remove_and_assert_not_persisted(): void
     {
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         $post->remove();
 
@@ -44,7 +44,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function functions_are_passed_to_wrapped_object(): void
     {
-        $post = PostFactory::new()->create(['title' => 'my title']);
+        $post = PostFactory::createOne(['title' => 'my title']);
 
         $this->assertSame('my title', $post->getTitle());
     }
@@ -54,7 +54,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_convert_to_string_if_wrapped_object_can(): void
     {
-        $post = PostFactory::new()->create(['title' => 'my title']);
+        $post = PostFactory::createOne(['title' => 'my title']);
 
         $this->assertSame('my title', (string) $post);
     }
@@ -68,7 +68,7 @@ final class ProxyTest extends KernelTestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf('Proxied object "%s" cannot be converted to a string.', Category::class));
 
-        (string) CategoryFactory::new()->create();
+        (string) CategoryFactory::createOne();
     }
 
     /**
@@ -77,7 +77,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function on_php_versions_less_than_7_4_if_underlying_object_is_missing_to_string_proxy_to_string_returns_note(): void
     {
-        $this->assertSame('(no __toString)', (string) CategoryFactory::new()->create());
+        $this->assertSame('(no __toString)', (string) CategoryFactory::createOne());
     }
 
     /**
@@ -85,7 +85,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_refetch_object_if_object_manager_has_been_cleared(): void
     {
-        $post = PostFactory::new()->create(['title' => 'my title']);
+        $post = PostFactory::createOne(['title' => 'my title']);
 
         self::$container->get('doctrine')->getManager()->clear();
 
@@ -97,7 +97,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function exception_thrown_if_trying_to_refresh_deleted_object(): void
     {
-        $post = PostFactory::new()->create();
+        $post = PostFactory::createOne();
 
         self::$container->get('doctrine')->getManager()->clear();
 
@@ -114,7 +114,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_force_set_and_save(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title']);
+        $post = PostFactory::createOne(['title' => 'old title']);
 
         $post->repository()->assertNotExists(['title' => 'new title']);
 
@@ -128,7 +128,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function can_force_set_multiple_fields(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -148,7 +148,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function demonstrate_setting_field_problem_with_auto_refreshing_enabled(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -169,7 +169,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function force_set_all_solves_the_auto_refresh_problem(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -192,7 +192,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function without_auto_refresh_solves_the_auto_refresh_problem(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -217,7 +217,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function without_auto_refresh_does_not_enable_auto_refresh_if_it_was_disabled_originally(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -243,7 +243,7 @@ final class ProxyTest extends KernelTestCase
      */
     public function without_auto_refresh_re_enables_if_enabled_originally(): void
     {
-        $post = PostFactory::new()->create(['title' => 'old title', 'body' => 'old body']);
+        $post = PostFactory::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -38,7 +38,7 @@ final class RepositoryProxyTest extends KernelTestCase
 
         $repository->assertEmpty();
 
-        CategoryFactory::new()->createMany(2);
+        CategoryFactory::createMany(2);
 
         $repository->assertCount(2);
         $repository->assertCountGreaterThan(1);
@@ -54,7 +54,7 @@ final class RepositoryProxyTest extends KernelTestCase
     {
         $repository = repository(Category::class);
 
-        CategoryFactory::new()->createMany(2);
+        CategoryFactory::createMany(2);
 
         $objects = $repository->findAll();
 
@@ -85,7 +85,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $ids = [];
 
@@ -112,7 +112,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $objects = repository(Category::class)->randomSet(3);
 
@@ -149,7 +149,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        CategoryFactory::new()->createMany(5);
+        CategoryFactory::createMany(5);
 
         $counts = [];
 
@@ -268,7 +268,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function repository_proxy_is_countable_and_iterable(): void
     {
-        CategoryFactory::new()->createMany(4);
+        CategoryFactory::createMany(4);
 
         $repository = CategoryFactory::repository();
 
@@ -282,7 +282,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_use_get_count(): void
     {
-        CategoryFactory::new()->createMany(4);
+        CategoryFactory::createMany(4);
 
         $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using RepositoryProxy::getCount() is deprecated, use RepositoryProxy::count() (it is now Countable).');
 

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -73,7 +73,7 @@ final class RepositoryProxyTest extends KernelTestCase
     public function find_can_be_passed_proxy_or_object_or_array(): void
     {
         $repository = repository(Category::class);
-        $proxy = CategoryFactory::new()->create(['name' => 'foo']);
+        $proxy = CategoryFactory::createOne(['name' => 'foo']);
 
         $this->assertInstanceOf(Proxy::class, $repository->find($proxy));
         $this->assertInstanceOf(Proxy::class, $repository->find($proxy->object()));
@@ -136,7 +136,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function the_number_of_persisted_objects_must_be_at_least_the_random_set_number(): void
     {
-        CategoryFactory::new()->createMany(1);
+        CategoryFactory::createOne();
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', Category::class));
@@ -171,7 +171,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function the_number_of_persisted_objects_must_be_at_least_the_random_range_max(): void
     {
-        CategoryFactory::new()->createMany(1);
+        CategoryFactory::createOne();
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', Category::class));
@@ -208,7 +208,7 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function doctrine_proxies_are_converted_to_foundry_proxies(): void
     {
-        PostFactory::new()->create(['category' => CategoryFactory::new()]);
+        PostFactory::createOne(['category' => CategoryFactory::new()]);
 
         // clear the em so nothing is tracked
         static::$kernel->getContainer()->get('doctrine')->getManager()->clear();
@@ -229,9 +229,9 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function proxy_wrapping_orm_entity_manager_can_order_by_in_find_one_by(): void
     {
-        $categoryA = CategoryFactory::new()->create();
-        $categoryB = CategoryFactory::new()->create();
-        $categoryC = CategoryFactory::new()->create();
+        $categoryA = CategoryFactory::createOne();
+        $categoryB = CategoryFactory::createOne();
+        $categoryC = CategoryFactory::createOne();
 
         $this->assertSame($categoryC->getId(), CategoryFactory::repository()->findOneBy([], ['id' => 'DESC'])->getId());
     }
@@ -241,9 +241,9 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function first_and_last_return_the_correct_object(): void
     {
-        $categoryA = CategoryFactory::new()->create(['name' => '3']);
-        $categoryB = CategoryFactory::new()->create(['name' => '2']);
-        $categoryC = CategoryFactory::new()->create(['name' => '1']);
+        $categoryA = CategoryFactory::createOne(['name' => '3']);
+        $categoryB = CategoryFactory::createOne(['name' => '2']);
+        $categoryC = CategoryFactory::createOne(['name' => '1']);
         $repository = CategoryFactory::repository();
 
         $this->assertSame($categoryA->getId(), $repository->first()->getId());

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Faker;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\Proxy;
@@ -18,7 +19,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
  */
 final class FactoryTest extends TestCase
 {
-    use Factories;
+    use ExpectDeprecationTrait, Factories;
 
     /**
      * @test
@@ -40,9 +41,12 @@ final class FactoryTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
-    public function can_instantiate_many_objects(): void
+    public function can_instantiate_many_objects_legacy(): void
     {
+        $this->expectDeprecation('Since zenstruck/foundry 1.7: Calling instance method "'.Factory::class.'::createMany()" is deprecated and will be removed in 2.0, use the static "'.Factory::class.':createMany()" method instead.');
+
         $attributeArray = ['title' => 'title', 'body' => 'body'];
         $attributeCallback = static function(Faker\Generator $faker) {
             return ['title' => 'title', 'body' => 'body'];
@@ -265,9 +269,12 @@ final class FactoryTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
-    public function can_create_many_objects(): void
+    public function can_create_many_objects_legacy(): void
     {
+        $this->expectDeprecation('Since zenstruck/foundry 1.7: Calling instance method "'.Factory::class.'::createMany()" is deprecated and will be removed in 2.0, use the static "'.Factory::class.':createMany()" method instead.');
+
         $registry = $this->createMock(ManagerRegistry::class);
         $registry
             ->expects($this->exactly(6))

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -42,10 +42,22 @@ final class ModelFactoryTest extends TestCase
 
     /**
      * @test
+     * @group legacy
+     */
+    public function can_instantiate_many_legacy(): void
+    {
+        $objects = PostFactory::createMany(2, ['title' => 'title']);
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('title', $objects[0]->getTitle());
+    }
+
+    /**
+     * @test
      */
     public function can_instantiate_many(): void
     {
-        $objects = PostFactory::new()->createMany(2, ['title' => 'title']);
+        $objects = PostFactory::createMany(2, ['title' => 'title']);
 
         $this->assertCount(2, $objects);
         $this->assertSame('title', $objects[0]->getTitle());

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -18,7 +18,7 @@ final class ModelFactoryTest extends TestCase
      */
     public function can_set_states_with_method(): void
     {
-        $this->assertFalse(PostFactory::new()->create()->isPublished());
+        $this->assertFalse(PostFactory::createOne()->isPublished());
         $this->assertTrue(PostFactory::new()->published()->create()->isPublished());
     }
 
@@ -27,7 +27,7 @@ final class ModelFactoryTest extends TestCase
      */
     public function can_set_state_via_new(): void
     {
-        $this->assertFalse(PostFactory::new()->create()->isPublished());
+        $this->assertFalse(PostFactory::createOne()->isPublished());
         $this->assertTrue(PostFactory::new('published')->create()->isPublished());
     }
 
@@ -37,6 +37,7 @@ final class ModelFactoryTest extends TestCase
     public function can_instantiate(): void
     {
         $this->assertSame('title', PostFactory::new()->create(['title' => 'title'])->getTitle());
+        $this->assertSame('title', PostFactory::createOne(['title' => 'title'])->getTitle());
     }
 
     /**


### PR DESCRIPTION
This is an approach on removing "visual duplication" when creating new models:

```php
// before
$post = PostFactory::new()->create();
$post = PostFactory::new()->published()->create();
$posts = PostFactory::new()->createMany(3);
$posts = PostFactory::new()->published()->createMany(3);

// after
$post = PostFactory::createOne();
$post = PostFactory::new()->published()->create();
$posts = PostFactory::createMany(3);
$posts = PostFactory::new()->published()->many(3)->create();
```

We can't use `PostFactory::create()` as it conflicts with the `Factory#create()` instance method. <s>I used the magic method name to clearly indicate that we're not creating a new factory, but we are creating a new entity. An alternative name that doesn't need the magic `__callStatic()` method can be `createSingle()` (which seems consistent with `createMany()`).</s>