### PR TITLE
fix small typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ common use-case: encoding a password with the `UserPasswordEncoderInterface` ser
 ```php
 // src/Factory/UserFactory.php
 
-namespace App\Story;
+namespace App\Factory;
 
 use App\Entity\User;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;


### PR DESCRIPTION
Hello,

here is a fix for a small typo I found in the docs

cheers, your library is amazing, thanks!