### PR TITLE
Fix exception message

### DIFF
--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -21,7 +21,7 @@ abstract class ModelFactory extends Factory
     public static function __callStatic(string $name, array $arguments)
     {
         if ('createMany' !== $name) {
-            throw new \BadMethodCallException(\sprintf('Call to undefined static method "%s::%s".', static::class, __METHOD__));
+            throw new \BadMethodCallException(\sprintf('Call to undefined static method "%s::%s".', static::class, $name));
         }
 
         return static::new()->many($arguments[0])->create($arguments[1] ?? []);


### PR DESCRIPTION
The exception message was: `Uncaught BadMethodCallException: Call to undefined static method "FooFactory::FooFactory::__callStatic".`

Now it is: `Uncaught BadMethodCallException: Call to undefined static method "FooFactory::bar".`