### PR TITLE
[feature] Handle schema reset for mongo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
   code-coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    if: false
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mongo:
+        image: mongo:4
+        ports:
+          - 27017:27017
     strategy:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0]
@@ -35,9 +39,9 @@ jobs:
           - php: 7.2
             stability: '@stable'
             versions: lowest
-          - php: 8.0
-            stability: '@dev'
-            versions: highest
+#          - php: 8.0
+#            stability: '@dev'
+#            versions: highest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.3
@@ -49,7 +53,7 @@ jobs:
         uses: shivammathur/setup-php@2.7.0
         with:
           php-version: ${{ matrix.php }}
-          extensions: pgsql, sqlite
+          extensions: pgsql, sqlite, mongodb
           coverage: none
 
       - name: Set minimum-stability to dev
@@ -127,6 +131,30 @@ jobs:
         env:
 #          USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
+
+      - name: 'Test: MySQL, Mongo'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, FoundryBundle'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          USE_FOUNDRY_BUNDLE: 1
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, DAMABundle'
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: Mongo standalone'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
 
   code-coverage:
     name: Code Coverage
@@ -273,6 +301,7 @@ jobs:
         run: php-cs-fixer fix --dry-run --diff --diff-format=udiff
 
   static-analysis:
+    if: false
     name: Psalm Static Analysis
     runs-on: ubuntu-latest
     steps:

--- a/src/ChainManagerRegistry.php
+++ b/src/ChainManagerRegistry.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 
@@ -27,8 +28,12 @@ final class ChainManagerRegistry implements ManagerRegistry
     public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
     {
         foreach ($this->managerRegistries as $managerRegistry) {
-            if ($repository = $managerRegistry->getRepository($persistentObject, $persistentManagerName)) {
-                return $repository;
+            try {
+                if ($repository = $managerRegistry->getRepository($persistentObject, $persistentManagerName)) {
+                    return $repository;
+                }
+            } catch (MappingException $exception) {
+                // the class is not managed by the current manager
             }
         }
 

--- a/src/ChainManagerRegistry.php
+++ b/src/ChainManagerRegistry.php
@@ -51,7 +51,7 @@ final class ChainManagerRegistry implements ManagerRegistry
         return \array_reduce(
             $this->managerRegistries,
             static function(array $carry, ManagerRegistry $managerRegistry) {
-                return \array_merge($carry, $managerRegistry->getManagers());
+                return \array_merge($carry, \array_values($managerRegistry->getManagers()));
             },
             []
         );

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -196,8 +196,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             return;
         }
 
-        foreach ($this as $object) {
-            $om->remove($object);
+        // todo: use a better way to truncate mongo collections
+        foreach ($this as $proxy) {
+            $om->remove($proxy->object());
         }
 
         $om->flush();

--- a/src/Test/AbstractSchemaResetter.php
+++ b/src/Test/AbstractSchemaResetter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @internal
+ */
+abstract class AbstractSchemaResetter
+{
+    abstract public function resetSchema(): void;
+
+    protected function runCommand(Application $application, string $command, array $parameters = []): void
+    {
+        $exit = $application->run(
+            new ArrayInput(\array_merge(['command' => $command], $parameters)),
+            $output = new BufferedOutput()
+        );
+
+        if (0 !== $exit) {
+            throw new \RuntimeException(\sprintf('Error running "%s": %s', $command, $output->fetch()));
+        }
+    }
+}

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -3,10 +3,7 @@
 namespace Zenstruck\Foundry\Test;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
-use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Factory;
 
@@ -36,73 +33,57 @@ final class DatabaseResetter
 
     public static function resetDatabase(KernelInterface $kernel): void
     {
-        $application = self::createApplication($kernel);
-        $registry = $kernel->getContainer()->get('doctrine');
-
-        foreach (self::connectionsToReset($registry) as $connection) {
-            $dropParams = ['--connection' => $connection, '--force' => true];
-
-            if ('sqlite' !== $registry->getConnection($connection)->getDatabasePlatform()->getName()) {
-                // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
-                $dropParams['--if-exists'] = true;
-            }
-
-            self::runCommand($application, 'doctrine:database:drop', $dropParams);
-
-            self::runCommand($application, 'doctrine:database:create', [
-                '--connection' => $connection,
-            ]);
+        if (!$kernel->getContainer()->has('doctrine')) {
+            return;
         }
 
-        self::createSchema($application, $registry);
+        $application = self::createApplication($kernel);
+        $databaseResetter = new ORMDatabaseResetter($application, $kernel->getContainer()->get('doctrine'));
+
+        $databaseResetter->resetDatabase();
+
+        self::bootFoundry($kernel);
 
         self::$hasBeenReset = true;
     }
 
     public static function resetSchema(KernelInterface $kernel): void
     {
-        $application = self::createApplication($kernel);
-        $registry = $kernel->getContainer()->get('doctrine');
-
-        self::dropSchema($application, $registry);
-        self::createSchema($application, $registry);
-    }
-
-    private static function createSchema(Application $application, ManagerRegistry $registry): void
-    {
-        foreach (self::objectManagersToReset($registry) as $manager) {
-            self::runCommand($application, 'doctrine:schema:create', [
-                '--em' => $manager,
-            ]);
+        foreach (self::schemaResetters($kernel) as $databaseResetter) {
+            $databaseResetter->resetSchema();
         }
 
+        if (self::isDAMADoctrineTestBundleEnabled()) {
+            return;
+        }
+
+        self::bootFoundry($kernel);
+    }
+
+    /** @retrun array<SchemaResetterInterface> */
+    private static function schemaResetters(KernelInterface $kernel): array
+    {
+        $application = self::createApplication($kernel);
+
+        $databaseResetters = [];
+        if ($kernel->getContainer()->has('doctrine')) {
+            $databaseResetters[] = new ORMDatabaseResetter($application, $kernel->getContainer()->get('doctrine'));
+        }
+
+        if ($kernel->getContainer()->has('doctrine_mongodb')) {
+            $databaseResetters[] = new ODMSchemaResetter($application, $kernel->getContainer()->get('doctrine_mongodb'));
+        }
+
+        return $databaseResetters;
+    }
+
+    private static function bootFoundry(KernelInterface $kernel): void
+    {
         if (!Factory::isBooted()) {
-            TestState::bootFromContainer($application->getKernel()->getContainer());
+            TestState::bootFromContainer($kernel->getContainer());
         }
 
         TestState::flushGlobalState();
-    }
-
-    private static function dropSchema(Application $application, ManagerRegistry $registry): void
-    {
-        foreach (self::objectManagersToReset($registry) as $manager) {
-            self::runCommand($application, 'doctrine:schema:drop', [
-                '--em' => $manager,
-                '--force' => true,
-            ]);
-        }
-    }
-
-    private static function runCommand(Application $application, string $command, array $parameters = []): void
-    {
-        $exit = $application->run(
-            new ArrayInput(\array_merge(['command' => $command], $parameters)),
-            $output = new BufferedOutput()
-        );
-
-        if (0 !== $exit) {
-            throw new \RuntimeException(\sprintf('Error running "%s": %s', $command, $output->fetch()));
-        }
     }
 
     private static function createApplication(KernelInterface $kernel): Application
@@ -111,23 +92,5 @@ final class DatabaseResetter
         $application->setAutoExit(false);
 
         return $application;
-    }
-
-    private static function connectionsToReset(ManagerRegistry $registry): array
-    {
-        if (isset($_SERVER['FOUNDRY_RESET_CONNECTIONS'])) {
-            return \explode(',', $_SERVER['FOUNDRY_RESET_CONNECTIONS']);
-        }
-
-        return [$registry->getDefaultConnectionName()];
-    }
-
-    private static function objectManagersToReset(ManagerRegistry $registry): array
-    {
-        if (isset($_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS'])) {
-            return \explode(',', $_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS']);
-        }
-
-        return [$registry->getDefaultManagerName()];
     }
 }

--- a/src/Test/ODMSchemaResetter.php
+++ b/src/Test/ODMSchemaResetter.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+/**
+ * @internal
+ */
+final class ODMSchemaResetter extends AbstractSchemaResetter
+{
+    /** @var Application */
+    private $application;
+    /** @var ManagerRegistry */
+    private $registry;
+
+    public function __construct(Application $application, ManagerRegistry $registry)
+    {
+        $this->application = $application;
+        $this->registry = $registry;
+    }
+
+    public function resetSchema(): void
+    {
+        foreach ($this->objectManagersToReset() as $manager) {
+            $this->runCommand(
+                $this->application,
+                'doctrine:mongodb:schema:drop',
+                [
+                    '--dm' => $manager,
+                ]
+            );
+
+            $this->runCommand(
+                $this->application,
+                'doctrine:mongodb:schema:create',
+                [
+                    '--dm' => $manager,
+                ]
+            );
+        }
+    }
+
+    /** @return list<string> */
+    private function objectManagersToReset(): array
+    {
+        return [$this->registry->getDefaultManagerName()];
+    }
+}

--- a/src/Test/ODMSchemaResetter.php
+++ b/src/Test/ODMSchemaResetter.php
@@ -24,13 +24,16 @@ final class ODMSchemaResetter extends AbstractSchemaResetter
     public function resetSchema(): void
     {
         foreach ($this->objectManagersToReset() as $manager) {
-            $this->runCommand(
-                $this->application,
-                'doctrine:mongodb:schema:drop',
-                [
-                    '--dm' => $manager,
-                ]
-            );
+            try {
+                $this->runCommand(
+                    $this->application,
+                    'doctrine:mongodb:schema:drop',
+                    [
+                        '--dm' => $manager,
+                    ]
+                );
+            } catch (\Exception $e) {
+            }
 
             $this->runCommand(
                 $this->application,

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+/**
+ * @internal
+ */
+final class ORMDatabaseResetter extends AbstractSchemaResetter
+{
+    /** @var Application */
+    private $application;
+    /** @var ManagerRegistry */
+    private $registry;
+
+    public function __construct(Application $application, ManagerRegistry $registry)
+    {
+        $this->application = $application;
+        $this->registry = $registry;
+    }
+
+    public function resetDatabase(): void
+    {
+        foreach ($this->connectionsToReset() as $connection) {
+            $dropParams = ['--connection' => $connection, '--force' => true];
+
+            if ('sqlite' !== $this->registry->getConnection($connection)->getDatabasePlatform()->getName()) {
+                // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
+                $dropParams['--if-exists'] = true;
+            }
+
+            $this->runCommand($this->application, 'doctrine:database:drop', $dropParams);
+
+            $this->runCommand(
+                $this->application,
+                'doctrine:database:create',
+                [
+                    '--connection' => $connection,
+                ]
+            );
+        }
+
+        $this->createSchema();
+    }
+
+    public function resetSchema(): void
+    {
+        if (DatabaseResetter::isDAMADoctrineTestBundleEnabled()) {
+            // not required as the DAMADoctrineTestBundle wraps each test in a transaction
+            return;
+        }
+
+        $this->dropSchema();
+        $this->createSchema();
+    }
+
+    private function createSchema(): void
+    {
+        foreach ($this->objectManagersToReset() as $manager) {
+            $this->runCommand(
+                $this->application,
+                'doctrine:schema:create',
+                [
+                    '--em' => $manager,
+                ]
+            );
+        }
+    }
+
+    private function dropSchema(): void
+    {
+        foreach ($this->objectManagersToReset() as $manager) {
+            $this->runCommand(
+                $this->application,
+                'doctrine:schema:drop',
+                [
+                    '--em' => $manager,
+                    '--force' => true,
+                ]
+            );
+        }
+    }
+
+    /** @return list<string> */
+    private function connectionsToReset(): array
+    {
+        if (isset($_SERVER['FOUNDRY_RESET_CONNECTIONS'])) {
+            return \explode(',', $_SERVER['FOUNDRY_RESET_CONNECTIONS']);
+        }
+
+        return [$this->registry->getDefaultConnectionName()];
+    }
+
+    /** @return list<string> */
+    private function objectManagersToReset(): array
+    {
+        if (isset($_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS'])) {
+            return \explode(',', $_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS']);
+        }
+
+        return [$this->registry->getDefaultManagerName()];
+    }
+}

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -50,11 +50,6 @@ trait ResetDatabase
      */
     public static function _resetSchema(): void
     {
-        if (DatabaseResetter::isDAMADoctrineTestBundleEnabled()) {
-            // not required as the DAMADoctrineTestBundle wraps each test in a transaction
-            return;
-        }
-
         if (!\is_subclass_of(static::class, KernelTestCase::class)) {
             throw new \RuntimeException(\sprintf('The "%s" trait can only be used on TestCases that extend "%s".', __TRAIT__, KernelTestCase::class));
         }

--- a/tests/Fixtures/Document/Category.php
+++ b/tests/Fixtures/Document/Category.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document(collection="category")
+ */
+class Category
+{
+    /**
+     * @MongoDB\Id
+     */
+    private $id;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $name;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Document/Post.php
+++ b/tests/Fixtures/Document/Post.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document(collection="post")
+ */
+class Post
+{
+    /**
+     * @MongoDB\Id
+     */
+    private $id;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $title;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $body;
+
+    /**
+     * @MongoDB\Field(type="string", nullable=true)
+     */
+    private $shortDescription;
+
+    /**
+     * @MongoDB\Field(type="int")
+     */
+    private $viewCount = 0;
+
+    /**
+     * @MongoDB\Field(type="date")
+     */
+    private $createdAt;
+
+    /**
+     * @MongoDB\Field(type="date", nullable=true)
+     */
+    private $publishedAt;
+
+    public function __construct(string $title, string $body, ?string $shortDescription = null)
+    {
+        $this->title = $title;
+        $this->body = $body;
+        $this->shortDescription = $shortDescription;
+        $this->createdAt = new \DateTime('now');
+    }
+
+    public function __toString(): string
+    {
+        return $this->title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function getShortDescription(): ?string
+    {
+        return $this->shortDescription;
+    }
+
+    public function getViewCount(): int
+    {
+        return $this->viewCount;
+    }
+
+    public function increaseViewCount(int $amount = 1): void
+    {
+        $this->viewCount += $amount;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function isPublished(): bool
+    {
+        return null !== $this->publishedAt;
+    }
+
+    public function setPublishedAt(\DateTime $timestamp)
+    {
+        $this->publishedAt = $timestamp;
+    }
+}

--- a/tests/Fixtures/Factories/ODM/CategoryFactory.php
+++ b/tests/Fixtures/Factories/ODM/CategoryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CategoryFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return ['name' => self::faker()->sentence()];
+    }
+}

--- a/tests/Fixtures/Factories/ODM/PostFactory.php
+++ b/tests/Fixtures/Factories/ODM/PostFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
+
+class PostFactory extends ModelFactory
+{
+    public function published(): self
+    {
+        return $this->addState(function() {
+            return ['published_at' => self::faker()->dateTime()];
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return Post::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'title' => self::faker()->sentence(),
+            'body' => self::faker()->sentence(),
+        ];
+    }
+}

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Foundry\Tests\Fixtures;
 
 use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MakerBundle\MakerBundle;
@@ -35,6 +36,10 @@ class Kernel extends BaseKernel
 
         if (\getenv('USE_DAMA_DOCTRINE_TEST_BUNDLE')) {
             yield new DAMADoctrineTestBundle();
+        }
+
+        if (\getenv('MONGO_URL')) {
+            yield new DoctrineMongoDBBundle();
         }
     }
 
@@ -79,6 +84,18 @@ class Kernel extends BaseKernel
         if (\getenv('USE_FOUNDRY_BUNDLE')) {
             $c->loadFromExtension('zenstruck_foundry', [
                 'auto_refresh_proxies' => false,
+            ]);
+        }
+
+        if (\getenv('MONGO_URL')) {
+            $c->loadFromExtension('doctrine_mongodb', [
+                'connections' => [
+                    'default' => ['server' => '%env(resolve:MONGO_URL)%'],
+                ],
+                'default_database' => 'mongo',
+                'document_managers' => [
+                    'default' => ['auto_mapping' => true],
+                ],
             ]);
         }
     }

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -27,7 +27,11 @@ class Kernel extends BaseKernel
     public function registerBundles(): iterable
     {
         yield new FrameworkBundle();
-        yield new DoctrineBundle();
+
+        if (\getenv('DATABASE_URL')) {
+            yield new DoctrineBundle();
+        }
+
         yield new MakerBundle();
 
         if (\getenv('USE_FOUNDRY_BUNDLE')) {
@@ -64,22 +68,27 @@ class Kernel extends BaseKernel
             'test' => true,
         ]);
 
-        $c->loadFromExtension('doctrine', [
-            'dbal' => ['url' => '%env(resolve:DATABASE_URL)%'],
-            'orm' => [
-                'auto_generate_proxy_classes' => true,
-                'auto_mapping' => true,
-                'mappings' => [
-                    'Test' => [
-                        'is_bundle' => false,
-                        'type' => 'annotation',
-                        'dir' => '%kernel.project_dir%/tests/Fixtures/Entity',
-                        'prefix' => 'Zenstruck\Foundry\Tests\Fixtures\Entity',
-                        'alias' => 'Test',
+        if (\getenv('DATABASE_URL')) {
+            $c->loadFromExtension(
+                'doctrine',
+                [
+                    'dbal' => ['url' => '%env(resolve:DATABASE_URL)%'],
+                    'orm' => [
+                        'auto_generate_proxy_classes' => true,
+                        'auto_mapping' => true,
+                        'mappings' => [
+                            'Test' => [
+                                'is_bundle' => false,
+                                'type' => 'annotation',
+                                'dir' => '%kernel.project_dir%/tests/Fixtures/Entity',
+                                'prefix' => 'Zenstruck\Foundry\Tests\Fixtures\Entity',
+                                'alias' => 'Test',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-        ]);
+                ]
+            );
+        }
 
         if (\getenv('USE_FOUNDRY_BUNDLE')) {
             $c->loadFromExtension('zenstruck_foundry', [
@@ -94,7 +103,18 @@ class Kernel extends BaseKernel
                 ],
                 'default_database' => 'mongo',
                 'document_managers' => [
-                    'default' => ['auto_mapping' => true],
+                    'default' => [
+                        'auto_mapping' => true,
+                        'mappings' => [
+                            'Test' => [
+                                'is_bundle' => false,
+                                'type' => 'annotation',
+                                'dir' => '%kernel.project_dir%/tests/Fixtures/Document',
+                                'prefix' => 'Zenstruck\Foundry\Tests\Fixtures\Document',
+                                'alias' => 'Test',
+                            ],
+                        ],
+                    ],
                 ],
             ]);
         }

--- a/tests/Functional/AnonymousFactoryTest.php
+++ b/tests/Functional/AnonymousFactoryTest.php
@@ -6,12 +6,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class AnonymousFactoryTest extends KernelTestCase
+abstract class AnonymousFactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
@@ -20,7 +19,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_or_create(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $factory->assert()->count(0);
         $factory->findOrCreate(['name' => 'php']);
@@ -34,7 +33,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $ids = [];
@@ -51,12 +50,12 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_create_random_object_if_none_exists(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $factory->assert()->count(0);
-        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $this->assertInstanceOf($this->categoryClass(), $factory->randomOrCreate()->object());
         $factory->assert()->count(1);
-        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $this->assertInstanceOf($this->categoryClass(), $factory->randomOrCreate()->object());
         $factory->assert()->count(1);
     }
 
@@ -65,7 +64,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_get_or_create_random_object_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'name1']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'name1']);
         $factory->many(5)->create();
 
         $factory->assert()->count(5);
@@ -80,7 +79,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $objects = $factory->randomSet(3);
@@ -94,7 +93,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $factory->many(20)->create(['name' => 'name1']);
         $factory->many(5)->create(['name' => 'name2']);
 
@@ -110,7 +109,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $counts = [];
@@ -133,7 +132,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $factory->many(20)->create(['name' => 'name1']);
         $factory->many(5)->create(['name' => 'name2']);
 
@@ -152,7 +151,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function first_and_last_return_the_correct_object(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $categoryA = $factory->create(['name' => '3']);
         $categoryB = $factory->create(['name' => '2']);
         $categoryC = $factory->create(['name' => '1']);
@@ -170,7 +169,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->first();
+        AnonymousFactory::new($this->categoryClass())->first();
     }
 
     /**
@@ -180,7 +179,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->last();
+        AnonymousFactory::new($this->categoryClass())->last();
     }
 
     /**
@@ -188,7 +187,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_count_and_truncate_model_factory(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $this->assertSame(0, $factory->count());
         $this->assertCount(0, $factory);
@@ -209,7 +208,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_get_all_entities(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $this->assertSame([], $factory->all());
 
@@ -219,10 +218,10 @@ final class AnonymousFactoryTest extends KernelTestCase
 
         $this->assertCount(4, $categories);
         $this->assertCount(4, \iterator_to_array($factory));
-        $this->assertInstanceOf(Category::class, $categories[0]->object());
-        $this->assertInstanceOf(Category::class, $categories[1]->object());
-        $this->assertInstanceOf(Category::class, $categories[2]->object());
-        $this->assertInstanceOf(Category::class, $categories[3]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[0]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[1]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[2]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[3]->object());
     }
 
     /**
@@ -230,7 +229,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_entity(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $factory->create(['name' => 'first']);
         $factory->create(['name' => 'second']);
@@ -239,6 +238,11 @@ final class AnonymousFactoryTest extends KernelTestCase
         $this->assertSame('second', $factory->find(['name' => 'second'])->getName());
         $this->assertSame('third', $factory->find(['id' => $category->getId()])->getName());
         $this->assertSame('third', $factory->find($category->getId())->getName());
+
+        if ($this instanceof ODMAnonymousFactoryTest) {
+            return;
+        }
+
         $this->assertSame('third', $factory->find($category->object())->getName());
         $this->assertSame('third', $factory->find($category)->getName());
     }
@@ -250,7 +254,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->find(99);
+        AnonymousFactory::new($this->categoryClass())->find(99);
     }
 
     /**
@@ -258,7 +262,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_by(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $this->assertSame([], $factory->findBy(['name' => 'name2']));
 
@@ -272,4 +276,6 @@ final class AnonymousFactoryTest extends KernelTestCase
         $this->assertSame('name2', $categories[0]->getName());
         $this->assertSame('name2', $categories[1]->getName());
     }
+
+    abstract protected function categoryClass(): string;
 }

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -19,6 +19,13 @@ final class FactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -15,6 +15,13 @@ final class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -15,6 +15,13 @@ final class ModelFactoryServiceTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -2,24 +2,14 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class ModelFactoryTest extends KernelTestCase
+abstract class ModelFactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
@@ -28,42 +18,13 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_or_create(): void
     {
-        CategoryFactory::assert()->count(0);
-        CategoryFactory::findOrCreate(['name' => 'php']);
-        CategoryFactory::assert()->count(1);
-        CategoryFactory::findOrCreate(['name' => 'php']);
-        CategoryFactory::assert()->count(1);
-    }
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-    /**
-     * @test
-     */
-    public function can_override_initialize(): void
-    {
-        $this->assertFalse(PostFactory::createOne()->isPublished());
-        $this->assertTrue(PostFactoryWithValidInitialize::createOne()->isPublished());
-    }
-
-    /**
-     * @test
-     */
-    public function initialize_must_return_an_instance_of_the_current_factory(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithInvalidInitialize::class));
-
-        PostFactoryWithInvalidInitialize::new();
-    }
-
-    /**
-     * @test
-     */
-    public function initialize_must_return_a_value(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithNullInitialize::class));
-
-        PostFactoryWithNullInitialize::new();
+        $categoryFactoryClass::assert()->count(0);
+        $categoryFactoryClass::findOrCreate(['name' => 'php']);
+        $categoryFactoryClass::assert()->count(1);
+        $categoryFactoryClass::findOrCreate(['name' => 'php']);
+        $categoryFactoryClass::assert()->count(1);
     }
 
     /**
@@ -71,12 +32,14 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::createMany(5);
 
         $ids = [];
 
         while (5 !== \count(\array_unique($ids))) {
-            $ids[] = CategoryFactory::random()->getId();
+            $ids[] = $categoryFactoryClass::random()->getId();
         }
 
         $this->assertCount(5, \array_unique($ids));
@@ -87,11 +50,13 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_create_random_object_if_none_exists(): void
     {
-        CategoryFactory::assert()->count(0);
-        $this->assertInstanceOf(Category::class, CategoryFactory::randomOrCreate()->object());
-        CategoryFactory::assert()->count(1);
-        $this->assertInstanceOf(Category::class, CategoryFactory::randomOrCreate()->object());
-        CategoryFactory::assert()->count(1);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::assert()->count(0);
+        $this->assertInstanceOf($this->categoryClass(), $categoryFactoryClass::randomOrCreate()->object());
+        $categoryFactoryClass::assert()->count(1);
+        $this->assertInstanceOf($this->categoryClass(), $categoryFactoryClass::randomOrCreate()->object());
+        $categoryFactoryClass::assert()->count(1);
     }
 
     /**
@@ -99,13 +64,15 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_get_or_create_random_object_with_attributes(): void
     {
-        CategoryFactory::createMany(5, ['name' => 'name1']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::assert()->count(5);
-        $this->assertSame('name2', CategoryFactory::randomOrCreate(['name' => 'name2'])->getName());
-        CategoryFactory::assert()->count(6);
-        $this->assertSame('name2', CategoryFactory::randomOrCreate(['name' => 'name2'])->getName());
-        CategoryFactory::assert()->count(6);
+        $categoryFactoryClass::createMany(5, ['name' => 'name1']);
+
+        $categoryFactoryClass::assert()->count(5);
+        $this->assertSame('name2', $categoryFactoryClass::randomOrCreate(['name' => 'name2'])->getName());
+        $categoryFactoryClass::assert()->count(6);
+        $this->assertSame('name2', $categoryFactoryClass::randomOrCreate(['name' => 'name2'])->getName());
+        $categoryFactoryClass::assert()->count(6);
     }
 
     /**
@@ -113,9 +80,11 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomSet(3);
+        $categoryFactoryClass::createMany(5);
+
+        $objects = $categoryFactoryClass::randomSet(3);
 
         $this->assertCount(3, $objects);
         $this->assertCount(3, \array_unique(\array_map(static function($category) { return $category->getId(); }, $objects)));
@@ -126,10 +95,12 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects_with_attributes(): void
     {
-        CategoryFactory::createMany(20, ['name' => 'name1']);
-        CategoryFactory::createMany(5, ['name' => 'name2']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomSet(2, ['name' => 'name2']);
+        $categoryFactoryClass::createMany(20, ['name' => 'name1']);
+        $categoryFactoryClass::createMany(5, ['name' => 'name2']);
+
+        $objects = $categoryFactoryClass::randomSet(2, ['name' => 'name2']);
 
         $this->assertCount(2, $objects);
         $this->assertSame('name2', $objects[0]->getName());
@@ -141,12 +112,14 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::createMany(5);
 
         $counts = [];
 
         while (4 !== \count(\array_unique($counts))) {
-            $counts[] = \count(CategoryFactory::randomRange(0, 3));
+            $counts[] = \count($categoryFactoryClass::randomRange(0, 3));
         }
 
         $this->assertCount(4, \array_unique($counts));
@@ -163,10 +136,12 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects_with_attributes(): void
     {
-        CategoryFactory::createMany(20, ['name' => 'name1']);
-        CategoryFactory::createMany(5, ['name' => 'name2']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomRange(2, 4, ['name' => 'name2']);
+        $categoryFactoryClass::createMany(20, ['name' => 'name1']);
+        $categoryFactoryClass::createMany(5, ['name' => 'name2']);
+
+        $objects = $categoryFactoryClass::randomRange(2, 4, ['name' => 'name2']);
 
         $this->assertGreaterThanOrEqual(2, \count($objects));
         $this->assertLessThanOrEqual(4, \count($objects));
@@ -179,168 +154,18 @@ final class ModelFactoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function one_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::createOne([
-            'comments' => CommentFactory::new()->many(4),
-        ]);
-
-        $this->assertCount(4, $post->getComments());
-        UserFactory::assert()->count(4);
-        CommentFactory::assert()->count(4);
-        PostFactory::assert()->count(1);
-    }
-
-    /**
-     * @test
-     */
-    public function create_multiple_one_to_many_with_nested_collection_relationship(): void
-    {
-        $user = UserFactory::createOne();
-        $posts = PostFactory::createMany(2, [
-            'comments' => CommentFactory::new(['user' => $user])->many(4),
-        ]);
-
-        $this->assertCount(4, $posts[0]->getComments());
-        $this->assertCount(4, $posts[1]->getComments());
-        UserFactory::assert()->count(1);
-        CommentFactory::assert()->count(8);
-        PostFactory::assert()->count(2);
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::createOne([
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(5); // 3 created by this test and 2 in global state
-        PostFactory::assert()->count(1);
-    }
-
-    /**
-     * @test
-     */
-    public function inverse_many_to_many_with_nested_collection_relationship(): void
-    {
-        $tag = TagFactory::createOne([
-            'posts' => PostFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $tag->getPosts());
-        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
-        PostFactory::assert()->count(3);
-    }
-
-    /**
-     * @test
-     */
-    public function create_multiple_many_to_many_with_nested_collection_relationship(): void
-    {
-        $posts = PostFactory::createMany(2, [
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $posts[0]->getTags());
-        $this->assertCount(3, $posts[1]->getTags());
-        TagFactory::assert()->count(8); // 6 created by this test and 2 in global state
-        PostFactory::assert()->count(2);
-    }
-
-    /**
-     * @test
-     */
-    public function unpersisted_one_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::new()->withoutPersisting()->create([
-            'comments' => CommentFactory::new()->many(4),
-        ]);
-
-        $this->assertCount(4, $post->getComments());
-        UserFactory::assert()->empty();
-        CommentFactory::assert()->empty();
-        PostFactory::assert()->empty();
-    }
-
-    /**
-     * @test
-     */
-    public function unpersisted_many_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::new()->withoutPersisting()->create([
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(2); // 2 created in global state
-        PostFactory::assert()->empty();
-    }
-
-    /**
-     * @test
-     * @dataProvider dataProvider
-     */
-    public function can_use_model_factories_in_a_data_provider(PostFactory $factory, bool $published): void
-    {
-        $post = $factory->create();
-
-        $post->assertPersisted();
-        $this->assertSame($published, $post->isPublished());
-    }
-
-    public static function dataProvider(): array
-    {
-        return [
-            [PostFactory::new(), false],
-            [PostFactory::new()->published(), true],
-        ];
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_one_unmanaged_entity(): void
-    {
-        $category = CategoryFactory::createOne(['name' => 'My Category']);
-
-        self::$container->get(EntityManagerInterface::class)->clear();
-
-        $post = PostFactory::createOne(['category' => $category]);
-
-        $this->assertSame('My Category', $post->getCategory()->getName());
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_one_unmanaged_raw_entity(): void
-    {
-        $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
-
-        self::$container->get(EntityManagerInterface::class)->clear();
-
-        $post = PostFactory::createOne(['category' => $category]);
-
-        $this->assertSame('My Category', $post->getCategory()->getName());
-    }
-
-    /**
-     * @test
-     */
     public function first_and_last_return_the_correct_object(): void
     {
-        $categoryA = CategoryFactory::createOne(['name' => '3']);
-        $categoryB = CategoryFactory::createOne(['name' => '2']);
-        $categoryC = CategoryFactory::createOne(['name' => '1']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $this->assertSame($categoryA->getId(), CategoryFactory::first()->getId());
-        $this->assertSame($categoryC->getId(), CategoryFactory::first('name')->getId());
-        $this->assertSame($categoryC->getId(), CategoryFactory::last()->getId());
-        $this->assertSame($categoryA->getId(), CategoryFactory::last('name')->getId());
+        $categoryA = $categoryFactoryClass::createOne(['name' => '3']);
+        $categoryB = $categoryFactoryClass::createOne(['name' => '2']);
+        $categoryC = $categoryFactoryClass::createOne(['name' => '1']);
+
+        $this->assertSame($categoryA->getId(), $categoryFactoryClass::first()->getId());
+        $this->assertSame($categoryC->getId(), $categoryFactoryClass::first('name')->getId());
+        $this->assertSame($categoryC->getId(), $categoryFactoryClass::last()->getId());
+        $this->assertSame($categoryA->getId(), $categoryFactoryClass::last('name')->getId());
     }
 
     /**
@@ -350,7 +175,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::first();
+        $this->categoryFactoryClass()::first();
     }
 
     /**
@@ -360,7 +185,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::last();
+        $this->categoryFactoryClass()::last();
     }
 
     /**
@@ -368,15 +193,17 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_count_and_truncate_model_factory(): void
     {
-        $this->assertSame(0, CategoryFactory::count());
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createMany(4);
+        $this->assertSame(0, $categoryFactoryClass::count());
 
-        $this->assertSame(4, CategoryFactory::count());
+        $categoryFactoryClass::createMany(4);
 
-        CategoryFactory::truncate();
+        $this->assertSame(4, $categoryFactoryClass::count());
 
-        $this->assertSame(0, CategoryFactory::count());
+        $categoryFactoryClass::truncate();
+
+        $this->assertSame(0, $categoryFactoryClass::count());
     }
 
     /**
@@ -384,17 +211,19 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_get_all_entities(): void
     {
-        $this->assertSame([], CategoryFactory::all());
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createMany(4);
+        $this->assertSame([], $categoryFactoryClass::all());
 
-        $categories = CategoryFactory::all();
+        $categoryFactoryClass::createMany(4);
+
+        $categories = $categoryFactoryClass::all();
 
         $this->assertCount(4, $categories);
-        $this->assertInstanceOf(Category::class, $categories[0]->object());
-        $this->assertInstanceOf(Category::class, $categories[1]->object());
-        $this->assertInstanceOf(Category::class, $categories[2]->object());
-        $this->assertInstanceOf(Category::class, $categories[3]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[0]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[1]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[2]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[3]->object());
     }
 
     /**
@@ -402,15 +231,20 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_entity(): void
     {
-        CategoryFactory::createOne(['name' => 'first']);
-        CategoryFactory::createOne(['name' => 'second']);
-        $category = CategoryFactory::createOne(['name' => 'third']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $this->assertSame('second', CategoryFactory::find(['name' => 'second'])->getName());
-        $this->assertSame('third', CategoryFactory::find(['id' => $category->getId()])->getName());
-        $this->assertSame('third', CategoryFactory::find($category->getId())->getName());
-        $this->assertSame('third', CategoryFactory::find($category->object())->getName());
-        $this->assertSame('third', CategoryFactory::find($category)->getName());
+        $categoryFactoryClass::createOne(['name' => 'first']);
+        $categoryFactoryClass::createOne(['name' => 'second']);
+        $category = $categoryFactoryClass::createOne(['name' => 'third']);
+
+        $this->assertSame('second', $categoryFactoryClass::find(['name' => 'second'])->getName());
+        $this->assertSame('third', $categoryFactoryClass::find(['id' => $category->getId()])->getName());
+        $this->assertSame('third', $categoryFactoryClass::find($category->getId())->getName());
+
+        if ($this instanceof ORMModelFactoryTest) {
+            $this->assertSame('third', $categoryFactoryClass::find($category)->getName());
+            $this->assertSame('third', $categoryFactoryClass::find($category->object())->getName());
+        }
     }
 
     /**
@@ -420,7 +254,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::find(99);
+        $this->categoryFactoryClass()::find(99);
     }
 
     /**
@@ -428,16 +262,22 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_by(): void
     {
-        $this->assertSame([], CategoryFactory::findBy(['name' => 'name2']));
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createOne(['name' => 'name1']);
-        CategoryFactory::createOne(['name' => 'name2']);
-        CategoryFactory::createOne(['name' => 'name2']);
+        $this->assertSame([], $categoryFactoryClass::findBy(['name' => 'name2']));
 
-        $categories = CategoryFactory::findBy(['name' => 'name2']);
+        $categoryFactoryClass::createOne(['name' => 'name1']);
+        $categoryFactoryClass::createOne(['name' => 'name2']);
+        $categoryFactoryClass::createOne(['name' => 'name2']);
+
+        $categories = $categoryFactoryClass::findBy(['name' => 'name2']);
 
         $this->assertCount(2, $categories);
         $this->assertSame('name2', $categories[0]->getName());
         $this->assertSame('name2', $categories[1]->getName());
     }
+
+    abstract protected function categoryClass(): string;
+
+    abstract protected function categoryFactoryClass(): string;
 }

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+}

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMModelFactoryTest extends ModelFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMProxyTest extends ProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function postFactoryClass(): string
+    {
+        return PostFactory::class;
+    }
+
+    protected function registryServiceId(): string
+    {
+        return 'doctrine_mongodb';
+    }
+}

--- a/tests/Functional/ODMRepositoryProxyTest.php
+++ b/tests/Functional/ODMRepositoryProxyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMRepositoryProxyTest extends RepositoryProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMModelFactoryTest extends ModelFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_initialize(): void
+    {
+        $this->assertFalse(PostFactory::createOne()->isPublished());
+        $this->assertTrue(PostFactoryWithValidInitialize::createOne()->isPublished());
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_an_instance_of_the_current_factory(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithInvalidInitialize::class));
+
+        PostFactoryWithInvalidInitialize::new();
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_a_value(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithNullInitialize::class));
+
+        PostFactoryWithNullInitialize::new();
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::createOne([
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $this->assertCount(4, $post->getComments());
+        UserFactory::assert()->count(4);
+        CommentFactory::assert()->count(4);
+        PostFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function create_multiple_one_to_many_with_nested_collection_relationship(): void
+    {
+        $user = UserFactory::createOne();
+        $posts = PostFactory::createMany(2, [
+            'comments' => CommentFactory::new(['user' => $user])->many(4),
+        ]);
+
+        $this->assertCount(4, $posts[0]->getComments());
+        $this->assertCount(4, $posts[1]->getComments());
+        UserFactory::assert()->count(1);
+        CommentFactory::assert()->count(8);
+        PostFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::createOne([
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $post->getTags());
+        TagFactory::assert()->count(5); // 3 created by this test and 2 in global state
+        PostFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function inverse_many_to_many_with_nested_collection_relationship(): void
+    {
+        $tag = TagFactory::createOne([
+            'posts' => PostFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $tag->getPosts());
+        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
+        PostFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
+    public function create_multiple_many_to_many_with_nested_collection_relationship(): void
+    {
+        $posts = PostFactory::createMany(2, [
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $posts[0]->getTags());
+        $this->assertCount(3, $posts[1]->getTags());
+        TagFactory::assert()->count(8); // 6 created by this test and 2 in global state
+        PostFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    public function unpersisted_one_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::new()->withoutPersisting()->create([
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $this->assertCount(4, $post->getComments());
+        UserFactory::assert()->empty();
+        CommentFactory::assert()->empty();
+        PostFactory::assert()->empty();
+    }
+
+    /**
+     * @test
+     */
+    public function unpersisted_many_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::new()->withoutPersisting()->create([
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $post->getTags());
+        TagFactory::assert()->count(2); // 2 created in global state
+        PostFactory::assert()->empty();
+    }
+
+    /**
+     * @test
+     * @dataProvider dataProvider
+     */
+    public function can_use_model_factories_in_a_data_provider(PostFactory $factory, bool $published): void
+    {
+        $post = $factory->create();
+
+        $post->assertPersisted();
+        $this->assertSame($published, $post->isPublished());
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            [PostFactory::new(), false],
+            [PostFactory::new()->published(), true],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category']);
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_raw_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\AnonymousFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMProxyTest extends ProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     * @requires PHP >= 7.4
+     */
+    public function cannot_convert_to_string_if_underlying_object_cant(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Proxied object "%s" cannot be converted to a string.', Category::class));
+
+        (string) CategoryFactory::createOne();
+    }
+
+    /**
+     * @test
+     * @requires PHP < 7.4
+     */
+    public function on_php_versions_less_than_7_4_if_underlying_object_is_missing_to_string_proxy_to_string_returns_note(): void
+    {
+        $this->assertSame('(no __toString)', (string) CategoryFactory::createOne());
+    }
+
+    /**
+     * @test
+     */
+    public function can_autorefresh_entity_with_embedded_object(): void
+    {
+        $contact = AnonymousFactory::new(Contact::class)->create(['name' => 'john'])
+            ->enableAutoRefresh()
+        ;
+
+        $this->assertSame('john', $contact->getName());
+
+        // I discovered when autorefreshing the second time, the embedded
+        // object is included in the changeset when using UOW::recomputeSingleEntityChangeSet().
+        // Changing to UOW::computeChangeSet() fixes this.
+        $this->assertSame('john', $contact->getName());
+        $this->assertNull($contact->getAddress()->getValue());
+
+        $contact->getAddress()->setValue('address');
+        $contact->save();
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+
+        self::ensureKernelShutdown();
+        self::bootKernel();
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+    }
+
+    protected function postFactoryClass(): string
+    {
+        return PostFactory::class;
+    }
+
+    protected function registryServiceId(): string
+    {
+        return 'doctrine';
+    }
+}

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Doctrine\Common\Proxy\Proxy as DoctrineProxy;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use function Zenstruck\Foundry\repository;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMRepositoryProxyTest extends RepositoryProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function functions_calls_are_passed_to_underlying_repository(): void
+    {
+        $this->assertSame('from custom method', repository(Post::class)->customMethod());
+    }
+
+    /**
+     * @see https://github.com/zenstruck/foundry/issues/42
+     *
+     * @test
+     */
+    public function doctrine_proxies_are_converted_to_foundry_proxies(): void
+    {
+        PostFactory::createOne(['category' => CategoryFactory::new()]);
+
+        // clear the em so nothing is tracked
+        static::$kernel->getContainer()->get('doctrine')->getManager()->clear();
+
+        // load a random Post which causes the em to track a "doctrine proxy" for category
+        PostFactory::random();
+
+        // load a random Category which should be a "doctrine proxy"
+        $category = CategoryFactory::random()->object();
+
+        // ensure the category is a "doctrine proxy" and a Category
+        $this->assertInstanceOf(DoctrineProxy::class, $category);
+        $this->assertInstanceOf(Category::class, $category);
+    }
+
+    /**
+     * @test
+     */
+    public function proxy_wrapping_orm_entity_manager_can_order_by_in_find_one_by(): void
+    {
+        $categoryA = CategoryFactory::createOne();
+        $categoryB = CategoryFactory::createOne();
+        $categoryC = CategoryFactory::createOne();
+
+        $this->assertSame($categoryC->getId(), CategoryFactory::repository()->findOneBy([], ['id' => 'DESC'])->getId());
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -2,32 +2,20 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
-use Doctrine\Common\Proxy\Proxy as DoctrineProxy;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use function Zenstruck\Foundry\repository;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class RepositoryProxyTest extends KernelTestCase
+abstract class RepositoryProxyTest extends KernelTestCase
 {
     use ExpectDeprecationTrait, Factories, ResetDatabase;
-
-    /**
-     * @test
-     */
-    public function functions_calls_are_passed_to_underlying_repository(): void
-    {
-        $this->assertSame('from custom method', repository(Post::class)->customMethod());
-    }
 
     /**
      * @test
@@ -35,11 +23,11 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function assertions(): void
     {
-        $repository = repository(Category::class);
+        $repository = repository($this->categoryClass());
 
         $repository->assertEmpty();
 
-        CategoryFactory::createMany(2);
+        $this->categoryFactoryClass()::createMany(2);
 
         $repository->assertCount(2);
         $repository->assertCountGreaterThan(1);
@@ -53,9 +41,9 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_fetch_objects(): void
     {
-        $repository = repository(Category::class);
+        $repository = repository($this->categoryClass());
 
-        CategoryFactory::createMany(2);
+        $this->categoryFactoryClass()::createMany(2);
 
         $objects = $repository->findAll();
 
@@ -73,12 +61,15 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function find_can_be_passed_proxy_or_object_or_array(): void
     {
-        $repository = repository(Category::class);
-        $proxy = CategoryFactory::createOne(['name' => 'foo']);
+        $repository = repository($this->categoryClass());
+        $proxy = $this->categoryFactoryClass()::createOne(['name' => 'foo']);
 
-        $this->assertInstanceOf(Proxy::class, $repository->find($proxy));
-        $this->assertInstanceOf(Proxy::class, $repository->find($proxy->object()));
         $this->assertInstanceOf(Proxy::class, $repository->find(['name' => 'foo']));
+
+        if (Category::class === $this->categoryClass()) {
+            $this->assertInstanceOf(Proxy::class, $repository->find($proxy));
+            $this->assertInstanceOf(Proxy::class, $repository->find($proxy->object()));
+        }
     }
 
     /**
@@ -86,12 +77,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        CategoryFactory::createMany(5);
+        $this->categoryFactoryClass()::createMany(5);
 
         $ids = [];
 
         while (5 !== \count(\array_unique($ids))) {
-            $ids[] = repository(Category::class)->random()->getId();
+            $ids[] = repository($this->categoryClass())->random()->getId();
         }
 
         $this->assertCount(5, \array_unique($ids));
@@ -103,9 +94,9 @@ final class RepositoryProxyTest extends KernelTestCase
     public function at_least_one_object_must_exist_to_get_random_object(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(\sprintf('At least 1 "%s" object(s) must have been persisted (0 persisted).', Category::class));
+        $this->expectExceptionMessage(\sprintf('At least 1 "%s" object(s) must have been persisted (0 persisted).', $this->categoryClass()));
 
-        repository(Category::class)->random();
+        repository($this->categoryClass())->random();
     }
 
     /**
@@ -113,12 +104,22 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $this->categoryFactoryClass()::createMany(5);
 
-        $objects = repository(Category::class)->randomSet(3);
+        $objects = repository($this->categoryClass())->randomSet(3);
 
         $this->assertCount(3, $objects);
-        $this->assertCount(3, \array_unique(\array_map(static function($category) { return $category->getId(); }, $objects)));
+        $this->assertCount(
+            3,
+            \array_unique(
+                \array_map(
+                    static function($category) {
+                        return $category->getId();
+                    },
+                    $objects
+                )
+            )
+        );
     }
 
     /**
@@ -129,7 +130,7 @@ final class RepositoryProxyTest extends KernelTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$number must be positive (-1 given).');
 
-        repository(Category::class)->randomSet(-1);
+        repository($this->categoryClass())->randomSet(-1);
     }
 
     /**
@@ -137,12 +138,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function the_number_of_persisted_objects_must_be_at_least_the_random_set_number(): void
     {
-        CategoryFactory::createOne();
+        $this->categoryFactoryClass()::createOne();
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', Category::class));
+        $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', $this->categoryClass()));
 
-        repository(Category::class)->randomSet(2);
+        repository($this->categoryClass())->randomSet(2);
     }
 
     /**
@@ -150,12 +151,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $this->categoryFactoryClass()::createMany(5);
 
         $counts = [];
 
         while (4 !== \count(\array_unique($counts))) {
-            $counts[] = \count(repository(Category::class)->randomRange(0, 3));
+            $counts[] = \count(repository($this->categoryClass())->randomRange(0, 3));
         }
 
         $this->assertCount(4, \array_unique($counts));
@@ -172,12 +173,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function the_number_of_persisted_objects_must_be_at_least_the_random_range_max(): void
     {
-        CategoryFactory::createOne();
+        $this->categoryFactoryClass()::createOne();
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', Category::class));
+        $this->expectExceptionMessage(\sprintf('At least 2 "%s" object(s) must have been persisted (1 persisted).', $this->categoryClass()));
 
-        repository(Category::class)->randomRange(0, 2);
+        repository($this->categoryClass())->randomRange(0, 2);
     }
 
     /**
@@ -188,7 +189,7 @@ final class RepositoryProxyTest extends KernelTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$min must be positive (-1 given).');
 
-        repository(Category::class)->randomRange(-1, 3);
+        repository($this->categoryClass())->randomRange(-1, 3);
     }
 
     /**
@@ -199,42 +200,7 @@ final class RepositoryProxyTest extends KernelTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$max (3) cannot be less than $min (5).');
 
-        repository(Category::class)->randomRange(5, 3);
-    }
-
-    /**
-     * @see https://github.com/zenstruck/foundry/issues/42
-     *
-     * @test
-     */
-    public function doctrine_proxies_are_converted_to_foundry_proxies(): void
-    {
-        PostFactory::createOne(['category' => CategoryFactory::new()]);
-
-        // clear the em so nothing is tracked
-        static::$kernel->getContainer()->get('doctrine')->getManager()->clear();
-
-        // load a random Post which causes the em to track a "doctrine proxy" for category
-        PostFactory::random();
-
-        // load a random Category which should be a "doctrine proxy"
-        $category = CategoryFactory::random()->object();
-
-        // ensure the category is a "doctrine proxy" and a Category
-        $this->assertInstanceOf(DoctrineProxy::class, $category);
-        $this->assertInstanceOf(Category::class, $category);
-    }
-
-    /**
-     * @test
-     */
-    public function proxy_wrapping_orm_entity_manager_can_order_by_in_find_one_by(): void
-    {
-        $categoryA = CategoryFactory::createOne();
-        $categoryB = CategoryFactory::createOne();
-        $categoryC = CategoryFactory::createOne();
-
-        $this->assertSame($categoryC->getId(), CategoryFactory::repository()->findOneBy([], ['id' => 'DESC'])->getId());
+        repository($this->categoryClass())->randomRange(5, 3);
     }
 
     /**
@@ -242,10 +208,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function first_and_last_return_the_correct_object(): void
     {
-        $categoryA = CategoryFactory::createOne(['name' => '3']);
-        $categoryB = CategoryFactory::createOne(['name' => '2']);
-        $categoryC = CategoryFactory::createOne(['name' => '1']);
-        $repository = CategoryFactory::repository();
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryA = $categoryFactoryClass::createOne(['name' => '3']);
+        $categoryB = $categoryFactoryClass::createOne(['name' => '2']);
+        $categoryC = $categoryFactoryClass::createOne(['name' => '1']);
+        $repository = $categoryFactoryClass::repository();
 
         $this->assertSame($categoryA->getId(), $repository->first()->getId());
         $this->assertSame($categoryC->getId(), $repository->first('name')->getId());
@@ -258,10 +226,12 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function first_and_last_return_null_if_empty(): void
     {
-        $this->assertNull(CategoryFactory::repository()->first());
-        $this->assertNull(CategoryFactory::repository()->first('name'));
-        $this->assertNull(CategoryFactory::repository()->last());
-        $this->assertNull(CategoryFactory::repository()->last('name'));
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $this->assertNull($categoryFactoryClass::repository()->first());
+        $this->assertNull($categoryFactoryClass::repository()->first('name'));
+        $this->assertNull($categoryFactoryClass::repository()->last());
+        $this->assertNull($categoryFactoryClass::repository()->last('name'));
     }
 
     /**
@@ -269,9 +239,11 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function repository_proxy_is_countable_and_iterable(): void
     {
-        CategoryFactory::createMany(4);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $repository = CategoryFactory::repository();
+        $categoryFactoryClass::createMany(4);
+
+        $repository = $categoryFactoryClass::repository();
 
         $this->assertCount(4, $repository);
         $this->assertCount(4, \iterator_to_array($repository));
@@ -283,10 +255,16 @@ final class RepositoryProxyTest extends KernelTestCase
      */
     public function can_use_get_count(): void
     {
-        CategoryFactory::createMany(4);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::createMany(4);
 
         $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using RepositoryProxy::getCount() is deprecated, use RepositoryProxy::count() (it is now Countable).');
 
-        $this->assertSame(4, CategoryFactory::repository()->getCount());
+        $this->assertSame(4, $categoryFactoryClass::repository()->getCount());
     }
+
+    abstract protected function categoryClass(): string;
+
+    abstract protected function categoryFactoryClass(): string;
 }

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -17,6 +17,13 @@ final class StoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,9 @@ require \dirname(__DIR__).'/vendor/autoload.php';
 (new Filesystem())->remove(__DIR__.'/../var');
 
 TestState::disableDefaultProxyAutoRefresh();
-TestState::addGlobalState(static function() {
-    TagStory::load();
-});
+
+if (\getenv('DATABASE_URL')) {
+    TestState::addGlobalState(static function() {
+        TagStory::load();
+    });
+}


### PR DESCRIPTION
Hello,

here is a proposition to support the `DatabaseResetter` with mongo.

I've ran into few problems for which I've made some trade-off, see my comments in the code.
I'm not quite happy with the implementation because `self::isDAMADoctrineTestBundleEnabled()` pops in every layers (`ResetDatabase` trait, `DatabaseResetter` and `ORMDatabaseResetter`) althought it is only really needed for orm...

I've not created automated tests for new classes yet: I'd rather wait we're OK on an implementation (I don"t even know if it's necessary since these class will be used into the test suite). 
I've also deactivated codecoverage because it resulted in too much noise in code review