### PR TITLE
Try out ProxyManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,4 +314,4 @@ jobs:
           composer-options: --prefer-dist
 
       - name: Run static analysis
-        run: vendor/bin/psalm --output-format=github
+        run: vendor/bin/psalm --output-format=github --php-version=$(php -r 'echo PHP_VERSION;')

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $post = PostFactory::new() // Create the factory for Post objects
 The factories can be used inside [DoctrineFixturesBundle](https://symfony.com/doc/master/bundles/DoctrineFixturesBundle/index.html)
 to load fixtures or inside your tests, [where it has even more features](#using-in-your-tests).
 
-Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/foundry
+Want to watch a screencast  about it? Check out https://symfonycasts.com/foundry
 
 ## Documentation
 
@@ -44,19 +44,19 @@ Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/fou
 5. [Using in your Tests](#using-in-your-tests)
     1. [Enable Foundry in your TestCase](#enable-foundry-in-your-testcase)
     2. [Database Reset](#database-reset)
-    3. [Object Proxy](#object-proxy)
-        1. [Force Setting](#force-setting)
-        2. [Auto-Refresh](#auto-refresh)
-    4. [Repository Proxy](#repository-proxy)
-    5. [Assertions](#assertions)
-    6. [Global State](#global-state)
-    7. [PHPUnit Data Providers](#phpunit-data-providers)
-    8. [Performance](#performance)
+    3. [Force Setting](#force-setting)
+    4. [Object Proxy](#object-proxy)
+        1. [Auto-Refresh](#auto-refresh)
+    5. [Repository Proxy](#repository-proxy)
+    6. [Assertions](#assertions)
+    7. [Global State](#global-state)
+    8. [PHPUnit Data Providers](#phpunit-data-providers)
+    9. [Performance](#performance)
         1. [DAMADoctrineTestBundle](#damadoctrinetestbundle)
         2. [Miscellaneous](#miscellaneous)
-    9. [Non-Kernel Test](#non-kernel-tests)
-    10. [Test-Only Configuration](#test-only-configuration)
-    11. [Using without the Bundle](#using-without-the-bundle)
+    10. [Non-Kernel Test](#non-kernel-tests)
+    11. [Test-Only Configuration](#test-only-configuration)
+    12. [Using without the Bundle](#using-without-the-bundle)
 6. [Stories](#stories)
     1. [Stories as Services](#stories-as-services)
     2. [Story State](#story-state)
@@ -193,23 +193,22 @@ use App\Entity\Post;
 use App\Repository\PostRepository;
 use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\ModelFactory;
-use Zenstruck\Foundry\Proxy;
 
 /**
- * @method static Post|Proxy createOne(array $attributes = [])
- * @method static Post[]|Proxy[] createMany(int $number, $attributes = [])
- * @method static Post|Proxy find($criteria)
- * @method static Post|Proxy findOrCreate(array $attributes)
- * @method static Post|Proxy first(string $sortedField = 'id')
- * @method static Post|Proxy last(string $sortedField = 'id')
- * @method static Post|Proxy random(array $attributes = [])
- * @method static Post|Proxy randomOrCreate(array $attributes = []))
- * @method static Post[]|Proxy[] all()
- * @method static Post[]|Proxy[] findBy(array $attributes)
- * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
- * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @method static Post createOne(array $attributes = [])
+ * @method static Post[] createMany(int $number, $attributes = [])
+ * @method static Post find($criteria)
+ * @method static Post findOrCreate(array $attributes)
+ * @method static Post first(string $sortedField = 'id')
+ * @method static Post last(string $sortedField = 'id')
+ * @method static Post random(array $attributes = [])
+ * @method static Post randomOrCreate(array $attributes = []))
+ * @method static Post[] all()
+ * @method static Post[] findBy(array $attributes)
+ * @method static Post[] randomSet(int $number, array $attributes = []))
+ * @method static Post[] randomRange(int $min, int $max, array $attributes = []))
  * @method static PostRepository|RepositoryProxy repository()
- * @method Post|Proxy create($attributes = [])
+ * @method Post create($attributes = [])
  */
 final class PostFactory extends ModelFactory
 {
@@ -273,21 +272,16 @@ PostFactory::createOne();
 // or provide values for some properties (others will be random)
 PostFactory::createOne(['title' => 'My Title']);
 
-// createOne() returns the persisted Post object wrapped in a Proxy object
+// createOne() returns the persisted Post object
 $post = PostFactory::createOne();
-
-// the "Proxy" magically calls the underlying Post methods and is type-hinted to "Post"
-$title = $post->getTitle(); // getTitle() can be autocompleted by your IDE!
-
-// if you need the actual Post object, use ->object()
-$realPost = $post->object();
+$title = $post->getTitle();
 
 // create/persist 5 Posts with random data from getDefaults()
-PostFactory::createMany(5); // returns Post[]|Proxy[]
+PostFactory::createMany(5); // returns an array of Post objects
 PostFactory::createMany(5, ['title' => 'My Title']);
 
 // find a persisted object for the given attributes, if not found, create with the attributes
-PostFactory::findOrCreate(['title' => 'My Title']); // returns Post|Proxy
+PostFactory::findOrCreate(['title' => 'My Title']); // returns a Post object
 
 PostFactory::first(); // get the first object (assumes an auto-incremented "id" column)
 PostFactory::first('createdAt'); // assuming "createdAt" is a datetime column, this will return latest object
@@ -298,15 +292,15 @@ PostFactory::truncate(); // empty the database table
 
 PostFactory::count(); // the number of persisted Posts
 
-PostFactory::all(); // Post[]|Proxy[] all the persisted Posts
+PostFactory::all(); // Post[] all the persisted Posts
 
-PostFactory::findBy(['author' => 'kevin']); // Post[]|Proxy[] matching the filter
+PostFactory::findBy(['author' => 'kevin']); // Post[] matching the filter
 
-$post = PostFactory::find(5); // Post|Proxy with the id of 5
-$post = PostFactory::find(['title' => 'My First Post']); // Post|Proxy matching the filter
+$post = PostFactory::find(5); // Post with the id of 5
+$post = PostFactory::find(['title' => 'My First Post']); // Post matching the filter
 
 // get a random object that has been persisted
-$post = PostFactory::random(); // returns Post|Proxy
+$post = PostFactory::random(); // returns Post
 $post = PostFactory::random(['author' => 'kevin']); // filter by the passed attributes
 
 // or automatically persist a new random object if none exists
@@ -314,13 +308,16 @@ $post = PostFactory::randomOrCreate();
 $post = PostFactory::randomOrCreate(['author' => 'kevin']); // filter by or create with the passed attributes
 
 // get a random set of objects that have been persisted
-$posts = PostFactory::randomSet(4); // array containing 4 "Post|Proxy" objects
+$posts = PostFactory::randomSet(4); // array containing 4 "Post" objects
 $posts = PostFactory::randomSet(4, ['author' => 'kevin']); // filter by the passed attributes
 
 // random range of persisted objects
-$posts = PostFactory::randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
+$posts = PostFactory::randomRange(0, 5); // array containing 0-5 "Post" objects
 $posts = PostFactory::randomRange(0, 5, ['author' => 'kevin']); // filter by the passed attributes
 ```
+
+Instead of the real Post object, all factory methods return a proxy object wrapping the Post object. This proxy behaves
+exactly like the real object (including type hints). Read more about this in [Proxy object](#proxy-object).
 
 ### Reusable Model Factory "States"
 
@@ -455,7 +452,6 @@ they were added.
 
 ```php
 use App\Factory\PostFactory;
-use Zenstruck\Foundry\Proxy;
 
 PostFactory::new()
     ->beforeInstantiate(function(array $attributes): array {
@@ -468,14 +464,6 @@ PostFactory::new()
         // $object is the instantiated object
         // $attributes contains the attributes used to instantiate the object and any extras
     })
-    ->afterPersist(function(Proxy $object, array $attributes) {
-        /* @var Post $object */
-        // this event is only called if the object was persisted
-        // $proxy is a Proxy wrapping the persisted object
-        // $attributes contains the attributes used to instantiate the object and any extras
-    })
-
-    // if the first argument is type-hinted as the object, it will be passed to the closure (and not the proxy)
     ->afterPersist(function(Post $object, array $attributes) {
         // this event is only called if the object was persisted
         // $object is the persisted Post object
@@ -618,10 +606,9 @@ use App\Factory\CommentFactory;
 use App\Factory\PostFactory;
 
 // Example 1: pre-create Post and attach to Comment
-$post = PostFactory::createOne(); // instance of Proxy
+$post = PostFactory::createOne();
 
 CommentFactory::createOne(['post' => $post]);
-CommentFactory::createOne(['post' => $post->object()]); // functionally the same as above
 
 // Example 2: pre-create Posts and choose a random one
 PostFactory::createMany(5); // create 5 Posts
@@ -823,15 +810,15 @@ $factory->last('createdAt'); // assuming "createdAt" is a datetime column, this 
 
 $factory->truncate(); // empty the database table
 $factory->count(); // the number of persisted Post's
-$factory->all(); // Post[]|Proxy[] all the persisted Post's
+$factory->all(); // Post[] all the persisted Post's
 
-$factory->findBy(['author' => 'kevin']); // Post[]|Proxy[] matching the filter
+$factory->findBy(['author' => 'kevin']); // Post[] matching the filter
 
-$factory->find(5); // Post|Proxy with the id of 5
-$factory->find(['title' => 'My First Post']); // Post|Proxy matching the filter
+$factory->find(5); // Post with the id of 5
+$factory->find(['title' => 'My First Post']); // Post matching the filter
 
 // get a random object that has been persisted
-$factory->random(); // returns Post|Proxy
+$factory->random(); // returns Post
 $factory->random(['author' => 'kevin']); // filter by the passed attributes
 
 // or automatically persist a new random object if none exists
@@ -839,11 +826,11 @@ $factory->randomOrCreate();
 $factory->randomOrCreate(['author' => 'kevin']); // filter by or create with the passed attributes
 
 // get a random set of objects that have been persisted
-$factory->randomSet(4); // array containing 4 "Post|Proxy" objects
+$factory->randomSet(4); // array containing 4 "Post" objects
 $factory->randomSet(4, ['author' => 'kevin']); // filter by the passed attributes
 
 // random range of persisted objects
-$factory->randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
+$factory->randomRange(0, 5); // array containing 0-5 "Post" objects
 $factory->randomRange(0, 5, ['author' => 'kevin']); // filter by the passed attributes
 
 // repository proxy wrapping PostRepository (see Repository Proxy section below)
@@ -857,8 +844,7 @@ $entities = create_many(Post::class, 5, ['field' => 'value']);
 ### Without Persisting
 
 Factories can also create objects without persisting them. This can be useful for unit tests where you just want to test
-the behaviour of the actual object or for creating objects that are not entities. When created, they are still wrapped
-in a `Proxy` to optionally save later.
+the behaviour of the actual object or for creating objects that are not entities.
 
 ```php
 use App\Factory\PostFactory;
@@ -867,22 +853,19 @@ use Zenstruck\Foundry\AnonymousFactory;
 use function Zenstruck\Foundry\instantiate;
 use function Zenstruck\Foundry\instantiate_many;
 
-$post = PostFactory::new()->withoutPersisting()->create(); // returns Post|Proxy
+$post = PostFactory::new()->withoutPersisting()->create(); // returns a Post object
 $post->setTitle('something else'); // do something with object
-$post->save(); // persist the Post (save() is a method on Proxy)
 
-$post = PostFactory::new()->withoutPersisting()->create()->object(); // actual Post object
+PostFactory::save($post); // persist the Post
 
-$posts = PostFactory::new()->withoutPersisting()->many(5)->create(); // returns Post[]|Proxy[]
+$posts = PostFactory::new()->withoutPersisting()->many(5)->create(); // returns Post[]
 
 // anonymous factories:
 $factory = new AnonymousFactory(Post::class);
 
-$entity = $factory->withoutPersisting()->create(['field' => 'value']); // returns Post|Proxy
+$entity = $factory->withoutPersisting()->create(['field' => 'value']); // returns Post
 
-$entity = $factory->withoutPersisting()->create(['field' => 'value'])->object(); // actual Post object
-
-$entities = $factory->withoutPersisting()->many(5)->create(['field' => 'value']); // returns Post[]|Proxy[]
+$entities = $factory->withoutPersisting()->many(5)->create(['field' => 'value']); // returns Post[]
 
 // convenience functions
 $entity = instantiate(Post::class, ['field' => 'value']);
@@ -994,7 +977,7 @@ public function test_can_post_a_comment(): void
     // 3. "Assert"
     self::assertResponseRedirects('/posts/post-a');
 
-    $this->assertCount(1, $post->refresh()->getComments()); // Refresh $post from the database and call ->getComments()
+    $this->assertCount(1, $post->getComments()); // Before calling getComments(), $post is reloaded from the database (see "Auto-Refresh" below)
 
     CommentFactory::assert()->exists([ // Doctrine repository assertions
         'name' => 'John',
@@ -1068,64 +1051,44 @@ FOUNDRY_RESET_CONNECTIONS=connection1,connection2
 FOUNDRY_RESET_OBJECT_MANAGERS=manager1,manager2
 ```
 
-### Object Proxy
+### Force Setting
 
-Objects created by a factory are wrapped in a special *Proxy* object. These objects allow your doctrine entities
-to have [Active Record](https://en.wikipedia.org/wiki/Active_record_pattern) *like* behavior:
-
-```php
-use App\Factory\PostFactory;
-
-$post = PostFactory::createOne()->create(['title' => 'My Title']); // instance of Zenstruck\Foundry\Proxy
-
-// get the wrapped object
-$realPost = $post->object(); // instance of Post
-
-// call any Post method
-$post->getTitle(); // "My Title"
-
-// set property and save to the database
-$post->setTitle('New Title');
-$post->save();
-
-// refresh from the database
-$post->refresh();
-
-// delete from the database
-$post->remove();
-
-$post->repository(); // repository proxy wrapping PostRepository (see Repository Proxy section below)
-```
-
-#### Force Setting
-
-Object proxies have helper methods to access non-public properties of the object they wrap:
+Sometimes, you want to set properties of an object that aren't accessible. Foundry provides some helper functions to set and read values of these
+inaccessible properties:
 
 ```php
+use function Zenstruck\Foundry\force_set;
+use function Zenstruck\Foundry\force_set_all;
+use function Zenstruck\Foundry\force_get;
+
 // set private/protected properties
-$post->forceSet('createdAt', new \DateTime());
+force_set($post, 'createdAt', new \DateTime());
+force_set_all($post, [
+    'createdAt' => new \DateTime(),
+    'updatedAt' => new \DateTime(),
+]);
 
 // get private/protected properties
-$post->forceGet('createdAt');
+force_get($post, 'createdAt');
 ```
+
+### Object Proxy
+
+All entities returned by the factory are actual special *proxy* objects that wrap the real entity.
 
 #### Auto-Refresh
 
-Object proxies have the option to enable *auto refreshing* that removes the need to call `->refresh()` before calling
-methods on the underlying object. When auto-refresh is enabled, most calls to proxy objects first refresh the wrapped
-object from the database.
+Object proxies use a technique called *auto refreshing* that reloads data from the database before calling methods on the
+underlying object.
 
 ```php
 use App\Factory\PostFactory;
 
-$post = PostFactory::new(['title' => 'Original Title'])
-    ->create()
-    ->enableAutoRefresh()
-;
+$post = PostFactory::createOne(['title' => 'Original Title']);
 
-// ... logic that changes the $post title to "New Title" (like your functional test)
+// ... logic that changes the $post title to "New Title" (like a request in your functional test)
 
-$post->getTitle(); // "New Title" (equivalent to $post->refresh()->getTitle())
+$post->getTitle(); // "New Title" (equivalent to PostFactory::repository()->find($post->getId())->getTitle())
 ```
 
 Without auto-refreshing enabled, the above call to `$post->getTitle()` would return "Original Title".
@@ -1137,10 +1100,7 @@ thrown:
 ```php
 use App\Factory\PostFactory;
 
-$post = PostFactory::new(['title' => 'Original Title', 'body' => 'Original Body'])
-    ->create()
-    ->enableAutoRefresh()
-;
+$post = PostFactory::createOne(['title' => 'Original Title', 'body' => 'Original Body']);
 
 $post->setTitle('New Title');
 $post->setBody('New Body'); // exception thrown because of "unsaved changes" to $post from above
@@ -1151,35 +1111,36 @@ To overcome this, you need to first disable auto-refreshing, then re-enable afte
 ```php
 use App\Entity\Post;
 use App\Factory\PostFactory;
+use function Zenstruck\Foundry\disable_autorefresh;
+use function Zenstruck\Foundry\enable_autorefresh;
+use function Zenstruck\Foundry\without_autorefresh;
+use function Zenstruck\Foundry\force_set_all;
 
-$post = PostFactory::new(['title' => 'Original Title', 'body' => 'Original Body'])
-    ->create()
-    ->enableAutoRefresh()
-;
+$post = PostFactory::createOne(['title' => 'Original Title', 'body' => 'Original Body']);
 
-$post->disableAutoRefresh();
-$post->setTitle('New Title'); // or using ->forceSet('title', 'New Title')
-$post->setBody('New Body'); // or using ->forceSet('body', 'New Body')
-$post->enableAutoRefresh();
-$post->save();
+disable_autorefresh($post);
+$post->setTitle('New Title'); // or using force_set($post, 'title', 'New Title')
+$post->setBody('New Body'); // or using force_set($post, 'body', 'New Body')
+enable_autorefresh($post);
+PostFactory::save($post);
 
 $post->getBody(); // "New Body"
 $post->getTitle(); // "New Title"
 
-// alternatively, use the ->withoutAutoRefresh() helper which first disables auto-refreshing, then re-enables after
+// alternatively, use the without_autorefresh() helper which first disables auto-refreshing, then re-enables after
 // executing the callback.
-$post->withoutAutoRefresh(function (Post $post) { // can pass either Post or Proxy to the callback
+without_autorefresh($post, function (Post $post) {
     $post->setTitle('New Title');
     $post->setBody('New Body');
 });
-$post->save();
+PostFactory::save($post);
 
-// if force-setting properties, you can use the ->forceSetAll() helper:
-$post->forceSetAll([
+// if force-setting properties, you can use the force_set_all() helper:
+force_set_all($post, [
     'title' => 'New Title',
     'body' => 'New Body',
 ]);
-$post->save();
+PostFactory::save($post);
 ```
 
 **NOTE**: You can enable/disable auto-refreshing globally to have every proxy auto-refreshable by default or not. When
@@ -1222,15 +1183,15 @@ $repository->randomRange(0, 5); // get 0-5 random objects
 $repository->randomRange(0, 5, ['author' => 'kevin']); // get 0-5 random objects filtered by the passed criteria
 
 // instance of ObjectRepository - all returned object(s) are proxied
-$repository->find(1); // Proxy|Post|null
-$repository->find(['title' => 'My Title']); // Proxy|Post|null
-$repository->findOneBy(['title' => 'My Title']); // Proxy|Post|null
-$repository->findAll(); // Proxy[]|Post[]
+$repository->find(1); // Post|null
+$repository->find(['title' => 'My Title']); // Post|null
+$repository->findOneBy(['title' => 'My Title']); // Post|null
+$repository->findAll(); // Post[]
 iterator_to_array($repository); // equivalent to above (RepositoryProxy implements \IteratorAggregate)
-$repository->findBy(['title' => 'My Title']); // Proxy[]|Post[]
+$repository->findBy(['title' => 'My Title']); // Post[]
 
 // can call methods on the underlying repository - returned object(s) are proxied
-$repository->findOneByTitle('My Title'); // Proxy|Post|null
+$repository->findOneByTitle('My Title'); // Post|null
 ```
 
 ### Assertions

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": ">=7.2.12",
         "doctrine/persistence": "^1.3.3|^2.0",
         "fakerphp/faker": "^1.5",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "symfony/deprecation-contracts": "^2.2",
         "symfony/property-access": "^3.4|^4.4|^5.0",
         "zenstruck/callback": "^1.1"

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\Foundry;
 
+use ProxyManager\Proxy\ValueHolderInterface;
+
 /**
  * @template TModel of object
  * @template-extends Factory<TModel>
@@ -68,9 +70,9 @@ abstract class ModelFactory extends Factory
      *
      * @return Proxy|object
      *
-     * @psalm-return Proxy<TModel>
+     * @psalm-return Proxy<TModel>|ValueHolderInterface<TModel>|TModel
      */
-    final public static function createOne(array $attributes = []): Proxy
+    final public static function createOne(array $attributes = []): object
     {
         return static::new()->create($attributes);
     }
@@ -81,9 +83,9 @@ abstract class ModelFactory extends Factory
      *
      * @return Proxy|object
      *
-     * @psalm-return Proxy<TModel>
+     * @psalm-return Proxy<TModel>|ValueHolderInterface<TModel>
      */
-    final public static function findOrCreate(array $attributes): Proxy
+    final public static function findOrCreate(array $attributes): object
     {
         if ($found = static::repository()->find($attributes)) {
             return \is_array($found) ? $found[0] : $found;
@@ -97,7 +99,7 @@ abstract class ModelFactory extends Factory
      *
      * @throws \RuntimeException If no entities exist
      */
-    final public static function first(string $sortedField = 'id'): Proxy
+    final public static function first(string $sortedField = 'id'): object
     {
         if (null === $proxy = static::repository()->first($sortedField)) {
             throw new \RuntimeException(\sprintf('No "%s" objects persisted.', static::getClass()));
@@ -111,7 +113,7 @@ abstract class ModelFactory extends Factory
      *
      * @throws \RuntimeException If no entities exist
      */
-    final public static function last(string $sortedField = 'id'): Proxy
+    final public static function last(string $sortedField = 'id'): object
     {
         if (null === $proxy = static::repository()->last($sortedField)) {
             throw new \RuntimeException(\sprintf('No "%s" objects persisted.', static::getClass()));
@@ -123,7 +125,7 @@ abstract class ModelFactory extends Factory
     /**
      * @see RepositoryProxy::random()
      */
-    final public static function random(array $attributes = []): Proxy
+    final public static function random(array $attributes = []): object
     {
         return static::repository()->random($attributes);
     }
@@ -133,9 +135,9 @@ abstract class ModelFactory extends Factory
      *
      * @return Proxy|object
      *
-     * @psalm-return Proxy<TModel>
+     * @psalm-return Proxy<TModel>|ValueHolderInterface<TModel>
      */
-    final public static function randomOrCreate(array $attributes = []): Proxy
+    final public static function randomOrCreate(array $attributes = []): object
     {
         try {
             return static::repository()->random($attributes);
@@ -189,7 +191,7 @@ abstract class ModelFactory extends Factory
      *
      * @throws \RuntimeException If no entity found
      */
-    final public static function find($criteria): Proxy
+    final public static function find($criteria): object
     {
         if (null === $proxy = static::repository()->find($criteria)) {
             throw new \RuntimeException(\sprintf('Could not find "%s" object.', static::getClass()));

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -3,7 +3,6 @@
 namespace Zenstruck\Foundry\Proxy;
 
 use Doctrine\ORM\EntityManagerInterface;
-use ProxyManager\Factory\AccessInterceptorValueHolderFactory;
 use Zenstruck\Foundry\Configuration;
 
 /**
@@ -16,13 +15,13 @@ class ProxyGenerator
 {
     /** @var Configuration */
     private $configuration;
-    /** @var AccessInterceptorValueHolderFactory */
+    /** @var ValueReplacingAccessInterceptorValueHolderFactory */
     private $factory;
 
-    public function __construct(Configuration $configuration, ?AccessInterceptorValueHolderFactory $factory = null)
+    public function __construct(Configuration $configuration, ?ValueReplacingAccessInterceptorValueHolderFactory $factory = null)
     {
         $this->configuration = $configuration;
-        $this->factory = $factory ?? new AccessInterceptorValueHolderFactory();
+        $this->factory = $factory ?? new ValueReplacingAccessInterceptorValueHolderFactory();
     }
 
     public function generate(object $object, array $methods = []): object

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Zenstruck\Foundry\Proxy;
+
+use Doctrine\ORM\EntityManagerInterface;
+use ProxyManager\Factory\AccessInterceptorValueHolderFactory;
+use Zenstruck\Foundry\Configuration;
+
+/**
+ * Generates model proxies to autorefresh property values
+ * from the database.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ProxyGenerator
+{
+    /** @var Configuration */
+    private $configuration;
+    /** @var AccessInterceptorValueHolderFactory */
+    private $factory;
+
+    public function __construct(Configuration $configuration, ?AccessInterceptorValueHolderFactory $factory = null)
+    {
+        $this->configuration = $configuration;
+        $this->factory = $factory ?? new AccessInterceptorValueHolderFactory();
+    }
+
+    public function generate(object $object, array $methods = []): object
+    {
+        $objectManager = $this->configuration->objectManagerFor(\get_class($object));
+        $interceptor = function(object $proxy, object $model) use ($objectManager): void {
+            $autoRefreshEnabled = \property_exists($model, '_foundry_autoRefresh') ? $model->_foundry_autoRefresh : true;
+            if (!$autoRefreshEnabled) {
+                return;
+            }
+
+            $modelClassMetadata = $objectManager->getClassMetadata(\get_class($model));
+
+            // only check for changes if the object is managed in the current om
+            if ($objectManager instanceof EntityManagerInterface && $objectManager->contains($model)) {
+                // cannot use UOW::recomputeSingleEntityChangeSet() here as it wrongly computes embedded objects as changed
+                $objectManager->getUnitOfWork()->computeChangeSet($modelClassMetadata, $model);
+
+                if (!empty($objectManager->getUnitOfWork()->getEntityChangeSet($model))) {
+                    throw new \RuntimeException(\sprintf('Cannot auto refresh "%s" as there are unsaved changes. Be sure to call ->save() or disable auto refreshing (see https://github.com/zenstruck/foundry#auto-refresh for details).', \get_class($model)));
+                }
+
+                $objectManager->refresh($model);
+
+                return;
+            }
+
+            // refetch the model as it's no longer managed
+            $modelId = $modelClassMetadata->getIdentifierValues($model);
+            if (!$modelId) {
+                throw new \RuntimeException('The object no longer exists.');
+            }
+
+            $proxy->setWrappedValueHolder($objectManager->find(\get_class($model), $modelId));
+        };
+
+        $methodsToIntercept = $this->filterGlob(\get_class_methods($object), $methods);
+
+        return $this->factory->createProxy($object, \array_fill_keys($methodsToIntercept, $interceptor));
+    }
+
+    private function filterGlob(array $objectMethods, array $methodFilter): array
+    {
+        $methods = [];
+        if (!$methodFilter) {
+            $methods = $objectMethods;
+        } else {
+            foreach ($methodFilter as $filter) {
+                // no *, assume filter is an exact match and no glob
+                if (false === \mb_strpos($filter, '*')) {
+                    $methods[] = $filter;
+                    continue;
+                }
+
+                // transform glob (e.g. "get*") into a regex
+                $methodNameRegex = '/^'.\str_replace('*', '[[:alnum:]]+', $filter).'$/';
+                $methods = \array_merge($methods, \array_filter($objectMethods, function($objectMethod) use ($methodNameRegex) {
+                    return 1 !== \preg_match($methodNameRegex, $objectMethod);
+                }));
+            }
+        }
+
+        return \array_unique($methods);
+    }
+}

--- a/src/Proxy/SetValueHolderMethod.php
+++ b/src/Proxy/SetValueHolderMethod.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zenstruck\Foundry\Proxy;
+
+use Laminas\Code\Generator\ParameterGenerator;
+use Laminas\Code\Generator\PropertyGenerator;
+use ProxyManager\Generator\MethodGenerator;
+
+/**
+ * Adds a setter method for the proxied value holder.
+ *
+ * The ProxyManager doesn't allow replacing the value holder, but this is
+ * required if Foundry is used across Symfony kernel reboots (which is
+ * common in HTTP tests).
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class SetValueHolderMethod extends MethodGenerator
+{
+    public function __construct(PropertyGenerator $valueHolderProperty)
+    {
+        parent::__construct('setWrappedValueHolder');
+
+        $this->setParameter(new ParameterGenerator('wrappedValueHolder'));
+        $this->setReturnType('void');
+        $this->setBody('$this->'.$valueHolderProperty->getName().' = $wrappedValueHolder;');
+    }
+}

--- a/src/Proxy/ValueReplacingAccessInterceptorValueHolderFactory.php
+++ b/src/Proxy/ValueReplacingAccessInterceptorValueHolderFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Zenstruck\Foundry\Proxy;
+
+use ProxyManager\Factory\AccessInterceptorValueHolderFactory;
+use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
+
+/**
+ * A little extension to add {@see SetValueHolderMethod} to the proxy.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ValueReplacingAccessInterceptorValueHolderFactory extends AccessInterceptorValueHolderFactory
+{
+    protected function getGenerator(): ProxyGeneratorInterface
+    {
+        return new ValueReplacingGenerator(parent::getGenerator());
+    }
+}

--- a/src/Proxy/ValueReplacingGenerator.php
+++ b/src/Proxy/ValueReplacingGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Proxy;
+
+use Laminas\Code\Generator\ClassGenerator;
+use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator\ValueHolderProperty;
+use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
+use ReflectionClass;
+
+/**
+ * A generator decorator to add {@see SetValueHolderMethod}.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ValueReplacingGenerator implements ProxyGeneratorInterface
+{
+    /** @var ProxyGeneratorInterface */
+    private $generator;
+
+    public function __construct(ProxyGeneratorInterface $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator): void
+    {
+        $this->generator->generate($originalClass, $classGenerator);
+
+        $valueHolderProperty = null;
+        foreach ($classGenerator->getProperties() as $property) {
+            if ($property instanceof ValueHolderProperty) {
+                $valueHolderProperty = $property;
+
+                break;
+            }
+        }
+        \assert($valueHolderProperty instanceof ValueHolderProperty);
+
+        $classGenerator->addMethodFromGenerator(new SetValueHolderMethod($valueHolderProperty));
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry;
 
 use Faker;
+use ProxyManager\Proxy\ValueHolderInterface;
 
 /**
  * @see Factory::__construct()
@@ -86,4 +87,127 @@ function repository($objectOrClass): RepositoryProxy
 function faker(): Faker\Generator
 {
     return Factory::faker();
+}
+
+/**
+ * Enables autorefresh on the model.
+ *
+ * @param Proxy|ValueHolderInterface $model
+ */
+function enable_autorefresh(object $model): void
+{
+    if ($model instanceof Proxy) {
+        $model->enableAutoRefresh();
+
+        return;
+    }
+
+    if ($model instanceof ValueHolderInterface) {
+        $realModel = $model->getWrappedValueHolderValue();
+        if (!$realModel) {
+            return;
+        }
+
+        $realModel->_foundry_autoRefresh = true;
+    }
+}
+
+/**
+ * Disables autorefresh on the model.
+ *
+ * @param Proxy|ValueHolderInterface $model
+ */
+function disable_autorefresh(object $model): void
+{
+    if ($model instanceof Proxy) {
+        $model->disableAutoRefresh();
+
+        return;
+    }
+
+    if ($model instanceof ValueHolderInterface) {
+        $realModel = $model->getWrappedValueHolderValue();
+        if (!$realModel) {
+            return;
+        }
+
+        $realModel->_foundry_autoRefresh = false;
+    }
+}
+
+/**
+ * Ensures "autoRefresh" is disabled when executing $callback. Re-enables
+ * "autoRefresh" after executing callback if it was enabled.
+ *
+ * @param Proxy|ValueHolderInterface $model
+ * @param callable                   $callback (Proxy|ValueHolderInterface $model): void
+ *
+ * @template TModel as Proxy|ValueHolderInterface
+ * @psalm-param TModel $model
+ * @psalm-param callable(TModel):void $callback
+ */
+function without_autorefresh(object $model, callable $callback): void
+{
+    if ($model instanceof Proxy) {
+        $model->withoutAutoRefresh($callback);
+
+        return;
+    }
+
+    $originalValue = null;
+    if ($model instanceof ValueHolderInterface) {
+        $realModel = get_real_object($model);
+
+        /** @psalm-suppress NoInterfaceProperties */
+        $originalValue = \property_exists($realModel, '_foundry_autoRefresh') ? $realModel->_foundry_autoRefresh : true;
+        /** @psalm-suppress NoInterfaceProperties */
+        $realModel->_foundry_autoRefresh = false;
+    }
+
+    ($callback)($model);
+
+    if (null !== $originalValue) {
+        $realModel->_foundry_autoRefresh = $originalValue;
+    }
+}
+
+function force_set(object $model, string $property, $value): void
+{
+    force_set_all($model, [$property => $value]);
+}
+
+function force_set_all(object $model, array $properties): void
+{
+    foreach ($properties as $property => $value) {
+        Instantiator::forceSet(get_real_object($model), $property, $value);
+    }
+}
+
+/**
+ * @return mixed
+ */
+function force_get(object $model, string $property)
+{
+    return Instantiator::forceGet(get_real_object($model), $property);
+}
+
+/**
+ * @template T of object
+ * @psalm-param T|Proxy<T>|ValueHolderInterface<T> $proxyObject
+ * @psalm-return T
+ *
+ * @psalm-suppress InvalidReturnType
+ * @psalm-suppress InvalidReturnStatement
+ */
+function get_real_object(object $proxyObject): object
+{
+    if ($proxyObject instanceof Proxy) {
+        return $proxyObject->object();
+    }
+
+    if ($proxyObject instanceof ValueHolderInterface && $valueHolder = $proxyObject->getWrappedValueHolderValue()) {
+        return $valueHolder;
+    }
+
+    return $proxyObject;
 }

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -84,9 +84,19 @@ class Post
         return $this->title;
     }
 
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
     public function getBody(): ?string
     {
         return $this->body;
+    }
+
+    public function setBody(string $body): void
+    {
+        $this->body = $body;
     }
 
     public function getShortDescription(): ?string

--- a/tests/Fixtures/Factories/PostFactoryWithProxyGenerator.php
+++ b/tests/Fixtures/Factories/PostFactoryWithProxyGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class PostFactoryWithProxyGenerator extends PostFactory
+{
+    protected function initialize(): self
+    {
+        return parent::initialize()->withProxyGenerator();
+    }
+}

--- a/tests/Functional/ProxyGeneratorTest.php
+++ b/tests/Functional/ProxyGeneratorTest.php
@@ -105,8 +105,6 @@ final class ProxyGeneratorTest extends ProxyTest
      */
     public function can_autorefresh_between_kernel_boots(): void
     {
-        $this->markTestSkipped('not supported');
-
         $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
 
         $this->assertSame('old title', $post->getTitle());

--- a/tests/Functional/ProxyGeneratorTest.php
+++ b/tests/Functional/ProxyGeneratorTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\AnonymousFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithProxyGenerator;
+use function Zenstruck\Foundry\disable_autorefresh;
+use function Zenstruck\Foundry\force_set;
+use function Zenstruck\Foundry\force_set_all;
+use function Zenstruck\Foundry\without_autorefresh;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+final class ProxyGeneratorTest extends ProxyTest
+{
+    protected static $POST_FACTORY = PostFactoryWithProxyGenerator::class;
+
+    /**
+     * @test
+     */
+    public function can_assert_persisted(): void
+    {
+        $this->markTestSkipped('assertPersisted() is not supported');
+    }
+
+    /**
+     * @test
+     */
+    public function can_remove_and_assert_not_persisted(): void
+    {
+        $this->markTestSkipped('assertNotPersisted() is not supported');
+    }
+
+    /**
+     * @test
+     */
+    public function can_refetch_object_if_object_manager_has_been_cleared(): void
+    {
+        $this->markTestSkipped('refresh() is not supported');
+    }
+
+    /**
+     * @test
+     */
+    public function exception_thrown_if_trying_to_refresh_deleted_object(): void
+    {
+        $this->markTestSkipped('refresh() is not supported');
+    }
+
+    /**
+     * @test
+     */
+    public function can_force_set_and_save(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title']);
+
+        static::$POST_FACTORY::assert()->notExists(['title' => 'new title']);
+
+        force_set($post, 'title', 'new title');
+        static::$POST_FACTORY::save($post);
+
+        static::$POST_FACTORY::assert()->exists(['title' => 'new title']);
+    }
+
+    /**
+     * @test
+     */
+    public function can_force_set_multiple_fields(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        force_set($post, 'title', 'new title');
+        force_set($post, 'body', 'new body');
+        static::$POST_FACTORY::save($post);
+
+        $this->assertSame('new title', $post->getTitle());
+        $this->assertSame('new body', $post->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function exception_thrown_if_trying_to_autorefresh_object_with_unsaved_changes(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        $post->setTitle('new title');
+
+        $this->expectException(\RuntimeException::class);
+
+        $post->setBody('new body');
+    }
+
+    /**
+     * @test
+     */
+    public function can_autorefresh_between_kernel_boots(): void
+    {
+        $this->markTestSkipped('not supported');
+
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        // reboot kernel
+        static::ensureKernelShutdown();
+        static::bootKernel();
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function can_autorefresh_entity_with_embedded_object(): void
+    {
+        $contactFactory = AnonymousFactory::new(Contact::class)->withProxyGenerator();
+        $contact = $contactFactory->create(['name' => 'john']);
+
+        $this->assertSame('john', $contact->getName());
+
+        // I discovered when autorefreshing the second time, the embedded
+        // object is included in the changeset when using UOW::recomputeSingleEntityChangeSet().
+        // Changing to UOW::computeChangeSet() fixes this.
+        $this->assertSame('john', $contact->getName());
+        $this->assertNull($contact->getAddress()->getValue());
+
+        $contact->getAddress()->setValue('address');
+        $contactFactory->save($contact);
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+
+        static::ensureKernelShutdown();
+        static::bootKernel();
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function force_set_all_solves_the_auto_refresh_problem(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        force_set_all($post, [
+            'title' => 'new title',
+            'body' => 'new body',
+        ]);
+        static::$POST_FACTORY::save($post);
+
+        $this->assertSame('new title', $post->getTitle());
+        $this->assertSame('new body', $post->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function without_auto_refresh_solves_the_auto_refresh_problem(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        without_autorefresh($post, static function(Post $post) {
+            $post->setTitle('new title');
+            $post->setBody('new body');
+        });
+        static::$POST_FACTORY::save($post);
+
+        $this->assertSame('new title', $post->getTitle());
+        $this->assertSame('new body', $post->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function without_auto_refresh_does_not_enable_auto_refresh_if_it_was_disabled_originally(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        disable_autorefresh($post);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        without_autorefresh($post, static function(Post $post) {
+            $post->setTitle('new title');
+            $post->setBody('new body');
+        });
+
+        $post->setTitle('another new title');
+        $post->setBody('another new body');
+
+        static::$POST_FACTORY::save($post);
+
+        $this->assertSame('another new title', $post->getTitle());
+        $this->assertSame('another new body', $post->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function without_auto_refresh_keeps_disabled_if_originally_disabled(): void
+    {
+        $post = static::$POST_FACTORY::createOne(['title' => 'old title', 'body' => 'old body']);
+
+        disable_autorefresh($post);
+
+        $this->assertSame('old title', $post->getTitle());
+        $this->assertSame('old body', $post->getBody());
+
+        without_autorefresh($post, static function(Post $post) {
+            $post->setTitle('new title');
+            $post->setBody('new body');
+        });
+
+        static::$POST_FACTORY::save($post);
+
+        $post->setTitle('another new title');
+        $post->setBody('another new body');
+
+        static::$POST_FACTORY::save($post);
+
+        $this->assertSame('another new title', $post->getTitle());
+        $this->assertSame('another new body', $post->getBody());
+    }
+}

--- a/tests/Unit/Proxy/ProxyGeneratorTest.php
+++ b/tests/Unit/Proxy/ProxyGeneratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Unit\Proxy;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Proxy\ProxyGenerator;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
+
+class ProxyGeneratorTest extends TestCase
+{
+    /** @var EntityManagerInterface|MockObject */
+    private $objectManager;
+    /** @var ManagerRegistry|MockObject */
+    private $managerRegistry;
+    /** @var Configuration|MockObject */
+    private $config;
+    /** @var ProxyGenerator */
+    private $generator;
+
+    protected function setUp(): void
+    {
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork->expects($this->any())->method('getEntityChangeSet')->willReturn([]);
+
+        $this->objectManager = $this->createMock(EntityManagerInterface::class);
+        $this->objectManager->expects($this->any())->method('contains')->willReturn(true);
+        $this->objectManager->expects($this->any())->method('getClassMetadata')->willReturn($this->createMock(ClassMetadata::class));
+        $this->objectManager->expects($this->any())->method('getUnitOfWork')->willReturn($unitOfWork);
+
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+
+        $this->config = new Configuration();
+        $this->config->setManagerRegistry($this->managerRegistry);
+        $this->generator = new ProxyGenerator($this->config);
+    }
+
+    /** @test */
+    public function can_auto_refresh_all_methods(): void
+    {
+        $tag = new Tag();
+        $this->managerRegistry->expects($this->any())->method('getManagerForClass')->with(Tag::class)->willReturn($this->objectManager);
+        $proxyTag = $this->generator->generate($tag);
+
+        $this->objectManager->expects($this->exactly(2))->method('refresh')->with($tag);
+        $proxyTag->setName('proxy');
+        $this->assertEquals('proxy', $proxyTag->getName());
+    }
+
+    /** @test */
+    public function can_only_auto_refresh_getters(): void
+    {
+        $tag = new Tag();
+        $this->managerRegistry->expects($this->any())->method('getManagerForClass')->with(Tag::class)->willReturn($this->objectManager);
+        $proxyTag = $this->generator->generate($tag, ['get*']);
+
+        $this->objectManager->expects($this->once())->method('refresh')->with($tag);
+        $proxyTag->setName('proxy');
+        $this->assertEquals('proxy', $proxyTag->getName());
+    }
+}


### PR DESCRIPTION
I started trying out some of the ideas in #110 and #113.

The idea of this change is that instead of a "fake" `Proxy` object, we return a proxied entity/model. This allows removing `->object()` calls and removing some confusion when trying to pass the objects into typehinted functions. For this to work, the solution has to fulfill these promises:

* [x] The proxied entity/model has to support auto-refresh at least as good as the current `Proxy`
* [x] The AR helpers (`save()`, `remove()`, ...) have to be moved to `Factory`/`ModelFactory`
* [x] In 1.x, this new behavior should be opt-in per factory. This allows a smooth migration path, before removing the old factories in 2.0
* [ ] Reintroduce support for global auto refresh setting
* [ ] Document UPGRADE guide + deprecate the old Proxy