### PR TITLE
Throw exception during auto-refresh if unsaved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,7 +1133,8 @@ $post->getTitle(); // "New Title" (equivalent to $post->refresh()->getTitle())
 Without auto-refreshing enabled, the above call to `$post->getTitle()` would return "Original Title".
 
 **NOTE**: A situation you need to be aware of when using auto-refresh is that all methods refresh the object first. If
-changing the object's state via multiple methods (or multiple force-sets), the previous changes will be lost:
+changing the object's state via multiple methods (or multiple force-sets), an "unsaved changes" exception will be
+thrown:
 
 ```php
 use App\Factory\PostFactory;
@@ -1144,11 +1145,7 @@ $post = PostFactory::new(['title' => 'Original Title', 'body' => 'Original Body'
 ;
 
 $post->setTitle('New Title');
-$post->setBody('New Body'); // this causes the object to be refreshed, which means the "New Title" title was replaced by the database contents
-$post->save();
-
-$post->getBody(); // "New Body"
-$post->getTitle(); // "Original Title" !! because the subsequent call to ->setBody() "auto-refreshed" the object
+$post->setBody('New Body'); // exception thrown because of "unsaved changes" to $post from above
 ```
 
 To overcome this, you need to first disable auto-refreshing, then re-enable after making/saving the changes:

--- a/README.md
+++ b/README.md
@@ -1184,14 +1184,13 @@ $post->forceSetAll([
 $post->save();
 ```
 
-**NOTE**: You can optionally enable auto-refreshing globally to have every proxy auto-refreshable by default. With this
-enabled, you will have to *opt-out* of auto-refreshing as opposed to the default, which is *opt-in*. Be aware of the
-above situation before enabling.
+**NOTE**: You can enable/disable auto-refreshing globally to have every proxy auto-refreshable by default or not. When
+enabled, you will have to *opt-out* of auto-refreshing.
 
 ```yaml
 # config/packages/dev/zenstruck_foundry.yaml (see Bundle Configuration section about sharing this in the test environment)
 zenstruck_foundry:
-    auto_refresh_proxies: true
+    auto_refresh_proxies: true/false
 ```
 
 ### Repository Proxy
@@ -1441,7 +1440,10 @@ Zenstruck\Foundry\Test\TestState::setInstantiator(
 Zenstruck\Foundry\Test\TestState::setFaker(Faker\Factory::create('fr_FR'));
 
 // enable auto-refreshing "globally"
-Zenstruck\Foundry\Test\TestState::alwaysAutoRefreshProxies();
+Zenstruck\Foundry\Test\TestState::enableDefaultProxyAutoRefresh();
+
+// disable auto-refreshing "globally"
+Zenstruck\Foundry\Test\TestState::disableDefaultProxyAutoRefresh();
 ```
 
 **NOTE**: If using [bundle configuration](#bundle-configuration) as well, *test-only configuration* will override the
@@ -1611,7 +1613,7 @@ imports:
 zenstruck_foundry:
 
     # Whether to auto-refresh proxies by default (https://github.com/zenstruck/foundry#auto-refresh)
-    auto_refresh_proxies: false
+    auto_refresh_proxies: true
 
     # Configure faker to be used by your factories.
     faker:

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,6 +29,8 @@
                 <!-- Reference: https://github.com/dmaicher/doctrine-test-bundle/issues/139 -->
                 <referencedMethod name="DAMA\DoctrineTestBundle\Doctrine\DBAL\AbstractStaticDriver::isKeepStaticConnections" />
                 <referencedMethod name="DAMA\DoctrineTestBundle\Doctrine\DBAL\AbstractStaticDriver::setKeepStaticConnections" />
+
+                <referencedMethod name="Doctrine\ORM\UnitOfWork::computeChangeSet" />
             </errorLevel>
         </InternalMethod>
     </issueHandlers>

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('auto_refresh_proxies')
                     ->info('Whether to auto-refresh proxies by default (https://github.com/zenstruck/foundry#auto-refresh)')
-                    ->defaultFalse()
+                    ->defaultNull()
                 ->end()
                 ->arrayNode('faker')
                     ->addDefaultsIfNotSet()

--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -32,10 +32,10 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
         $this->configureFaker($mergedConfig['faker'], $container);
         $this->configureDefaultInstantiator($mergedConfig['instantiator'], $container);
 
-        if ($mergedConfig['auto_refresh_proxies']) {
-            $container->getDefinition(Configuration::class)
-                ->addMethodCall('alwaysAutoRefreshProxies')
-            ;
+        if (true === $mergedConfig['auto_refresh_proxies']) {
+            $container->getDefinition(Configuration::class)->addMethodCall('enableDefaultProxyAutoRefresh');
+        } elseif (false === $mergedConfig['auto_refresh_proxies']) {
+            $container->getDefinition(Configuration::class)->addMethodCall('disableDefaultProxyAutoRefresh');
         }
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -29,8 +29,8 @@ final class Configuration
     /** @var callable */
     private $instantiator;
 
-    /** @var bool */
-    private $defaultProxyAutoRefresh = false;
+    /** @var bool|null */
+    private $defaultProxyAutoRefresh;
 
     public function __construct()
     {
@@ -62,6 +62,12 @@ final class Configuration
 
     public function defaultProxyAutoRefresh(): bool
     {
+        if (null === $this->defaultProxyAutoRefresh) {
+            trigger_deprecation('zenstruck\foundry', '1.9', 'Not explicitly configuring the default proxy auto-refresh is deprecated and will default to "true" in 2.0. Use "zenstruck_foundry.auto_refresh_proxies" in the bundle config or TestState::enableDefaultProxyAutoRefresh()/disableDefaultProxyAutoRefresh().');
+
+            $this->defaultProxyAutoRefresh = false;
+        }
+
         return $this->defaultProxyAutoRefresh;
     }
 
@@ -100,9 +106,16 @@ final class Configuration
         return $this;
     }
 
-    public function alwaysAutoRefreshProxies(): self
+    public function enableDefaultProxyAutoRefresh(): self
     {
         $this->defaultProxyAutoRefresh = true;
+
+        return $this;
+    }
+
+    public function disableDefaultProxyAutoRefresh(): self
+    {
+        $this->defaultProxyAutoRefresh = false;
 
         return $this;
     }

--- a/src/Test/TestState.php
+++ b/src/Test/TestState.php
@@ -20,8 +20,8 @@ final class TestState
     /** @var Faker\Generator|null */
     private static $faker;
 
-    /** @var bool */
-    private static $alwaysAutoRefreshProxies = false;
+    /** @var bool|null */
+    private static $defaultProxyAutoRefresh;
 
     /** @var callable[] */
     private static $globalStates = [];
@@ -36,9 +36,24 @@ final class TestState
         self::$faker = $faker;
     }
 
+    public static function enableDefaultProxyAutoRefresh(): void
+    {
+        self::$defaultProxyAutoRefresh = true;
+    }
+
+    public static function disableDefaultProxyAutoRefresh(): void
+    {
+        self::$defaultProxyAutoRefresh = false;
+    }
+
+    /**
+     * @deprecated Use TestState::enableDefaultProxyAutoRefresh()
+     */
     public static function alwaysAutoRefreshProxies(): void
     {
-        self::$alwaysAutoRefreshProxies = true;
+        trigger_deprecation('zenstruck\foundry', '1.9', 'TestState::alwaysAutoRefreshProxies() is deprecated, use TestState::enableDefaultProxyAutoRefresh().');
+
+        self::enableDefaultProxyAutoRefresh();
     }
 
     /**
@@ -66,8 +81,10 @@ final class TestState
             $configuration->setFaker(self::$faker);
         }
 
-        if (self::$alwaysAutoRefreshProxies) {
-            $configuration->alwaysAutoRefreshProxies();
+        if (true === self::$defaultProxyAutoRefresh) {
+            $configuration->enableDefaultProxyAutoRefresh();
+        } elseif (false === self::$defaultProxyAutoRefresh) {
+            $configuration->disableDefaultProxyAutoRefresh();
         }
 
         Factory::boot($configuration);

--- a/tests/Fixtures/Entity/Address.php
+++ b/tests/Fixtures/Entity/Address.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable
+ */
+final class Address
+{
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $value;
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/Fixtures/Entity/Contact.php
+++ b/tests/Fixtures/Entity/Contact.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="contacts")
+ */
+class Contact
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+
+    /**
+     * @ORM\Embedded("Address")
+     */
+    private $address;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->address = new Address();
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+}

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -88,6 +88,12 @@ class Kernel extends BaseKernel
                 ],
             ],
         ]);
+
+        if (\getenv('USE_FOUNDRY_BUNDLE')) {
+            $c->loadFromExtension('zenstruck_foundry', [
+                'auto_refresh_proxies' => false,
+            ]);
+        }
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void

--- a/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
+++ b/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
@@ -144,7 +144,19 @@ final class ZenstruckFoundryExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService(Configuration::class);
         $this->assertCount(6, $this->container->findDefinition(Configuration::class)->getMethodCalls());
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'alwaysAutoRefreshProxies', []);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'enableDefaultProxyAutoRefresh', []);
+    }
+
+    /**
+     * @test
+     */
+    public function can_disable_auto_refresh_proxies(): void
+    {
+        $this->load(['auto_refresh_proxies' => false]);
+
+        $this->assertContainerBuilderHasService(Configuration::class);
+        $this->assertCount(6, $this->container->findDefinition(Configuration::class)->getMethodCalls());
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'disableDefaultProxyAutoRefresh', []);
     }
 
     protected function getContainerExtensions(): array

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,7 @@ require \dirname(__DIR__).'/vendor/autoload.php';
 
 (new Filesystem())->remove(\sys_get_temp_dir().'/zenstruck-foundry');
 
+TestState::disableDefaultProxyAutoRefresh();
 TestState::addGlobalState(static function() {
     TagStory::load();
 });


### PR DESCRIPTION
When auto-refreshing a proxy, if there are unsaved changes detected, a helpful exception is thrown. Also, trigger deprecation if not specifically globally configured.

Closes #113.