### PR TITLE
Fix unmanaged many-to-one entity problem

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -261,7 +261,7 @@ class Factory
     private function normalizeAttribute($value)
     {
         if ($value instanceof Proxy) {
-            return $value->object();
+            return $value->isPersisted() ? $value->refresh()->object() : $value->object();
         }
 
         if ($value instanceof FactoryCollection) {
@@ -279,7 +279,7 @@ class Factory
         }
 
         if (!$value instanceof self) {
-            return $value;
+            return \is_object($value) ? self::normalizeObject($value) : $value;
         }
 
         if (!$this->isPersisting()) {
@@ -288,6 +288,15 @@ class Factory
         }
 
         return $value->create()->object();
+    }
+
+    private static function normalizeObject(object $object): object
+    {
+        try {
+            return Proxy::createFromPersisted($object)->refresh()->object();
+        } catch (\RuntimeException $e) {
+            return $object;
+        }
     }
 
     private function normalizeCollection(FactoryCollection $collection): array

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -297,5 +298,33 @@ final class ModelFactoryTest extends KernelTestCase
             [PostFactory::new(), false],
             [PostFactory::new()->published(), true],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category']);
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_raw_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
     }
 }


### PR DESCRIPTION
Possible fix for #114.

When normalizing many-to-one entity attribute, if that object is no longer managed by the em, you would get the error shown in #114. This fix does the following:

1. If the object is a proxy and is marked as persisted, refreshes the object prior to returning it.
2. If the object is not a proxy, wrap in a temporary proxy and attempt to refresh before returning the object. If the refresh fails (because the object isn't persisted or not managed by doctrine) just return the object as is.