### PR TITLE
Add option to use doctrine migrations to reset database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
           - php: 7.2
             stability: '@stable'
             versions: lowest
-          - php: 8.0
-            stability: '@dev'
-            versions: highest
+#          - php: 8.0
+#            stability: '@dev'
+#            versions: highest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,18 @@ jobs:
           USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
+      - name: 'Test: MySQL, DoctrineMigrationsBundle'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          FOUNDRY_RESET_MODE: migrate
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+
+      - name: 'Test: MySQL, DoctrineMigrationsBundle, DAMABundle'
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        env:
+          FOUNDRY_RESET_MODE: migrate
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+
       - name: 'Test: PostgreSQL'
         run: vendor/bin/simple-phpunit -v
         env:
@@ -187,6 +199,18 @@ jobs:
         run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-foundry-dama.clover --configuration phpunit-dama-doctrine.xml.dist
         env:
           USE_FOUNDRY_BUNDLE: 1
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+
+      - name: 'Test: MySQL, DoctrineMigrationsBundle'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-migrations.clover
+        env:
+          FOUNDRY_RESET_MODE: migrate
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+
+      - name: 'Test: MySQL, DoctrineMigrationsBundle, DAMABundle'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-migrations-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        env:
+          FOUNDRY_RESET_MODE: migrate
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Coverage: PostgreSQL'

--- a/README.md
+++ b/README.md
@@ -43,24 +43,25 @@ Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/fou
 4. [Using with DoctrineFixturesBundle](#using-with-doctrinefixturesbundle)
 5. [Using in your Tests](#using-in-your-tests)
     1. [Enable Foundry in your TestCase](#enable-foundry-in-your-testcase)
-    2. [Object Proxy](#object-proxy)
+    2. [Database Reset](#database-reset)
+    3. [Object Proxy](#object-proxy)
         1. [Force Setting](#force-setting)
         2. [Auto-Refresh](#auto-refresh)
-    3. [Repository Proxy](#repository-proxy)
-    4. [Assertions](#assertions)
-    5. [Global State](#global-state)
-    6. [PHPUnit Data Providers](#phpunit-data-providers)
-    7. [Performance](#performance)
+    4. [Repository Proxy](#repository-proxy)
+    5. [Assertions](#assertions)
+    6. [Global State](#global-state)
+    7. [PHPUnit Data Providers](#phpunit-data-providers)
+    8. [Performance](#performance)
         1. [DAMADoctrineTestBundle](#damadoctrinetestbundle)
         2. [Miscellaneous](#miscellaneous)
-    8. [Non-Kernel Test](#non-kernel-tests)
-    9. [Test-Only Configuration](#test-only-configuration)
-    10. [Using without the Bundle](#using-without-the-bundle)
-7. [Stories](#stories)
+    9. [Non-Kernel Test](#non-kernel-tests)
+    10. [Test-Only Configuration](#test-only-configuration)
+    11. [Using without the Bundle](#using-without-the-bundle)
+6. [Stories](#stories)
     1. [Stories as Services](#stories-as-services)
     2. [Story State](#story-state)
-8. [Bundle Configuration](#bundle-configuration)
-9. [Credit](#credit)
+7. [Bundle Configuration](#bundle-configuration)
+8. [Credit](#credit)
 
 ## Installation
 
@@ -1024,8 +1025,10 @@ class MyTest extends WebTestCase
 }
 ```
 
-This library requires that your database be reset before each test. The packaged `ResetDatabase` trait handles this for
-you. Before the first test, it drops (if exists) and creates the test database. Before each test, it resets the schema.
+### Database Reset
+
+This library requires that your database be reset before each test. The packaged `ResetDatabase` trait handles
+this for you.
 
 ```php
 use Zenstruck\Foundry\Test\Factories;
@@ -1039,6 +1042,15 @@ class MyTest extends WebTestCase
     // ...
 }
 ```
+
+Before the first test using the `ResetDatabase` trait, it drops (if exists) and creates the test database.
+Then, by default, before each test, it resets the schema using `doctrine:schema:drop`/`doctrine:schema:create`.
+
+Alternatively, you can have it run your migrations instead by setting the env variable `FOUNDRY_RESET_MODE=migrate`
+(in your `.env.test`). When using this *mode*, before each test, the database is dropped/created and your migrations
+run (via `doctrine:migrations:migrate`). This mode can really make your test suite slow (especially if you have a lot
+of migrations). It is highly recommended to use [DamaDoctrineTestBundle](#damadoctrinetestbundle) to improve the
+speed. When this bundle is enabled, the database is dropped/created and migrated only once for the suite.
 
 **TIP**: Create a base TestCase for tests using factories to avoid adding the traits to every TestCase.
 

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.0",
         "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "psalm/plugin-symfony": "^1.5|^2.0",
         "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/maker-bundle": "^1.13",
+        "symfony/maker-bundle": "^1.30",
         "symfony/phpunit-bridge": "^5.2",
         "vimeo/psalm": "^3.18|^4.0"
     },

--- a/run-tests
+++ b/run-tests
@@ -21,3 +21,13 @@ echo "Running with FoundryBundle and with DamaDoctrineTestBundle"
 echo "=========================================================="
 echo ""
 USE_FOUNDRY_BUNDLE=1 vendor/bin/simple-phpunit -c phpunit-dama-doctrine.xml
+
+echo "Running with DoctineMigrationsBundle and without DamaDoctrineTestBundle"
+echo "======================================================================="
+echo ""
+USE_FOUNDRY_BUNDLE=0 FOUNDRY_RESET_MODE=migrate vendor/bin/simple-phpunit
+
+echo "Running with DoctineMigrationsBundle and with DamaDoctrineTestBundle"
+echo "===================================================================="
+echo ""
+USE_FOUNDRY_BUNDLE=0 FOUNDRY_RESET_MODE=migrate vendor/bin/simple-phpunit -c phpunit-dama-doctrine.xml

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -34,11 +34,6 @@ final class DatabaseResetter
         return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
     }
 
-    public static function isResetUsingMigrations(): bool
-    {
-        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? 'schema');
-    }
-
     public static function resetDatabase(KernelInterface $kernel): void
     {
         $application = self::createApplication($kernel);
@@ -57,6 +52,11 @@ final class DatabaseResetter
 
         self::dropSchema($application, $registry);
         self::createSchema($application, $registry);
+    }
+
+    private static function isResetUsingMigrations(): bool
+    {
+        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? 'schema');
     }
 
     private static function dropAndCreateDatabase(Application $application, ManagerRegistry $registry): void

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -36,7 +36,7 @@ final class DatabaseResetter
 
     public static function isResetUsingMigrations(): bool
     {
-        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? null);
+        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? 'schema');
     }
 
     public static function resetDatabase(KernelInterface $kernel): void

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -34,26 +34,17 @@ final class DatabaseResetter
         return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
     }
 
+    public static function isResetUsingMigrations(): bool
+    {
+        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? null);
+    }
+
     public static function resetDatabase(KernelInterface $kernel): void
     {
         $application = self::createApplication($kernel);
         $registry = $kernel->getContainer()->get('doctrine');
 
-        foreach (self::connectionsToReset($registry) as $connection) {
-            $dropParams = ['--connection' => $connection, '--force' => true];
-
-            if ('sqlite' !== $registry->getConnection($connection)->getDatabasePlatform()->getName()) {
-                // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
-                $dropParams['--if-exists'] = true;
-            }
-
-            self::runCommand($application, 'doctrine:database:drop', $dropParams);
-
-            self::runCommand($application, 'doctrine:database:create', [
-                '--connection' => $connection,
-            ]);
-        }
-
+        self::dropAndCreateDatabase($application, $registry);
         self::createSchema($application, $registry);
 
         self::$hasBeenReset = true;
@@ -68,12 +59,34 @@ final class DatabaseResetter
         self::createSchema($application, $registry);
     }
 
+    private static function dropAndCreateDatabase(Application $application, ManagerRegistry $registry): void
+    {
+        foreach (self::connectionsToReset($registry) as $connection) {
+            $dropParams = ['--connection' => $connection, '--force' => true];
+
+            if ('sqlite' !== $registry->getConnection($connection)->getDatabasePlatform()->getName()) {
+                // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
+                $dropParams['--if-exists'] = true;
+            }
+
+            self::runCommand($application, 'doctrine:database:drop', $dropParams);
+
+            self::runCommand($application, 'doctrine:database:create', [
+                '--connection' => $connection,
+            ]);
+        }
+    }
+
     private static function createSchema(Application $application, ManagerRegistry $registry): void
     {
-        foreach (self::objectManagersToReset($registry) as $manager) {
-            self::runCommand($application, 'doctrine:schema:create', [
-                '--em' => $manager,
-            ]);
+        if (self::isResetUsingMigrations()) {
+            self::runCommand($application, 'doctrine:migrations:migrate', ['-n' => true]);
+        } else {
+            foreach (self::objectManagersToReset($registry) as $manager) {
+                self::runCommand($application, 'doctrine:schema:create', [
+                    '--em' => $manager,
+                ]);
+            }
         }
 
         if (!Factory::isBooted()) {
@@ -85,6 +98,12 @@ final class DatabaseResetter
 
     private static function dropSchema(Application $application, ManagerRegistry $registry): void
     {
+        if (self::isResetUsingMigrations()) {
+            self::dropAndCreateDatabase($application, $registry);
+
+            return;
+        }
+
         foreach (self::objectManagersToReset($registry) as $manager) {
             self::runCommand($application, 'doctrine:schema:drop', [
                 '--em' => $manager,

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Foundry\Tests\Fixtures;
 
 use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MakerBundle\MakerBundle;
@@ -35,6 +36,10 @@ class Kernel extends BaseKernel
 
         if (\getenv('USE_DAMA_DOCTRINE_TEST_BUNDLE')) {
             yield new DAMADoctrineTestBundle();
+        }
+
+        if ('migrate' === \getenv('FOUNDRY_RESET_MODE')) {
+            yield new DoctrineMigrationsBundle();
         }
     }
 
@@ -79,6 +84,14 @@ class Kernel extends BaseKernel
         if (\getenv('USE_FOUNDRY_BUNDLE')) {
             $c->loadFromExtension('zenstruck_foundry', [
                 'auto_refresh_proxies' => false,
+            ]);
+        }
+
+        if ('migrate' === \getenv('FOUNDRY_RESET_MODE')) {
+            $c->loadFromExtension('doctrine_migrations', [
+                'migrations_paths' => [
+                    'Zenstruck\Foundry\Tests\Fixtures\Migrations' => '%kernel.project_dir%/tests/Fixtures/Migrations',
+                ],
             ]);
         }
     }

--- a/tests/Fixtures/Migrations/Version20210218175742.php
+++ b/tests/Fixtures/Migrations/Version20210218175742.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210218175742 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'First migration.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE categories (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE comments (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, post_id INT NOT NULL, body LONGTEXT NOT NULL, createdAt DATETIME NOT NULL, approved TINYINT(1) NOT NULL, INDEX IDX_5F9E962AA76ED395 (user_id), INDEX IDX_5F9E962A4B89032C (post_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE contacts (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, address_value VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE posts (id INT AUTO_INCREMENT NOT NULL, category_id INT DEFAULT NULL, title VARCHAR(255) NOT NULL, body LONGTEXT NOT NULL, shortDescription VARCHAR(255) DEFAULT NULL, viewCount INT NOT NULL, createdAt DATETIME NOT NULL, publishedAt DATETIME DEFAULT NULL, INDEX IDX_885DBAFA12469DE2 (category_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE post_tag (post_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_5ACE3AF04B89032C (post_id), INDEX IDX_5ACE3AF0BAD26311 (tag_id), PRIMARY KEY(post_id, tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE tags (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE users (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/tests/Fixtures/Migrations/Version20210318175742.php
+++ b/tests/Fixtures/Migrations/Version20210318175742.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210318175742 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Second migration.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comments ADD CONSTRAINT FK_5F9E962AA76ED395 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE comments ADD CONSTRAINT FK_5F9E962A4B89032C FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE posts ADD CONSTRAINT FK_885DBAFA12469DE2 FOREIGN KEY (category_id) REFERENCES categories (id)');
+        $this->addSql('ALTER TABLE post_tag ADD CONSTRAINT FK_5ACE3AF04B89032C FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE post_tag ADD CONSTRAINT FK_5ACE3AF0BAD26311 FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
This feature gives the ability to have `ResetDatabase` run your migrations during the database reset (instead of `doctrine:schema:drop`/`doctrine:schema:create`). Enable in your `.env.test`: `FOUNDRY_RESET_MODE=migrate`.

When enabled, `ResetDatabase` does the following:
1. Before **first** test using the trait:
    1. drop database (if exists)
    2. create database
    3. run migrations
2. Before **each** test (skips if using DAMADoctrineTestBundle)
    1. drop database (if exists)
    2. create database (I couldn't find an easy way to drop all tables - see #144 for reference)
    3. run migrations

It is highly recommended to use DAMADoctrineTestBundle in conjunction with this feature as if not enabled, the entire database is dropped/created and migrations run before every test.

Todo:
- [x] Support DoctrineMigrationsBundle 2?
- [x] Docs

Fixes #144.