### PR TITLE
Add AnonymousFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,16 +793,14 @@ services.
 Foundry can be used to create factories for entities that you don't have model factories for:
 
 ```php
-use App\Entity\OtherEntity;
-use Zenstruck\Foundry\Factory;
+use App\Entity\Post;
+use Zenstruck\Foundry\AnonymousFactory;
 use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\create;
 use function Zenstruck\Foundry\create_many;
-use function Zenstruck\Foundry\instantiate;
-use function Zenstruck\Foundry\instantiate_many;
 
-$factory = new Factory(OtherEntity::class);
-$factory = factory(OtherEntity::class); // alternative to above
+$factory = AnonymousFactory::new(Post::class);
+$factory = factory(Post::class); // alternative to above
 
 // has the same API as ModelFactory's
 $factory->create(['field' => 'value']);
@@ -812,9 +810,45 @@ $factory->beforeInstantiate(function () {});
 $factory->afterInstantiate(function () {});
 $factory->afterPersist(function () {});
 
+// find a persisted object for the given attributes, if not found, create with the attributes
+$factory->findOrCreate(['title' => 'My Title']);
+
+$factory->first(); // get the first object (assumes an auto-incremented "id" column)
+$factory->first('createdAt'); // assuming "createdAt" is a datetime column, this will return latest object
+$factory->last(); // get the last object (assumes an auto-incremented "id" column)
+$factory->last('createdAt'); // assuming "createdAt" is a datetime column, this will return oldest object
+
+$factory->truncate(); // empty the database table
+$factory->count(); // the number of persisted Post's
+$factory->all(); // Post[]|Proxy[] all the persisted Post's
+
+$factory->findBy(['author' => 'kevin']); // Post[]|Proxy[] matching the filter
+
+$factory->find(5); // Post|Proxy with the id of 5
+$factory->find(['title' => 'My First Post']); // Post|Proxy matching the filter
+
+// get a random object that has been persisted
+$factory->random(); // returns Post|Proxy
+$factory->random(['author' => 'kevin']); // filter by the passed attributes
+
+// or automatically persist a new random object if none exists
+$factory->randomOrCreate();
+$factory->randomOrCreate(['author' => 'kevin']); // filter by or create with the passed attributes
+
+// get a random set of objects that have been persisted
+$factory->randomSet(4); // array containing 4 "Post|Proxy" objects
+$factory->randomSet(4, ['author' => 'kevin']); // filter by the passed attributes
+
+// random range of persisted objects
+$factory->randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
+$factory->randomRange(0, 5, ['author' => 'kevin']); // filter by the passed attributes
+
+// repository proxy wrapping PostRepository (see Repository Proxy section below)
+$factory->repository();
+
 // convenience functions
-$entity = create(OtherEntity::class, ['field' => 'value']);
-$entities = create_many(OtherEntity::class, 5, ['field' => 'value']);
+$entity = create(Post::class, ['field' => 'value']);
+$entities = create_many(Post::class, 5, ['field' => 'value']);
 ```
 
 ### Without Persisting
@@ -825,8 +859,8 @@ in a `Proxy` to optionally save later.
 
 ```php
 use App\Factory\PostFactory;
-use App\Entity\OtherEntity;
-use Zenstruck\Foundry\Factory;
+use App\Entity\Post;
+use Zenstruck\Foundry\AnonymousFactory;
 use function Zenstruck\Foundry\instantiate;
 use function Zenstruck\Foundry\instantiate_many;
 
@@ -839,17 +873,17 @@ $post = PostFactory::new()->withoutPersisting()->create()->object(); // actual P
 $posts = PostFactory::new()->withoutPersisting()->many(5)->create(); // returns Post[]|Proxy[]
 
 // anonymous factories:
-$factory = new Factory(OtherEntity::class);
+$factory = new AnonymousFactory(Post::class);
 
-$entity = $factory->withoutPersisting()->create(['field' => 'value']); // returns OtherEntity|Proxy
+$entity = $factory->withoutPersisting()->create(['field' => 'value']); // returns Post|Proxy
 
-$entity = $factory->withoutPersisting()->create(['field' => 'value'])->object(); // actual OtherEntity object
+$entity = $factory->withoutPersisting()->create(['field' => 'value'])->object(); // actual Post object
 
-$entities = $factory->withoutPersisting()->many(5)->create(['field' => 'value']); // returns OtherEntity[]|Proxy[]
+$entities = $factory->withoutPersisting()->many(5)->create(['field' => 'value']); // returns Post[]|Proxy[]
 
 // convenience functions
-$entity = instantiate(OtherEntity::class, ['field' => 'value']);
-$entities = instantiate_many(OtherEntity::class, 5, ['field' => 'value']);
+$entity = instantiate(Post::class, ['field' => 'value']);
+$entities = instantiate_many(Post::class, 5, ['field' => 'value']);
 ```
 
 If you'd like your model factory to not persist by default, override its `initialize()` method to add this behaviour:

--- a/src/AnonymousFactory.php
+++ b/src/AnonymousFactory.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+/**
+ * @template TModel of object
+ * @template-extends Factory<TModel>
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AnonymousFactory extends Factory implements \Countable, \IteratorAggregate
+{
+    /**
+     * @see Factory::__construct()
+     */
+    public static function new(string $class, $defaultAttributes = []): self
+    {
+        return new self($class, $defaultAttributes);
+    }
+
+    /**
+     * Try and find existing object for the given $attributes. If not found,
+     * instantiate and persist.
+     *
+     * @return Proxy|object
+     *
+     * @psalm-return Proxy<TModel>
+     */
+    public function findOrCreate(array $attributes): Proxy
+    {
+        if ($found = $this->repository()->find($attributes)) {
+            return \is_array($found) ? $found[0] : $found;
+        }
+
+        return $this->create($attributes);
+    }
+
+    /**
+     * @see RepositoryProxy::first()
+     *
+     * @throws \RuntimeException If no entities exist
+     */
+    public function first(string $sortedField = 'id'): Proxy
+    {
+        if (null === $proxy = $this->repository()->first($sortedField)) {
+            throw new \RuntimeException(\sprintf('No "%s" objects persisted.', $this->class()));
+        }
+
+        return $proxy;
+    }
+
+    /**
+     * @see RepositoryProxy::last()
+     *
+     * @throws \RuntimeException If no entities exist
+     */
+    public function last(string $sortedField = 'id'): Proxy
+    {
+        if (null === $proxy = $this->repository()->last($sortedField)) {
+            throw new \RuntimeException(\sprintf('No "%s" objects persisted.', $this->class()));
+        }
+
+        return $proxy;
+    }
+
+    /**
+     * @see RepositoryProxy::random()
+     */
+    public function random(array $attributes = []): Proxy
+    {
+        return $this->repository()->random($attributes);
+    }
+
+    /**
+     * Fetch one random object and create a new object if none exists.
+     *
+     * @return Proxy|object
+     *
+     * @psalm-return Proxy<TModel>
+     */
+    public function randomOrCreate(array $attributes = []): Proxy
+    {
+        try {
+            return $this->repository()->random($attributes);
+        } catch (\RuntimeException $e) {
+            return $this->create($attributes);
+        }
+    }
+
+    /**
+     * @see RepositoryProxy::randomSet()
+     */
+    public function randomSet(int $number, array $attributes = []): array
+    {
+        return $this->repository()->randomSet($number, $attributes);
+    }
+
+    /**
+     * @see RepositoryProxy::randomRange()
+     */
+    public function randomRange(int $min, int $max, array $attributes = []): array
+    {
+        return $this->repository()->randomRange($min, $max, $attributes);
+    }
+
+    /**
+     * @see RepositoryProxy::count()
+     */
+    public function count(): int
+    {
+        return $this->repository()->count();
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->all());
+    }
+
+    /**
+     * @see RepositoryProxy::truncate()
+     */
+    public function truncate(): void
+    {
+        $this->repository()->truncate();
+    }
+
+    /**
+     * @see RepositoryProxy::findAll()
+     */
+    public function all(): array
+    {
+        return $this->repository()->findAll();
+    }
+
+    /**
+     * @see RepositoryProxy::find()
+     *
+     * @throws \RuntimeException If no entity found
+     */
+    public function find($criteria): Proxy
+    {
+        if (null === $proxy = $this->repository()->find($criteria)) {
+            throw new \RuntimeException(\sprintf('Could not find "%s" object.', $this->class()));
+        }
+
+        return $proxy;
+    }
+
+    /**
+     * @see RepositoryProxy::findBy()
+     */
+    public function findBy(array $attributes): array
+    {
+        return $this->repository()->findBy($attributes);
+    }
+
+    public function assert(): RepositoryAssertions
+    {
+        return $this->repository()->assert();
+    }
+
+    /**
+     * @psalm-return RepositoryProxy<TModel>
+     */
+    public function repository(): RepositoryProxy
+    {
+        return self::configuration()->repositoryFor($this->class());
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ use Faker;
 
 /**
  * @template TObject as object
+ * @abstract
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -45,6 +46,10 @@ class Factory
      */
     public function __construct(string $class, $defaultAttributes = [])
     {
+        if (self::class === static::class) {
+            trigger_deprecation('zenstruck/foundry', '1.9', 'Instantiating "%s" directly is deprecated and this class will be abstract in 2.0, use "%s" instead.', self::class, AnonymousFactory::class);
+        }
+
         $this->class = $class;
         $this->attributeSet[] = $defaultAttributes;
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -246,6 +246,16 @@ class Factory
     }
 
     /**
+     * @internal
+     *
+     * @psalm-return class-string<TObject>
+     */
+    final protected function class(): string
+    {
+        return $this->class;
+    }
+
+    /**
      * @param array|callable $attributes
      */
     private static function normalizeAttributes($attributes): array

--- a/src/functions.php
+++ b/src/functions.php
@@ -9,11 +9,11 @@ use Faker;
  *
  * @template TObject as object
  * @psalm-param class-string<TObject> $class
- * @psalm-return Factory<TObject>
+ * @psalm-return AnonymousFactory<TObject>
  */
-function factory(string $class, $defaultAttributes = []): Factory
+function factory(string $class, $defaultAttributes = []): AnonymousFactory
 {
-    return new Factory($class, $defaultAttributes);
+    return new AnonymousFactory($class, $defaultAttributes);
 }
 
 /**

--- a/tests/Functional/AnonymousFactoryTest.php
+++ b/tests/Functional/AnonymousFactoryTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\AnonymousFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AnonymousFactoryTest extends KernelTestCase
+{
+    use Factories, ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function can_find_or_create(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+
+        $factory->assert()->count(0);
+        $factory->findOrCreate(['name' => 'php']);
+        $factory->assert()->count(1);
+        $factory->findOrCreate(['name' => 'php']);
+        $factory->assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_random_object(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory->many(5)->create();
+
+        $ids = [];
+
+        while (5 !== \count(\array_unique($ids))) {
+            $ids[] = $factory->random()->getId();
+        }
+
+        $this->assertCount(5, \array_unique($ids));
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_random_object_if_none_exists(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+
+        $factory->assert()->count(0);
+        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $factory->assert()->count(1);
+        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $factory->assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_or_create_random_object_with_attributes(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'name1']);
+        $factory->many(5)->create();
+
+        $factory->assert()->count(5);
+        $this->assertSame('name2', $factory->randomOrCreate(['name' => 'name2'])->getName());
+        $factory->assert()->count(6);
+        $this->assertSame('name2', $factory->randomOrCreate(['name' => 'name2'])->getName());
+        $factory->assert()->count(6);
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_random_set_of_objects(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory->many(5)->create();
+
+        $objects = $factory->randomSet(3);
+
+        $this->assertCount(3, $objects);
+        $this->assertCount(3, \array_unique(\array_map(static function($category) { return $category->getId(); }, $objects)));
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_random_set_of_objects_with_attributes(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+        $factory->many(20)->create(['name' => 'name1']);
+        $factory->many(5)->create(['name' => 'name2']);
+
+        $objects = $factory->randomSet(2, ['name' => 'name2']);
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('name2', $objects[0]->getName());
+        $this->assertSame('name2', $objects[1]->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_random_range_of_objects(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory->many(5)->create();
+
+        $counts = [];
+
+        while (4 !== \count(\array_unique($counts))) {
+            $counts[] = \count($factory->randomRange(0, 3));
+        }
+
+        $this->assertCount(4, \array_unique($counts));
+        $this->assertContains(0, $counts);
+        $this->assertContains(1, $counts);
+        $this->assertContains(2, $counts);
+        $this->assertContains(3, $counts);
+        $this->assertNotContains(4, $counts);
+        $this->assertNotContains(5, $counts);
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_random_range_of_objects_with_attributes(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+        $factory->many(20)->create(['name' => 'name1']);
+        $factory->many(5)->create(['name' => 'name2']);
+
+        $objects = $factory->randomRange(2, 4, ['name' => 'name2']);
+
+        $this->assertGreaterThanOrEqual(2, \count($objects));
+        $this->assertLessThanOrEqual(4, \count($objects));
+
+        foreach ($objects as $object) {
+            $this->assertSame('name2', $object->getName());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function first_and_last_return_the_correct_object(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+        $categoryA = $factory->create(['name' => '3']);
+        $categoryB = $factory->create(['name' => '2']);
+        $categoryC = $factory->create(['name' => '1']);
+
+        $this->assertSame($categoryA->getId(), $factory->first()->getId());
+        $this->assertSame($categoryC->getId(), $factory->first('name')->getId());
+        $this->assertSame($categoryC->getId(), $factory->last()->getId());
+        $this->assertSame($categoryA->getId(), $factory->last('name')->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function first_throws_exception_if_no_entities_exist(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        AnonymousFactory::new(Category::class)->first();
+    }
+
+    /**
+     * @test
+     */
+    public function last_throws_exception_if_no_entities_exist(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        AnonymousFactory::new(Category::class)->last();
+    }
+
+    /**
+     * @test
+     */
+    public function can_count_and_truncate_model_factory(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+
+        $this->assertSame(0, $factory->count());
+        $this->assertCount(0, $factory);
+
+        $factory->many(4)->create();
+
+        $this->assertSame(4, $factory->count());
+        $this->assertCount(4, $factory);
+
+        $factory->truncate();
+
+        $this->assertSame(0, $factory->count());
+        $this->assertCount(0, $factory);
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_all_entities(): void
+    {
+        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+
+        $this->assertSame([], $factory->all());
+
+        $factory->many(4)->create();
+
+        $categories = $factory->all();
+
+        $this->assertCount(4, $categories);
+        $this->assertCount(4, \iterator_to_array($factory));
+        $this->assertInstanceOf(Category::class, $categories[0]->object());
+        $this->assertInstanceOf(Category::class, $categories[1]->object());
+        $this->assertInstanceOf(Category::class, $categories[2]->object());
+        $this->assertInstanceOf(Category::class, $categories[3]->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_entity(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+
+        $factory->create(['name' => 'first']);
+        $factory->create(['name' => 'second']);
+        $category = $factory->create(['name' => 'third']);
+
+        $this->assertSame('second', $factory->find(['name' => 'second'])->getName());
+        $this->assertSame('third', $factory->find(['id' => $category->getId()])->getName());
+        $this->assertSame('third', $factory->find($category->getId())->getName());
+        $this->assertSame('third', $factory->find($category->object())->getName());
+        $this->assertSame('third', $factory->find($category)->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function find_throws_exception_if_no_entities_exist(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        AnonymousFactory::new(Category::class)->find(99);
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_by(): void
+    {
+        $factory = AnonymousFactory::new(Category::class);
+
+        $this->assertSame([], $factory->findBy(['name' => 'name2']));
+
+        $factory->create(['name' => 'name1']);
+        $factory->create(['name' => 'name2']);
+        $factory->create(['name' => 'name2']);
+
+        $categories = $factory->findBy(['name' => 'name2']);
+
+        $this->assertCount(2, $categories);
+        $this->assertSame('name2', $categories[0]->getName());
+        $this->assertSame('name2', $categories[1]->getName());
+    }
+}

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -3,7 +3,7 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
@@ -114,10 +114,10 @@ final class FactoryTest extends KernelTestCase
      */
     public function creating_with_factory_attribute_persists_the_factory(): void
     {
-        $object = (new Factory(Post::class))->create([
+        $object = (new AnonymousFactory(Post::class))->create([
             'title' => 'title',
             'body' => 'body',
-            'category' => new Factory(Category::class, ['name' => 'name']),
+            'category' => new AnonymousFactory(Category::class, ['name' => 'name']),
         ]);
 
         $this->assertNotNull($object->getCategory()->getId());


### PR DESCRIPTION
- adds an `AnonymousFactory` with all the features of #123 but as "instance methods"
- deprecate instantiating `Factory` directly (to be made abstract in 2.0)

Closes #126 