### PR TITLE
[feature] Mongo Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mongo:
+        image: mongo:4
+        ports:
+          - 27017:27017
     strategy:
       matrix:
         php: [7.4, 8.0, 8.1]
@@ -53,7 +57,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: pgsql, sqlite
+          extensions: pgsql, sqlite, mongodb
           coverage: none
           tools: flex
 
@@ -143,9 +147,34 @@ jobs:
 #          USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
 
+      - name: 'Test: MySQL, Mongo'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, FoundryBundle'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          USE_FOUNDRY_BUNDLE: 1
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, DAMABundle'
+        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: Mongo standalone'
+        run: vendor/bin/simple-phpunit -v
+        env:
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
   code-coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    if: false
     services:
       mysql:
         image: mysql:5.7
@@ -293,6 +322,7 @@ jobs:
     uses: zenstruck/.github/.github/workflows/php-cs-fixer.yml@main
 
   static-analysis:
+    if: false
     name: Psalm Static Analysis
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         ports:
           - 27017:27017
     strategy:
-      fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1]
         symfony: [4.4.*, 5.3.*, 5.4.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,6 @@ jobs:
   code-coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    if: false
     services:
       mysql:
         image: mysql:5.7
@@ -191,6 +190,10 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      mongo:
+        image: mongo:4
+        ports:
+          - 27017:27017
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.3
@@ -288,6 +291,30 @@ jobs:
         env:
 #          USE_FOUNDRY_BUNDLE: 1
           DATABASE_URL: sqlite:///%kernel.cache_dir%/app.db
+
+      - name: 'Test: MySQL, Mongo'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-mongo.clover
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, FoundryBundle'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-mongo-foundry.clover
+        env:
+          USE_FOUNDRY_BUNDLE: 1
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: MySQL, Mongo, DAMABundle'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mysql-mongo-dama.clover --configuration phpunit-dama-doctrine.xml.dist
+        env:
+          DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
+
+      - name: 'Test: Mongo standalone'
+        run: vendor/bin/simple-phpunit -v --coverage-text --coverage-clover=mongo.clover
+        env:
+          MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
 
       - name: Publish coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,6 @@ jobs:
     uses: zenstruck/.github/.github/workflows/php-cs-fixer.yml@main
 
   static-analysis:
-    if: false
     name: Psalm Static Analysis
     runs-on: ubuntu-latest
     steps:
@@ -371,4 +370,4 @@ jobs:
         run: composer bin psalm install
 
       - name: Run static analysis
-        run: bin/tools/psalm/vendor/vimeo/psalm/psalm --output-format=github
+        run: bin/tools/psalm/vendor/vimeo/psalm/psalm --output-format=github --php-version=7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         ports:
           - 27017:27017
     strategy:
+      fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1]
         symfony: [4.4.*, 5.3.*, 5.4.*]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ $post = PostFactory::new() // Create the factory for Post objects
 The factories can be used inside [DoctrineFixturesBundle](https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html)
 to load fixtures or inside your tests, [where it has even more features](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#using-in-your-tests).
 
+Foundry supports `doctrine/orm` (with [doctrine/doctrine-bundle](https://github.com/doctrine/doctrinebundle)),
+`doctrine/mongodb-odm` (with [doctrine/mongodb-odm-bundle](https://github.com/doctrine/DoctrineMongoDBBundle))
+or a combination of these.
+
 Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/foundry
 
 **[Read the Documentation](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html)**

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "dama/doctrine-test-bundle": "^6.0",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
+        "doctrine/mongodb-odm-bundle": "^3.1|^4.0",
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Foundry
 =======
 
+Foundry supports ``doctrine/orm`` (with `doctrine/doctrine-bundle <https://github.com/doctrine/doctrinebundle>`_),
+``doctrine/mongodb-odm`` (with `doctrine/mongodb-odm-bundle <https://github.com/doctrine/DoctrineMongoDBBundle>`_)
+or a combination of these.
+
 Installation
 ------------
 
@@ -1381,6 +1385,11 @@ accordingly. Your database is still reset before running your test suite but the
 
     If using `Global State`_, it is persisted to the database (not in a transaction) before your
     test suite is run. This could further improve test speed if you have a complex global state.
+
+.. caution::
+
+    Using `Global State`_ that creates both ORM and ODM factories when using DAMADoctrineTestBundle
+    is not supported.
 
 Miscellaneous
 .............

--- a/src/Bundle/DependencyInjection/ChainManagerRegistryPass.php
+++ b/src/Bundle/DependencyInjection/ChainManagerRegistryPass.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\Foundry\ChainManagerRegistry;
+
+final class ChainManagerRegistryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(ChainManagerRegistry::class)) {
+            return;
+        }
+
+        $managerRegistries = [];
+
+        if ($container->hasDefinition('doctrine')) {
+            $managerRegistries[] = new Reference('doctrine');
+        }
+
+        if ($container->hasDefinition('doctrine_mongodb')) {
+            $managerRegistries[] = new Reference('doctrine_mongodb');
+        }
+
+        if (0 === \count($managerRegistries)) {
+            throw new \LogicException('Neither doctrine/orm nor mongodb-odm are present.');
+        }
+
+        $container->getDefinition(ChainManagerRegistry::class)
+            ->setArgument('$managerRegistries', $managerRegistries)
+        ;
+    }
+}

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -185,7 +185,7 @@ final class MakeFactory extends AbstractMaker
         \sort($choices);
 
         if (empty($choices)) {
-            throw new RuntimeCommandException('No entities found.');
+            throw new RuntimeCommandException('No entities or documents found.');
         }
 
         return $choices;

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -12,7 +12,7 @@
 
         <service id="Zenstruck\Foundry\Configuration" public="true">
             <call method="setManagerRegistry">
-                <argument type="service" id="doctrine" />
+                <argument type="service" id="Zenstruck\Foundry\ChainManagerRegistry" />
             </call>
             <call method="setStoryManager">
                 <argument type="service" id="Zenstruck\Foundry\StoryManager" />
@@ -37,13 +37,17 @@
         </service>
 
         <service id="Zenstruck\Foundry\Bundle\Maker\MakeFactory">
-            <argument type="service" id="doctrine" />
+            <argument type="service" id="Zenstruck\Foundry\ChainManagerRegistry" />
             <argument type="tagged_iterator" tag="foundry.factory" />
             <tag name="maker.command" />
         </service>
 
         <service id="Zenstruck\Foundry\Bundle\Maker\MakeStory">
             <tag name="maker.command" />
+        </service>
+
+        <service id="Zenstruck\Foundry\ChainManagerRegistry">
+            <argument/> <!-- list<ManagerRegistry> set by compiler pass -->
         </service>
     </services>
 </container>

--- a/src/ChainManagerRegistry.php
+++ b/src/ChainManagerRegistry.php
@@ -62,47 +62,47 @@ final class ChainManagerRegistry implements ManagerRegistry
         );
     }
 
-    public function getDefaultConnectionName()
+    public function getDefaultConnectionName(): string
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getConnection($name = null)
+    public function getConnection($name = null): object
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getConnections()
+    public function getConnections(): array
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getConnectionNames()
+    public function getConnectionNames(): array
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getDefaultManagerName()
+    public function getDefaultManagerName(): string
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getManager($name = null)
+    public function getManager($name = null): ObjectManager
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function resetManager($name = null)
+    public function resetManager($name = null): ObjectManager
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getAliasNamespace($alias)
+    public function getAliasNamespace($alias): string
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }
 
-    public function getManagerNames()
+    public function getManagerNames(): array
     {
         throw new \BadMethodCallException('Not available in '.self::class);
     }

--- a/src/ChainManagerRegistry.php
+++ b/src/ChainManagerRegistry.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+
+/**
+ * @internal
+ */
+final class ChainManagerRegistry implements ManagerRegistry
+{
+    /** @var list<ManagerRegistry> */
+    private $managerRegistries;
+
+    /** @param list<ManagerRegistry> $managerRegistries */
+    public function __construct(array $managerRegistries)
+    {
+        if (0 === \count($managerRegistries)) {
+            throw new \InvalidArgumentException('no manager registry provided');
+        }
+
+        $this->managerRegistries = $managerRegistries;
+    }
+
+    public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
+    {
+        foreach ($this->managerRegistries as $managerRegistry) {
+            if ($repository = $managerRegistry->getRepository($persistentObject, $persistentManagerName)) {
+                return $repository;
+            }
+        }
+
+        throw new \LogicException("Cannot find repository for class {$persistentObject}");
+    }
+
+    public function getManagerForClass($class): ?ObjectManager
+    {
+        foreach ($this->managerRegistries as $managerRegistry) {
+            if ($managerForClass = $managerRegistry->getManagerForClass($class)) {
+                return $managerForClass;
+            }
+        }
+
+        return null;
+    }
+
+    public function getManagers(): array
+    {
+        return \array_reduce(
+            $this->managerRegistries,
+            static function(array $carry, ManagerRegistry $managerRegistry) {
+                return \array_merge($carry, $managerRegistry->getManagers());
+            },
+            []
+        );
+    }
+
+    public function getDefaultConnectionName()
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getConnection($name = null)
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getConnections()
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getConnectionNames()
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getDefaultManagerName()
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getManager($name = null)
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function resetManager($name = null)
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getAliasNamespace($alias)
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+
+    public function getManagerNames()
+    {
+        throw new \BadMethodCallException('Not available in '.self::class);
+    }
+}

--- a/src/ChainManagerRegistry.php
+++ b/src/ChainManagerRegistry.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 
@@ -27,8 +28,12 @@ final class ChainManagerRegistry implements ManagerRegistry
     public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
     {
         foreach ($this->managerRegistries as $managerRegistry) {
-            if ($repository = $managerRegistry->getRepository($persistentObject, $persistentManagerName)) {
-                return $repository;
+            try {
+                if ($repository = $managerRegistry->getRepository($persistentObject, $persistentManagerName)) {
+                    return $repository;
+                }
+            } catch (MappingException $exception) {
+                // the class is not managed by the current manager
             }
         }
 
@@ -51,7 +56,7 @@ final class ChainManagerRegistry implements ManagerRegistry
         return \array_reduce(
             $this->managerRegistries,
             static function(array $carry, ManagerRegistry $managerRegistry) {
-                return \array_merge($carry, $managerRegistry->getManagers());
+                return \array_merge($carry, \array_values($managerRegistry->getManagers()));
             },
             []
         );

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Faker;
 
@@ -358,6 +359,10 @@ class Factory
 
         // Check inversedBy side ($this is the owner of the relation)
         $factoryClassMetadata = self::configuration()->objectManagerFor($factoryClass)->getMetadataFactory()->getMetadataFor($factoryClass);
+
+        if (!$factoryClassMetadata instanceof ORMClassMetadata) {
+            return null;
+        }
 
         foreach ($factoryClassMetadata->getAssociationNames() as $field) {
             if (!$factoryClassMetadata->isAssociationInverseSide($field) && $factoryClassMetadata->getAssociationTargetClass($field) === $relationClass) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Faker;
 
 /**
@@ -432,12 +433,16 @@ class Factory
         }
 
         try {
-            self::configuration()->objectManagerFor($this->class);
-
-            return true;
+            $classMetadata = self::configuration()->objectManagerFor($this->class)->getClassMetadata($this->class);
         } catch (\RuntimeException $e) {
             // entity not managed (perhaps Embeddable)
             return false;
         }
+
+        if ($classMetadata instanceof ODMClassMetadata && $classMetadata->isEmbeddedDocument) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,8 +2,8 @@
 
 namespace Zenstruck\Foundry;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Faker;
 
 /**

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -282,8 +282,10 @@ final class Proxy
         $objectManager = $this->objectManager();
 
         if ($objectManager instanceof DocumentManager) {
-            // mongo cannot have multi fields identifiers
-            $id = $objectManager->getClassMetadata($this->class)->getIdentifierValue($this->object);
+            $classMetadata = $objectManager->getClassMetadata($this->class);
+            if (!$classMetadata->isEmbeddedDocument) {
+                $id = $classMetadata->getIdentifierValue($this->object);
+            }
         } else {
             $id = $objectManager->getClassMetadata($this->class)->getIdentifierValues($this->object);
         }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Zenstruck\Assert;
@@ -116,11 +117,13 @@ final class Proxy
         $om = $this->objectManager();
 
         // only check for changes if the object is managed in the current om
-        if ($om instanceof EntityManagerInterface && $om->contains($this->object)) {
+        if (($om instanceof EntityManagerInterface || $om instanceof DocumentManager) && $om->contains($this->object)) {
             // cannot use UOW::recomputeSingleEntityChangeSet() here as it wrongly computes embedded objects as changed
             $om->getUnitOfWork()->computeChangeSet($om->getClassMetadata($this->class), $this->object);
 
-            if (!empty($om->getUnitOfWork()->getEntityChangeSet($this->object))) {
+            if (
+                ($om instanceof EntityManagerInterface && !empty($om->getUnitOfWork()->getEntityChangeSet($this->object))) ||
+                ($om instanceof DocumentManager && !empty($om->getUnitOfWork()->getDocumentChangeSet($this->object)))) {
                 throw new \RuntimeException(\sprintf('Cannot auto refresh "%s" as there are unsaved changes. Be sure to call ->save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details).', $this->class));
             }
         }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -279,9 +279,16 @@ final class Proxy
      */
     private function fetchObject(): ?object
     {
-        $id = $this->objectManager()->getClassMetadata($this->class)->getIdentifierValues($this->object);
+        $objectManager = $this->objectManager();
 
-        return empty($id) ? null : $this->objectManager()->find($this->class, $id);
+        if ($objectManager instanceof DocumentManager) {
+            // mongo cannot have multi fields identifiers
+            $id = $objectManager->getClassMetadata($this->class)->getIdentifierValue($this->object);
+        } else {
+            $id = $objectManager->getClassMetadata($this->class)->getIdentifierValues($this->object);
+        }
+
+        return empty($id) ? null : $objectManager->find($this->class, $id);
     }
 
     private function objectManager(): ObjectManager

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ObjectRepository;
@@ -188,6 +189,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      */
     public function truncate(): void
     {
+        /** @var DocumentManager $om */
         $om = Factory::configuration()->objectManagerFor($this->getClassName());
 
         if ($om instanceof EntityManagerInterface) {
@@ -196,12 +198,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             return;
         }
 
-        // todo: use a better way to truncate mongo collections
-        foreach ($this as $proxy) {
-            $om->remove($proxy->object());
+        if ($om instanceof DocumentManager) {
+            $om->getDocumentCollection($this->getClassName())->deleteMany([]);
         }
-
-        $om->flush();
     }
 
     /**

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -196,8 +196,9 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             return;
         }
 
-        foreach ($this as $object) {
-            $om->remove($object);
+        // todo: use a better way to truncate mongo collections
+        foreach ($this as $proxy) {
+            $om->remove($proxy->object());
         }
 
         $om->flush();

--- a/src/Test/AbstractSchemaResetter.php
+++ b/src/Test/AbstractSchemaResetter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @internal
+ */
+abstract class AbstractSchemaResetter
+{
+    abstract public function resetSchema(): void;
+
+    protected function runCommand(Application $application, string $command, array $parameters = []): void
+    {
+        $exit = $application->run(
+            new ArrayInput(\array_merge(['command' => $command], $parameters)),
+            $output = new BufferedOutput()
+        );
+
+        if (0 !== $exit) {
+            throw new \RuntimeException(\sprintf('Error running "%s": %s', $command, $output->fetch()));
+        }
+    }
+}

--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -34,8 +34,9 @@ trait Factories
                     static::bootKernel();
                 }
 
-                return static::$kernel->getContainer()->get('doctrine');
-            })
+                return TestState::initializeChainManagerRegistry(static::$kernel->getContainer());
+            }
+            )
         );
 
         $kernel->shutdown();

--- a/src/Test/ODMSchemaResetter.php
+++ b/src/Test/ODMSchemaResetter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+/**
+ * @internal
+ */
+final class ODMSchemaResetter extends AbstractSchemaResetter
+{
+    /** @var Application */
+    private $application;
+    /** @var ManagerRegistry */
+    private $registry;
+
+    public function __construct(Application $application, ManagerRegistry $registry)
+    {
+        $this->application = $application;
+        $this->registry = $registry;
+    }
+
+    public function resetSchema(): void
+    {
+        foreach ($this->objectManagersToReset() as $manager) {
+            try {
+                $this->runCommand(
+                    $this->application,
+                    'doctrine:mongodb:schema:drop',
+                    [
+                        '--dm' => $manager,
+                    ]
+                );
+            } catch (\Exception $e) {
+            }
+
+            $this->runCommand(
+                $this->application,
+                'doctrine:mongodb:schema:create',
+                [
+                    '--dm' => $manager,
+                ]
+            );
+        }
+    }
+
+    /** @return list<string> */
+    private function objectManagersToReset(): array
+    {
+        return [$this->registry->getDefaultManagerName()];
+    }
+}

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Zenstruck\Foundry\Test;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+/**
+ * @internal
+ */
+final class ORMDatabaseResetter extends AbstractSchemaResetter
+{
+    /** @var Application */
+    private $application;
+    /** @var ManagerRegistry */
+    private $registry;
+
+    public function __construct(Application $application, ManagerRegistry $registry)
+    {
+        $this->application = $application;
+        $this->registry = $registry;
+    }
+
+    public function resetDatabase(): void
+    {
+        foreach ($this->connectionsToReset() as $connection) {
+            $dropParams = ['--connection' => $connection, '--force' => true];
+
+            if ('sqlite' !== $this->registry->getConnection($connection)->getDatabasePlatform()->getName()) {
+                // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
+                $dropParams['--if-exists'] = true;
+            }
+
+            $this->runCommand($this->application, 'doctrine:database:drop', $dropParams);
+
+            $this->runCommand(
+                $this->application,
+                'doctrine:database:create',
+                [
+                    '--connection' => $connection,
+                ]
+            );
+        }
+
+        $this->createSchema();
+    }
+
+    public function resetSchema(): void
+    {
+        if (DatabaseResetter::isDAMADoctrineTestBundleEnabled()) {
+            // not required as the DAMADoctrineTestBundle wraps each test in a transaction
+            return;
+        }
+
+        $this->dropSchema();
+        $this->createSchema();
+    }
+
+    private function createSchema(): void
+    {
+        if (self::isResetUsingMigrations()) {
+            $this->runCommand($this->application, 'doctrine:migrations:migrate', ['-n' => true]);
+
+            return;
+        }
+
+        foreach ($this->objectManagersToReset() as $manager) {
+            $this->runCommand(
+                $this->application,
+                'doctrine:schema:create',
+                [
+                    '--em' => $manager,
+                ]
+            );
+        }
+    }
+
+    private function dropSchema(): void
+    {
+        if (self::isResetUsingMigrations()) {
+            $this->resetDatabase();
+
+            return;
+        }
+
+        foreach ($this->objectManagersToReset() as $manager) {
+            $this->runCommand(
+                $this->application,
+                'doctrine:schema:drop',
+                [
+                    '--em' => $manager,
+                    '--force' => true,
+                ]
+            );
+        }
+    }
+
+    /** @return list<string> */
+    private function connectionsToReset(): array
+    {
+        if (isset($_SERVER['FOUNDRY_RESET_CONNECTIONS'])) {
+            return \explode(',', $_SERVER['FOUNDRY_RESET_CONNECTIONS']);
+        }
+
+        return [$this->registry->getDefaultConnectionName()];
+    }
+
+    /** @return list<string> */
+    private function objectManagersToReset(): array
+    {
+        if (isset($_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS'])) {
+            return \explode(',', $_SERVER['FOUNDRY_RESET_OBJECT_MANAGERS']);
+        }
+
+        return [$this->registry->getDefaultManagerName()];
+    }
+
+    private static function isResetUsingMigrations(): bool
+    {
+        return 'migrate' === ($_SERVER['FOUNDRY_RESET_MODE'] ?? 'schema');
+    }
+}

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -50,11 +50,6 @@ trait ResetDatabase
      */
     public static function _resetSchema(): void
     {
-        if (DatabaseResetter::isDAMADoctrineTestBundleEnabled()) {
-            // not required as the DAMADoctrineTestBundle wraps each test in a transaction
-            return;
-        }
-
         if (!\is_subclass_of(static::class, KernelTestCase::class)) {
             throw new \RuntimeException(\sprintf('The "%s" trait can only be used on TestCases that extend "%s".', __TRAIT__, KernelTestCase::class));
         }

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -2,8 +2,10 @@
 
 namespace Zenstruck\Foundry;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Zenstruck\Foundry\Bundle\DependencyInjection\ChainManagerRegistryPass;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ZenstruckFoundryExtension;
 
 /**
@@ -18,6 +20,13 @@ final class ZenstruckFoundryBundle extends Bundle
         if (!Factory::isBooted()) {
             Factory::boot($this->container->get(Configuration::class));
         }
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ChainManagerRegistryPass());
     }
 
     protected function createContainerExtension(): ?ExtensionInterface

--- a/tests/Fixtures/Document/Category.php
+++ b/tests/Fixtures/Document/Category.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document(collection="category")
+ */
+class Category
+{
+    /**
+     * @MongoDB\Id
+     */
+    private $id;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $name;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Document/Comment.php
+++ b/tests/Fixtures/Document/Comment.php
@@ -10,7 +10,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 class Comment
 {
     /**
-     * @MongoDB\Field(type="string")
+     * @MongoDB\EmbedOne(
+     *     targetDocument=User::class
+     * )
      */
     private $user;
 
@@ -29,14 +31,14 @@ class Comment
      */
     private $approved = false;
 
-    public function __construct(string $user, string $body)
+    public function __construct(User $user, string $body)
     {
         $this->user = $user;
         $this->body = $body;
         $this->createdAt = new \DateTime('now');
     }
 
-    public function getUser(): string
+    public function getUser(): User
     {
         return $this->user;
     }

--- a/tests/Fixtures/Document/Comment.php
+++ b/tests/Fixtures/Document/Comment.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\EmbeddedDocument
+ */
+class Comment
+{
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $user;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $body;
+
+    /**
+     * @MongoDB\Field(type="date")
+     */
+    private $createdAt;
+
+    /**
+     * @MongoDB\Field(type="boolean")
+     */
+    private $approved = false;
+
+    public function __construct(string $user, string $body)
+    {
+        $this->user = $user;
+        $this->body = $body;
+        $this->createdAt = new \DateTime('now');
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(string $body): self
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getApproved(): bool
+    {
+        return $this->approved;
+    }
+
+    public function setApproved(bool $approved): self
+    {
+        $this->approved = $approved;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Document/Post.php
+++ b/tests/Fixtures/Document/Post.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 
 /**
@@ -9,6 +11,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
  */
 class Post
 {
+    /**
+     * @MongoDB\EmbedMany(
+     *     targetDocument=Comment::class
+     * )
+     */
+    protected $comments;
     /**
      * @MongoDB\Id
      */
@@ -50,6 +58,7 @@ class Post
         $this->body = $body;
         $this->shortDescription = $shortDescription;
         $this->createdAt = new \DateTime('now');
+        $this->comments = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -95,5 +104,31 @@ class Post
     public function setPublishedAt(\DateTime $timestamp)
     {
         $this->publishedAt = $timestamp;
+    }
+
+    /**
+     * @return Collection<Comment>
+     */
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
+
+    public function addComment(Comment $comment): self
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments->add($comment);
+        }
+
+        return $this;
+    }
+
+    public function removeComment(Comment $comment): self
+    {
+        if ($this->comments->contains($comment)) {
+            $this->comments->removeElement($comment);
+        }
+
+        return $this;
     }
 }

--- a/tests/Fixtures/Document/Post.php
+++ b/tests/Fixtures/Document/Post.php
@@ -12,12 +12,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 class Post
 {
     /**
-     * @MongoDB\EmbedMany(
-     *     targetDocument=Comment::class
-     * )
-     */
-    protected $comments;
-    /**
      * @MongoDB\Id
      */
     private $id;
@@ -52,13 +46,28 @@ class Post
      */
     private $publishedAt;
 
-    public function __construct(string $title, string $body, ?string $shortDescription = null)
+    /**
+     * @MongoDB\EmbedMany(
+     *     targetDocument=Comment::class
+     * )
+     */
+    private $comments;
+
+    /**
+     * @MongoDB\EmbedOne(
+     *     targetDocument=User::class
+     * )
+     */
+    private $user;
+
+    public function __construct(string $title, string $body, User $user, ?string $shortDescription = null)
     {
         $this->title = $title;
         $this->body = $body;
         $this->shortDescription = $shortDescription;
         $this->createdAt = new \DateTime('now');
         $this->comments = new ArrayCollection();
+        $this->user = $user;
     }
 
     public function __toString(): string
@@ -74,6 +83,11 @@ class Post
     public function getBody(): ?string
     {
         return $this->body;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
     }
 
     public function getShortDescription(): ?string

--- a/tests/Fixtures/Document/Post.php
+++ b/tests/Fixtures/Document/Post.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document(collection="post")
+ */
+class Post
+{
+    /**
+     * @MongoDB\Id
+     */
+    private $id;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $title;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $body;
+
+    /**
+     * @MongoDB\Field(type="string", nullable=true)
+     */
+    private $shortDescription;
+
+    /**
+     * @MongoDB\Field(type="int")
+     */
+    private $viewCount = 0;
+
+    /**
+     * @MongoDB\Field(type="date")
+     */
+    private $createdAt;
+
+    /**
+     * @MongoDB\Field(type="date", nullable=true)
+     */
+    private $publishedAt;
+
+    public function __construct(string $title, string $body, ?string $shortDescription = null)
+    {
+        $this->title = $title;
+        $this->body = $body;
+        $this->shortDescription = $shortDescription;
+        $this->createdAt = new \DateTime('now');
+    }
+
+    public function __toString(): string
+    {
+        return $this->title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function getShortDescription(): ?string
+    {
+        return $this->shortDescription;
+    }
+
+    public function getViewCount(): int
+    {
+        return $this->viewCount;
+    }
+
+    public function increaseViewCount(int $amount = 1): void
+    {
+        $this->viewCount += $amount;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function isPublished(): bool
+    {
+        return null !== $this->publishedAt;
+    }
+
+    public function setPublishedAt(\DateTime $timestamp)
+    {
+        $this->publishedAt = $timestamp;
+    }
+}

--- a/tests/Fixtures/Document/User.php
+++ b/tests/Fixtures/Document/User.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\EmbeddedDocument
+ */
+class User
+{
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/Factories/ODM/CategoryFactory.php
+++ b/tests/Fixtures/Factories/ODM/CategoryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CategoryFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return ['name' => self::faker()->sentence()];
+    }
+}

--- a/tests/Fixtures/Factories/ODM/CommentFactory.php
+++ b/tests/Fixtures/Factories/ODM/CommentFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
+
+class CommentFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return Comment::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'user' => self::faker()->userName(),
+            'body' => self::faker()->sentence(),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/ODM/CommentFactory.php
+++ b/tests/Fixtures/Factories/ODM/CommentFactory.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
 
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
+use Zenstruck\Foundry\Tests\Fixtures\Document\User;
 
 class CommentFactory extends ModelFactory
 {
@@ -15,7 +16,7 @@ class CommentFactory extends ModelFactory
     protected function getDefaults(): array
     {
         return [
-            'user' => self::faker()->userName(),
+            'user' => new User(self::faker()->userName()),
             'body' => self::faker()->sentence(),
         ];
     }

--- a/tests/Fixtures/Factories/ODM/PostFactory.php
+++ b/tests/Fixtures/Factories/ODM/PostFactory.php
@@ -2,8 +2,11 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Document\User;
 
 class PostFactory extends ModelFactory
 {
@@ -11,6 +14,18 @@ class PostFactory extends ModelFactory
     {
         return $this->addState(function() {
             return ['published_at' => self::faker()->dateTime()];
+        });
+    }
+
+    public function withComments(): self
+    {
+        return $this->addState(function() {
+            return [
+                'comments' => new ArrayCollection([
+                    new Comment(new User('user'), 'body'),
+                    new Comment(new User('user'), 'body'),
+                ]),
+            ];
         });
     }
 
@@ -24,6 +39,7 @@ class PostFactory extends ModelFactory
         return [
             'title' => self::faker()->sentence(),
             'body' => self::faker()->sentence(),
+            'user' => new User('user'),
         ];
     }
 }

--- a/tests/Fixtures/Factories/ODM/PostFactory.php
+++ b/tests/Fixtures/Factories/ODM/PostFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
+
+class PostFactory extends ModelFactory
+{
+    public function published(): self
+    {
+        return $this->addState(function() {
+            return ['published_at' => self::faker()->dateTime()];
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return Post::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'title' => self::faker()->sentence(),
+            'body' => self::faker()->sentence(),
+        ];
+    }
+}

--- a/tests/Functional/AnonymousFactoryTest.php
+++ b/tests/Functional/AnonymousFactoryTest.php
@@ -6,12 +6,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class AnonymousFactoryTest extends KernelTestCase
+abstract class AnonymousFactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
@@ -20,7 +19,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_or_create(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $factory->assert()->count(0);
         $factory->findOrCreate(['name' => 'php']);
@@ -34,7 +33,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $ids = [];
@@ -51,12 +50,12 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_create_random_object_if_none_exists(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $factory->assert()->count(0);
-        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $this->assertInstanceOf($this->categoryClass(), $factory->randomOrCreate()->object());
         $factory->assert()->count(1);
-        $this->assertInstanceOf(Category::class, $factory->randomOrCreate()->object());
+        $this->assertInstanceOf($this->categoryClass(), $factory->randomOrCreate()->object());
         $factory->assert()->count(1);
     }
 
@@ -65,7 +64,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_get_or_create_random_object_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'name1']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'name1']);
         $factory->many(5)->create();
 
         $factory->assert()->count(5);
@@ -80,7 +79,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $objects = $factory->randomSet(3);
@@ -94,7 +93,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $factory->many(20)->create(['name' => 'name1']);
         $factory->many(5)->create(['name' => 'name2']);
 
@@ -110,7 +109,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
         $factory->many(5)->create();
 
         $counts = [];
@@ -133,7 +132,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects_with_attributes(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $factory->many(20)->create(['name' => 'name1']);
         $factory->many(5)->create(['name' => 'name2']);
 
@@ -152,7 +151,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function first_and_last_return_the_correct_object(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
         $categoryA = $factory->create(['name' => '3']);
         $categoryB = $factory->create(['name' => '2']);
         $categoryC = $factory->create(['name' => '1']);
@@ -170,7 +169,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->first();
+        AnonymousFactory::new($this->categoryClass())->first();
     }
 
     /**
@@ -180,7 +179,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->last();
+        AnonymousFactory::new($this->categoryClass())->last();
     }
 
     /**
@@ -188,7 +187,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_count_and_truncate_model_factory(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $this->assertSame(0, $factory->count());
         $this->assertCount(0, $factory);
@@ -209,7 +208,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_get_all_entities(): void
     {
-        $factory = AnonymousFactory::new(Category::class, ['name' => 'php']);
+        $factory = AnonymousFactory::new($this->categoryClass(), ['name' => 'php']);
 
         $this->assertSame([], $factory->all());
 
@@ -219,10 +218,10 @@ final class AnonymousFactoryTest extends KernelTestCase
 
         $this->assertCount(4, $categories);
         $this->assertCount(4, \iterator_to_array($factory));
-        $this->assertInstanceOf(Category::class, $categories[0]->object());
-        $this->assertInstanceOf(Category::class, $categories[1]->object());
-        $this->assertInstanceOf(Category::class, $categories[2]->object());
-        $this->assertInstanceOf(Category::class, $categories[3]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[0]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[1]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[2]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[3]->object());
     }
 
     /**
@@ -230,7 +229,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_entity(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $factory->create(['name' => 'first']);
         $factory->create(['name' => 'second']);
@@ -239,6 +238,11 @@ final class AnonymousFactoryTest extends KernelTestCase
         $this->assertSame('second', $factory->find(['name' => 'second'])->getName());
         $this->assertSame('third', $factory->find(['id' => $category->getId()])->getName());
         $this->assertSame('third', $factory->find($category->getId())->getName());
+
+        if ($this instanceof ODMAnonymousFactoryTest) {
+            return;
+        }
+
         $this->assertSame('third', $factory->find($category->object())->getName());
         $this->assertSame('third', $factory->find($category)->getName());
     }
@@ -250,7 +254,7 @@ final class AnonymousFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        AnonymousFactory::new(Category::class)->find(99);
+        AnonymousFactory::new($this->categoryClass())->find(99);
     }
 
     /**
@@ -258,7 +262,7 @@ final class AnonymousFactoryTest extends KernelTestCase
      */
     public function can_find_by(): void
     {
-        $factory = AnonymousFactory::new(Category::class);
+        $factory = AnonymousFactory::new($this->categoryClass());
 
         $this->assertSame([], $factory->findBy(['name' => 'name2']));
 
@@ -272,4 +276,6 @@ final class AnonymousFactoryTest extends KernelTestCase
         $this->assertSame('name2', $categories[0]->getName());
         $this->assertSame('name2', $categories[1]->getName());
     }
+
+    abstract protected function categoryClass(): string;
 }

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -420,12 +420,12 @@ EOF
 
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
 
-        $this->assertFileDoesNotExist(self::tempFile("src/Factory/$file.php"));
+        $this->assertFileDoesNotExist(self::tempFile("src/Factory/{$file}.php"));
 
         $tester->setInputs([$class]);
         $tester->execute([]);
 
-        $this->assertFileExists(self::tempFile("src/Factory/$file.php"));
+        $this->assertFileExists(self::tempFile("src/Factory/{$file}.php"));
     }
 
     public function documentProvider(): iterable

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
 
@@ -407,7 +408,11 @@ EOF
         $this->assertStringContainsString('namespace App\\Tests\\My\\Namespace;', \file_get_contents($expectedFile));
     }
 
-    public function can_create_factory_for_embedded_document(): void
+    /**
+     * @test
+     * @dataProvider documentProvider
+     */
+    public function can_create_factory_for_odm(string $class, string $file): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');
@@ -415,11 +420,17 @@ EOF
 
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
 
-        $this->assertFileDoesNotExist(self::tempFile('src/Factory/CommentFactory.php'));
+        $this->assertFileDoesNotExist(self::tempFile("src/Factory/$file.php"));
 
-        $tester->setInputs([Comment::class]);
+        $tester->setInputs([$class]);
         $tester->execute([]);
 
-        $this->assertFileExists(self::tempFile('src/Factory/CommentFactory.php'));
+        $this->assertFileExists(self::tempFile("src/Factory/$file.php"));
+    }
+
+    public function documentProvider(): iterable
+    {
+        yield 'document' => [Post::class, 'PostFactory'];
+        yield 'embedded document' => [Comment::class, 'CommentFactory'];
     }
 }

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Foundry\Tests\Functional\Bundle\Maker;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
 
@@ -404,5 +405,21 @@ EOF
 
         $this->assertFileExists($expectedFile);
         $this->assertStringContainsString('namespace App\\Tests\\My\\Namespace;', \file_get_contents($expectedFile));
+    }
+
+    public function can_create_factory_for_embedded_document(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+
+        $this->assertFileDoesNotExist(self::tempFile('src/Factory/CommentFactory.php'));
+
+        $tester->setInputs([Comment::class]);
+        $tester->execute([]);
+
+        $this->assertFileExists(self::tempFile('src/Factory/CommentFactory.php'));
     }
 }

--- a/tests/Functional/ContainerBC.php
+++ b/tests/Functional/ContainerBC.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
  */
 trait ContainerBC
 {
-    private static function container(): ContainerInterface
+    protected static function container(): ContainerInterface
     {
         if (!\method_exists(static::class, 'getContainer')) {
             if (!static::$booted) {

--- a/tests/Functional/FactoryDoctrineCascadeTest.php
+++ b/tests/Functional/FactoryDoctrineCascadeTest.php
@@ -22,6 +22,13 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    protected function setUp(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -20,7 +20,7 @@ final class FactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -20,6 +20,13 @@ final class FactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -20,7 +20,7 @@ final class FactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -15,6 +15,13 @@ final class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -15,7 +15,7 @@ final class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -15,7 +15,7 @@ final class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -15,7 +15,7 @@ final class ModelFactoryServiceTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -15,6 +15,13 @@ final class ModelFactoryServiceTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -15,7 +15,7 @@ final class ModelFactoryServiceTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -2,26 +2,21 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ContactFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class ModelFactoryTest extends KernelTestCase
+abstract class ModelFactoryTest extends KernelTestCase
 {
     use ContainerBC, Factories, ResetDatabase;
 
@@ -30,42 +25,13 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_or_create(): void
     {
-        CategoryFactory::assert()->count(0);
-        CategoryFactory::findOrCreate(['name' => 'php']);
-        CategoryFactory::assert()->count(1);
-        CategoryFactory::findOrCreate(['name' => 'php']);
-        CategoryFactory::assert()->count(1);
-    }
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-    /**
-     * @test
-     */
-    public function can_override_initialize(): void
-    {
-        $this->assertFalse(PostFactory::createOne()->isPublished());
-        $this->assertTrue(PostFactoryWithValidInitialize::createOne()->isPublished());
-    }
-
-    /**
-     * @test
-     */
-    public function initialize_must_return_an_instance_of_the_current_factory(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithInvalidInitialize::class));
-
-        PostFactoryWithInvalidInitialize::new();
-    }
-
-    /**
-     * @test
-     */
-    public function initialize_must_return_a_value(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithNullInitialize::class));
-
-        PostFactoryWithNullInitialize::new();
+        $categoryFactoryClass::assert()->count(0);
+        $categoryFactoryClass::findOrCreate(['name' => 'php']);
+        $categoryFactoryClass::assert()->count(1);
+        $categoryFactoryClass::findOrCreate(['name' => 'php']);
+        $categoryFactoryClass::assert()->count(1);
     }
 
     /**
@@ -73,12 +39,14 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_object(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::createMany(5);
 
         $ids = [];
 
         while (5 !== \count(\array_unique($ids))) {
-            $ids[] = CategoryFactory::random()->getId();
+            $ids[] = $categoryFactoryClass::random()->getId();
         }
 
         $this->assertCount(5, \array_unique($ids));
@@ -89,11 +57,13 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_create_random_object_if_none_exists(): void
     {
-        CategoryFactory::assert()->count(0);
-        $this->assertInstanceOf(Category::class, CategoryFactory::randomOrCreate()->object());
-        CategoryFactory::assert()->count(1);
-        $this->assertInstanceOf(Category::class, CategoryFactory::randomOrCreate()->object());
-        CategoryFactory::assert()->count(1);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::assert()->count(0);
+        $this->assertInstanceOf($this->categoryClass(), $categoryFactoryClass::randomOrCreate()->object());
+        $categoryFactoryClass::assert()->count(1);
+        $this->assertInstanceOf($this->categoryClass(), $categoryFactoryClass::randomOrCreate()->object());
+        $categoryFactoryClass::assert()->count(1);
     }
 
     /**
@@ -101,13 +71,15 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_get_or_create_random_object_with_attributes(): void
     {
-        CategoryFactory::createMany(5, ['name' => 'name1']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::assert()->count(5);
-        $this->assertSame('name2', CategoryFactory::randomOrCreate(['name' => 'name2'])->getName());
-        CategoryFactory::assert()->count(6);
-        $this->assertSame('name2', CategoryFactory::randomOrCreate(['name' => 'name2'])->getName());
-        CategoryFactory::assert()->count(6);
+        $categoryFactoryClass::createMany(5, ['name' => 'name1']);
+
+        $categoryFactoryClass::assert()->count(5);
+        $this->assertSame('name2', $categoryFactoryClass::randomOrCreate(['name' => 'name2'])->getName());
+        $categoryFactoryClass::assert()->count(6);
+        $this->assertSame('name2', $categoryFactoryClass::randomOrCreate(['name' => 'name2'])->getName());
+        $categoryFactoryClass::assert()->count(6);
     }
 
     /**
@@ -115,9 +87,11 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomSet(3);
+        $categoryFactoryClass::createMany(5);
+
+        $objects = $categoryFactoryClass::randomSet(3);
 
         $this->assertCount(3, $objects);
         $this->assertCount(3, \array_unique(\array_map(static function($category) { return $category->getId(); }, $objects)));
@@ -128,10 +102,12 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_set_of_objects_with_attributes(): void
     {
-        CategoryFactory::createMany(20, ['name' => 'name1']);
-        CategoryFactory::createMany(5, ['name' => 'name2']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomSet(2, ['name' => 'name2']);
+        $categoryFactoryClass::createMany(20, ['name' => 'name1']);
+        $categoryFactoryClass::createMany(5, ['name' => 'name2']);
+
+        $objects = $categoryFactoryClass::randomSet(2, ['name' => 'name2']);
 
         $this->assertCount(2, $objects);
         $this->assertSame('name2', $objects[0]->getName());
@@ -143,12 +119,14 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects(): void
     {
-        CategoryFactory::createMany(5);
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::createMany(5);
 
         $counts = [];
 
         while (4 !== \count(\array_unique($counts))) {
-            $counts[] = \count(CategoryFactory::randomRange(0, 3));
+            $counts[] = \count($categoryFactoryClass::randomRange(0, 3));
         }
 
         $this->assertCount(4, \array_unique($counts));
@@ -165,10 +143,12 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_random_range_of_objects_with_attributes(): void
     {
-        CategoryFactory::createMany(20, ['name' => 'name1']);
-        CategoryFactory::createMany(5, ['name' => 'name2']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $objects = CategoryFactory::randomRange(2, 4, ['name' => 'name2']);
+        $categoryFactoryClass::createMany(20, ['name' => 'name1']);
+        $categoryFactoryClass::createMany(5, ['name' => 'name2']);
+
+        $objects = $categoryFactoryClass::randomRange(2, 4, ['name' => 'name2']);
 
         $this->assertGreaterThanOrEqual(2, \count($objects));
         $this->assertLessThanOrEqual(4, \count($objects));
@@ -335,14 +315,16 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function first_and_last_return_the_correct_object(): void
     {
-        $categoryA = CategoryFactory::createOne(['name' => '3']);
-        $categoryB = CategoryFactory::createOne(['name' => '2']);
-        $categoryC = CategoryFactory::createOne(['name' => '1']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $this->assertSame($categoryA->getId(), CategoryFactory::first()->getId());
-        $this->assertSame($categoryC->getId(), CategoryFactory::first('name')->getId());
-        $this->assertSame($categoryC->getId(), CategoryFactory::last()->getId());
-        $this->assertSame($categoryA->getId(), CategoryFactory::last('name')->getId());
+        $categoryA = $categoryFactoryClass::createOne(['name' => '3']);
+        $categoryB = $categoryFactoryClass::createOne(['name' => '2']);
+        $categoryC = $categoryFactoryClass::createOne(['name' => '1']);
+
+        $this->assertSame($categoryA->getId(), $categoryFactoryClass::first()->getId());
+        $this->assertSame($categoryC->getId(), $categoryFactoryClass::first('name')->getId());
+        $this->assertSame($categoryC->getId(), $categoryFactoryClass::last()->getId());
+        $this->assertSame($categoryA->getId(), $categoryFactoryClass::last('name')->getId());
     }
 
     /**
@@ -352,7 +334,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::first();
+        $this->categoryFactoryClass()::first();
     }
 
     /**
@@ -362,7 +344,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::last();
+        $this->categoryFactoryClass()::last();
     }
 
     /**
@@ -370,15 +352,17 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_count_and_truncate_model_factory(): void
     {
-        $this->assertSame(0, CategoryFactory::count());
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createMany(4);
+        $this->assertSame(0, $categoryFactoryClass::count());
 
-        $this->assertSame(4, CategoryFactory::count());
+        $categoryFactoryClass::createMany(4);
 
-        CategoryFactory::truncate();
+        $this->assertSame(4, $categoryFactoryClass::count());
 
-        $this->assertSame(0, CategoryFactory::count());
+        $categoryFactoryClass::truncate();
+
+        $this->assertSame(0, $categoryFactoryClass::count());
     }
 
     /**
@@ -386,17 +370,19 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_get_all_entities(): void
     {
-        $this->assertSame([], CategoryFactory::all());
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createMany(4);
+        $this->assertSame([], $categoryFactoryClass::all());
 
-        $categories = CategoryFactory::all();
+        $categoryFactoryClass::createMany(4);
+
+        $categories = $categoryFactoryClass::all();
 
         $this->assertCount(4, $categories);
-        $this->assertInstanceOf(Category::class, $categories[0]->object());
-        $this->assertInstanceOf(Category::class, $categories[1]->object());
-        $this->assertInstanceOf(Category::class, $categories[2]->object());
-        $this->assertInstanceOf(Category::class, $categories[3]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[0]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[1]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[2]->object());
+        $this->assertInstanceOf($this->categoryClass(), $categories[3]->object());
     }
 
     /**
@@ -404,15 +390,20 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_entity(): void
     {
-        CategoryFactory::createOne(['name' => 'first']);
-        CategoryFactory::createOne(['name' => 'second']);
-        $category = CategoryFactory::createOne(['name' => 'third']);
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        $this->assertSame('second', CategoryFactory::find(['name' => 'second'])->getName());
-        $this->assertSame('third', CategoryFactory::find(['id' => $category->getId()])->getName());
-        $this->assertSame('third', CategoryFactory::find($category->getId())->getName());
-        $this->assertSame('third', CategoryFactory::find($category->object())->getName());
-        $this->assertSame('third', CategoryFactory::find($category)->getName());
+        $categoryFactoryClass::createOne(['name' => 'first']);
+        $categoryFactoryClass::createOne(['name' => 'second']);
+        $category = $categoryFactoryClass::createOne(['name' => 'third']);
+
+        $this->assertSame('second', $categoryFactoryClass::find(['name' => 'second'])->getName());
+        $this->assertSame('third', $categoryFactoryClass::find(['id' => $category->getId()])->getName());
+        $this->assertSame('third', $categoryFactoryClass::find($category->getId())->getName());
+
+        if ($this instanceof ORMModelFactoryTest) {
+            $this->assertSame('third', $categoryFactoryClass::find($category)->getName());
+            $this->assertSame('third', $categoryFactoryClass::find($category->object())->getName());
+        }
     }
 
     /**
@@ -422,7 +413,7 @@ final class ModelFactoryTest extends KernelTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        CategoryFactory::find(99);
+        $this->categoryFactoryClass()::find(99);
     }
 
     /**
@@ -430,13 +421,15 @@ final class ModelFactoryTest extends KernelTestCase
      */
     public function can_find_by(): void
     {
-        $this->assertSame([], CategoryFactory::findBy(['name' => 'name2']));
+        $categoryFactoryClass = $this->categoryFactoryClass();
 
-        CategoryFactory::createOne(['name' => 'name1']);
-        CategoryFactory::createOne(['name' => 'name2']);
-        CategoryFactory::createOne(['name' => 'name2']);
+        $this->assertSame([], $categoryFactoryClass::findBy(['name' => 'name2']));
 
-        $categories = CategoryFactory::findBy(['name' => 'name2']);
+        $categoryFactoryClass::createOne(['name' => 'name1']);
+        $categoryFactoryClass::createOne(['name' => 'name2']);
+        $categoryFactoryClass::createOne(['name' => 'name2']);
+
+        $categories = $categoryFactoryClass::findBy(['name' => 'name2']);
 
         $this->assertCount(2, $categories);
         $this->assertSame('name2', $categories[0]->getName());
@@ -468,4 +461,8 @@ final class ModelFactoryTest extends KernelTestCase
         $this->assertSame('Sally', $object->getName());
         $this->assertSame('Some address', $object->getAddress()->getValue());
     }
+
+    abstract protected function categoryClass(): string;
+
+    abstract protected function categoryFactoryClass(): string;
 }

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -5,13 +5,6 @@ namespace Zenstruck\Foundry\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\ContactFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -161,158 +154,6 @@ abstract class ModelFactoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function one_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::createOne([
-            'comments' => CommentFactory::new()->many(4),
-        ]);
-
-        $this->assertCount(4, $post->getComments());
-        UserFactory::assert()->count(4);
-        CommentFactory::assert()->count(4);
-        PostFactory::assert()->count(1);
-    }
-
-    /**
-     * @test
-     */
-    public function create_multiple_one_to_many_with_nested_collection_relationship(): void
-    {
-        $user = UserFactory::createOne();
-        $posts = PostFactory::createMany(2, [
-            'comments' => CommentFactory::new(['user' => $user])->many(4),
-        ]);
-
-        $this->assertCount(4, $posts[0]->getComments());
-        $this->assertCount(4, $posts[1]->getComments());
-        UserFactory::assert()->count(1);
-        CommentFactory::assert()->count(8);
-        PostFactory::assert()->count(2);
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::createOne([
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(5); // 3 created by this test and 2 in global state
-        PostFactory::assert()->count(1);
-    }
-
-    /**
-     * @test
-     */
-    public function inverse_many_to_many_with_nested_collection_relationship(): void
-    {
-        $tag = TagFactory::createOne([
-            'posts' => PostFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $tag->getPosts());
-        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
-        PostFactory::assert()->count(3);
-    }
-
-    /**
-     * @test
-     */
-    public function create_multiple_many_to_many_with_nested_collection_relationship(): void
-    {
-        $posts = PostFactory::createMany(2, [
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $posts[0]->getTags());
-        $this->assertCount(3, $posts[1]->getTags());
-        TagFactory::assert()->count(8); // 6 created by this test and 2 in global state
-        PostFactory::assert()->count(2);
-    }
-
-    /**
-     * @test
-     */
-    public function unpersisted_one_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::new()->withoutPersisting()->create([
-            'comments' => CommentFactory::new()->many(4),
-        ]);
-
-        $this->assertCount(4, $post->getComments());
-        UserFactory::assert()->empty();
-        CommentFactory::assert()->empty();
-        PostFactory::assert()->empty();
-    }
-
-    /**
-     * @test
-     */
-    public function unpersisted_many_to_many_with_nested_collection_relationship(): void
-    {
-        $post = PostFactory::new()->withoutPersisting()->create([
-            'tags' => TagFactory::new()->many(3),
-        ]);
-
-        $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(2); // 2 created in global state
-        PostFactory::assert()->empty();
-    }
-
-    /**
-     * @test
-     * @dataProvider dataProvider
-     */
-    public function can_use_model_factories_in_a_data_provider(PostFactory $factory, bool $published): void
-    {
-        $post = $factory->create();
-
-        $post->assertPersisted();
-        $this->assertSame($published, $post->isPublished());
-    }
-
-    public static function dataProvider(): array
-    {
-        return [
-            [PostFactory::new(), false],
-            [PostFactory::new()->published(), true],
-        ];
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_one_unmanaged_entity(): void
-    {
-        $category = CategoryFactory::createOne(['name' => 'My Category']);
-
-        self::container()->get(EntityManagerInterface::class)->clear();
-
-        $post = PostFactory::createOne(['category' => $category]);
-
-        $this->assertSame('My Category', $post->getCategory()->getName());
-    }
-
-    /**
-     * @test
-     */
-    public function many_to_one_unmanaged_raw_entity(): void
-    {
-        $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
-
-        self::container()->get(EntityManagerInterface::class)->clear();
-
-        $post = PostFactory::createOne(['category' => $category]);
-
-        $this->assertSame('My Category', $post->getCategory()->getName());
-    }
-
-    /**
-     * @test
-     */
     public function first_and_last_return_the_correct_object(): void
     {
         $categoryFactoryClass = $this->categoryFactoryClass();
@@ -434,32 +275,6 @@ abstract class ModelFactoryTest extends KernelTestCase
         $this->assertCount(2, $categories);
         $this->assertSame('name2', $categories[0]->getName());
         $this->assertSame('name2', $categories[1]->getName());
-    }
-
-    /**
-     * @test
-     */
-    public function embeddables_are_never_persisted(): void
-    {
-        $object1 = AddressFactory::createOne();
-        $object2 = AddressFactory::createOne(['value' => 'another address']);
-
-        $this->assertSame('Some address', $object1->getValue());
-        $this->assertSame('another address', $object2->getValue());
-    }
-
-    /**
-     * @test
-     */
-    public function factory_with_embeddable(): void
-    {
-        ContactFactory::repository()->assert()->empty();
-
-        $object = ContactFactory::createOne();
-
-        ContactFactory::repository()->assert()->count(1);
-        $this->assertSame('Sally', $object->getName());
-        $this->assertSame('Some address', $object->getAddress()->getValue());
     }
 
     abstract protected function categoryClass(): string;

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+}

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
  */
 final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
  */
 final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -15,7 +15,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMModelFactoryTest extends ModelFactoryTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -2,8 +2,13 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -15,6 +20,39 @@ final class ODMModelFactoryTest extends ModelFactoryTest
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');
         }
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_factory_for_embedded_object(): void
+    {
+        $proxyObject = CommentFactory::createOne(['user' => 'some user', 'body' => 'some body']);
+        self::assertInstanceOf(Proxy::class, $proxyObject);
+        self::assertFalse($proxyObject->isPersisted());
+
+        $comment = $proxyObject->object();
+        self::assertInstanceOf(Comment::class, $comment);
+        self::assertSame('some user', $comment->getUser());
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_embed_many_fields(): void
+    {
+        PostFactory::createOne([
+            'title' => 'foo',
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $posts = PostFactory::findBy(['title' => 'foo']);
+        self::assertCount(1, $posts);
+
+        $post = $posts[0]->object();
+        self::assertInstanceOf(Post::class, $post);
+        self::assertCount(4, $post->getComments());
+        self::assertContainsOnlyInstancesOf(Comment::class, $post->getComments());
     }
 
     protected function categoryClass(): string

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -6,6 +6,7 @@ use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Document\User;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
@@ -27,13 +28,14 @@ final class ODMModelFactoryTest extends ModelFactoryTest
      */
     public function can_use_factory_for_embedded_object(): void
     {
-        $proxyObject = CommentFactory::createOne(['user' => 'some user', 'body' => 'some body']);
+        $proxyObject = CommentFactory::createOne(['user' => new User('some user'), 'body' => 'some body']);
         self::assertInstanceOf(Proxy::class, $proxyObject);
         self::assertFalse($proxyObject->isPersisted());
 
         $comment = $proxyObject->object();
         self::assertInstanceOf(Comment::class, $comment);
-        self::assertSame('some user', $comment->getUser());
+        self::assertEquals(new User('some user'), $comment->getUser());
+        self::assertSame('some body', $comment->getBody());
     }
 
     /**
@@ -53,6 +55,17 @@ final class ODMModelFactoryTest extends ModelFactoryTest
         self::assertInstanceOf(Post::class, $post);
         self::assertCount(4, $post->getComments());
         self::assertContainsOnlyInstancesOf(Comment::class, $post->getComments());
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_one_with_nested_embedded(): void
+    {
+        PostFactory::new()->withComments()->create(['title' => 'foo']);
+
+        $posts = PostFactory::findBy(['title' => 'foo']);
+        self::assertCount(1, $posts);
     }
 
     protected function categoryClass(): string

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -15,7 +15,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMModelFactoryTest extends ModelFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMModelFactoryTest extends ModelFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
 
 /**
@@ -19,6 +20,11 @@ final class ODMProxyTest extends ProxyTest
     protected function postFactoryClass(): string
     {
         return PostFactory::class;
+    }
+
+    protected function postClass(): string
+    {
+        return Post::class;
     }
 
     protected function registryServiceId(): string

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMProxyTest extends ProxyTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMProxyTest extends ProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function postFactoryClass(): string
+    {
+        return PostFactory::class;
+    }
+
+    protected function registryServiceId(): string
+    {
+        return 'doctrine_mongodb';
+    }
+}

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMProxyTest extends ProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMRepositoryProxyTest.php
+++ b/tests/Functional/ODMRepositoryProxyTest.php
@@ -10,7 +10,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
  */
 final class ODMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMRepositoryProxyTest.php
+++ b/tests/Functional/ODMRepositoryProxyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ODMRepositoryProxyTest extends RepositoryProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ODMRepositoryProxyTest.php
+++ b/tests/Functional/ODMRepositoryProxyTest.php
@@ -10,7 +10,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
  */
 final class ODMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
  */
 final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
  */
 final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -18,7 +18,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
  */
 final class ORMModelFactoryTest extends ModelFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMModelFactoryTest extends ModelFactoryTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_initialize(): void
+    {
+        $this->assertFalse(PostFactory::createOne()->isPublished());
+        $this->assertTrue(PostFactoryWithValidInitialize::createOne()->isPublished());
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_an_instance_of_the_current_factory(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithInvalidInitialize::class));
+
+        PostFactoryWithInvalidInitialize::new();
+    }
+
+    /**
+     * @test
+     */
+    public function initialize_must_return_a_value(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(\sprintf('"%1$s::initialize()" must return an instance of "%1$s".', PostFactoryWithNullInitialize::class));
+
+        PostFactoryWithNullInitialize::new();
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::createOne([
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $this->assertCount(4, $post->getComments());
+        UserFactory::assert()->count(4);
+        CommentFactory::assert()->count(4);
+        PostFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function create_multiple_one_to_many_with_nested_collection_relationship(): void
+    {
+        $user = UserFactory::createOne();
+        $posts = PostFactory::createMany(2, [
+            'comments' => CommentFactory::new(['user' => $user])->many(4),
+        ]);
+
+        $this->assertCount(4, $posts[0]->getComments());
+        $this->assertCount(4, $posts[1]->getComments());
+        UserFactory::assert()->count(1);
+        CommentFactory::assert()->count(8);
+        PostFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::createOne([
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $post->getTags());
+        TagFactory::assert()->count(5); // 3 created by this test and 2 in global state
+        PostFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function inverse_many_to_many_with_nested_collection_relationship(): void
+    {
+        $tag = TagFactory::createOne([
+            'posts' => PostFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $tag->getPosts());
+        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
+        PostFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
+    public function create_multiple_many_to_many_with_nested_collection_relationship(): void
+    {
+        $posts = PostFactory::createMany(2, [
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $posts[0]->getTags());
+        $this->assertCount(3, $posts[1]->getTags());
+        TagFactory::assert()->count(8); // 6 created by this test and 2 in global state
+        PostFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    public function unpersisted_one_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::new()->withoutPersisting()->create([
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $this->assertCount(4, $post->getComments());
+        UserFactory::assert()->empty();
+        CommentFactory::assert()->empty();
+        PostFactory::assert()->empty();
+    }
+
+    /**
+     * @test
+     */
+    public function unpersisted_many_to_many_with_nested_collection_relationship(): void
+    {
+        $post = PostFactory::new()->withoutPersisting()->create([
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $post->getTags());
+        TagFactory::assert()->count(2); // 2 created in global state
+        PostFactory::assert()->empty();
+    }
+
+    /**
+     * @test
+     * @dataProvider dataProvider
+     */
+    public function can_use_model_factories_in_a_data_provider(PostFactory $factory, bool $published): void
+    {
+        $post = $factory->create();
+
+        $post->assertPersisted();
+        $this->assertSame($published, $post->isPublished());
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            [PostFactory::new(), false],
+            [PostFactory::new()->published(), true],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category']);
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_unmanaged_raw_entity(): void
+    {
+        $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
+
+        self::$container->get(EntityManagerInterface::class)->clear();
+
+        $post = PostFactory::createOne(['category' => $category]);
+
+        $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -4,8 +4,10 @@ namespace Zenstruck\Foundry\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ContactFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
@@ -187,7 +189,7 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     {
         $category = CategoryFactory::createOne(['name' => 'My Category']);
 
-        self::$container->get(EntityManagerInterface::class)->clear();
+        self::container()->get(EntityManagerInterface::class)->clear();
 
         $post = PostFactory::createOne(['category' => $category]);
 
@@ -201,11 +203,37 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     {
         $category = CategoryFactory::createOne(['name' => 'My Category'])->object();
 
-        self::$container->get(EntityManagerInterface::class)->clear();
+        self::container()->get(EntityManagerInterface::class)->clear();
 
         $post = PostFactory::createOne(['category' => $category]);
 
         $this->assertSame('My Category', $post->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function factory_with_embeddable(): void
+    {
+        ContactFactory::repository()->assert()->empty();
+
+        $object = ContactFactory::createOne();
+
+        ContactFactory::repository()->assert()->count(1);
+        $this->assertSame('Sally', $object->getName());
+        $this->assertSame('Some address', $object->getAddress()->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function embeddables_are_never_persisted(): void
+    {
+        $object1 = AddressFactory::createOne();
+        $object2 = AddressFactory::createOne(['value' => 'another address']);
+
+        $this->assertSame('Some address', $object1->getValue());
+        $this->assertSame('another address', $object2->getValue());
     }
 
     protected function categoryClass(): string

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -18,7 +18,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
  */
 final class ORMModelFactoryTest extends ModelFactoryTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -13,7 +13,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
  */
 final class ORMProxyTest extends ProxyTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\AnonymousFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMProxyTest extends ProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     * @requires PHP >= 7.4
+     */
+    public function cannot_convert_to_string_if_underlying_object_cant(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Proxied object "%s" cannot be converted to a string.', Category::class));
+
+        (string) CategoryFactory::createOne();
+    }
+
+    /**
+     * @test
+     * @requires PHP < 7.4
+     */
+    public function on_php_versions_less_than_7_4_if_underlying_object_is_missing_to_string_proxy_to_string_returns_note(): void
+    {
+        $this->assertSame('(no __toString)', (string) CategoryFactory::createOne());
+    }
+
+    /**
+     * @test
+     */
+    public function can_autorefresh_entity_with_embedded_object(): void
+    {
+        $contact = AnonymousFactory::new(Contact::class)->create(['name' => 'john'])
+            ->enableAutoRefresh()
+        ;
+
+        $this->assertSame('john', $contact->getName());
+
+        // I discovered when autorefreshing the second time, the embedded
+        // object is included in the changeset when using UOW::recomputeSingleEntityChangeSet().
+        // Changing to UOW::computeChangeSet() fixes this.
+        $this->assertSame('john', $contact->getName());
+        $this->assertNull($contact->getAddress()->getValue());
+
+        $contact->getAddress()->setValue('address');
+        $contact->save();
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+
+        self::ensureKernelShutdown();
+        self::bootKernel();
+
+        $this->assertSame('address', $contact->getAddress()->getValue());
+    }
+
+    protected function postFactoryClass(): string
+    {
+        return PostFactory::class;
+    }
+
+    protected function registryServiceId(): string
+    {
+        return 'doctrine';
+    }
+}

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -13,7 +13,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
  */
 final class ORMProxyTest extends ProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Foundry\Tests\Functional;
 use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 
@@ -72,6 +73,11 @@ final class ORMProxyTest extends ProxyTest
     protected function postFactoryClass(): string
     {
         return PostFactory::class;
+    }
+
+    protected function postClass(): string
+    {
+        return Post::class;
     }
 
     protected function registryServiceId(): string

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Doctrine\Common\Proxy\Proxy as DoctrineProxy;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use function Zenstruck\Foundry\repository;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ORMRepositoryProxyTest extends RepositoryProxyTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function functions_calls_are_passed_to_underlying_repository(): void
+    {
+        $this->assertSame('from custom method', repository(Post::class)->customMethod());
+    }
+
+    /**
+     * @see https://github.com/zenstruck/foundry/issues/42
+     *
+     * @test
+     */
+    public function doctrine_proxies_are_converted_to_foundry_proxies(): void
+    {
+        PostFactory::createOne(['category' => CategoryFactory::new()]);
+
+        // clear the em so nothing is tracked
+        static::$kernel->getContainer()->get('doctrine')->getManager()->clear();
+
+        // load a random Post which causes the em to track a "doctrine proxy" for category
+        PostFactory::random();
+
+        // load a random Category which should be a "doctrine proxy"
+        $category = CategoryFactory::random()->object();
+
+        // ensure the category is a "doctrine proxy" and a Category
+        $this->assertInstanceOf(DoctrineProxy::class, $category);
+        $this->assertInstanceOf(Category::class, $category);
+    }
+
+    /**
+     * @test
+     */
+    public function proxy_wrapping_orm_entity_manager_can_order_by_in_find_one_by(): void
+    {
+        $categoryA = CategoryFactory::createOne();
+        $categoryB = CategoryFactory::createOne();
+        $categoryC = CategoryFactory::createOne();
+
+        $this->assertSame($categoryC->getId(), CategoryFactory::repository()->findOneBy([], ['id' => 'DESC'])->getId());
+    }
+
+    protected function categoryClass(): string
+    {
+        return Category::class;
+    }
+
+    protected function categoryFactoryClass(): string
+    {
+        return CategoryFactory::class;
+    }
+}

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -14,7 +14,7 @@ use function Zenstruck\Foundry\repository;
  */
 final class ORMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -14,7 +14,7 @@ use function Zenstruck\Foundry\repository;
  */
 final class ORMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ProxyTest.php
+++ b/tests/Functional/ProxyTest.php
@@ -8,7 +8,6 @@ use Zenstruck\Assert;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -25,7 +24,7 @@ abstract class ProxyTest extends KernelTestCase
         $this->postFactoryClass()::createOne()->assertPersisted();
 
         Assert::that(function() { $this->postFactoryClass()::new()->withoutPersisting()->create()->assertPersisted(); })
-            ->throws(AssertionFailedError::class, \sprintf('%s is not persisted.', Post::class))
+            ->throws(AssertionFailedError::class, \sprintf('%s is not persisted.', $this->postClass()))
         ;
     }
 
@@ -37,7 +36,7 @@ abstract class ProxyTest extends KernelTestCase
         $this->postFactoryClass()::new()->withoutPersisting()->create()->assertNotPersisted();
 
         Assert::that(function() { $this->postFactoryClass()::createOne()->assertNotPersisted(); })
-            ->throws(AssertionFailedError::class, \sprintf('%s is persisted but it should not be.', Post::class))
+            ->throws(AssertionFailedError::class, \sprintf('%s is persisted but it should not be.', $this->postClass()))
         ;
     }
 
@@ -283,6 +282,8 @@ abstract class ProxyTest extends KernelTestCase
     }
 
     abstract protected function postFactoryClass(): string;
+
+    abstract protected function postClass(): string;
 
     abstract protected function registryServiceId(): string;
 }

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -17,7 +17,7 @@ final class StoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -17,6 +17,13 @@ final class StoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
+    public static function setUpBeforeClass(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+    }
+
     /**
      * @test
      */

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -17,7 +17,7 @@ final class StoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Unit/Bundle/DependencyInjection/ChainManagerRegistryPassTest.php
+++ b/tests/Unit/Bundle/DependencyInjection/ChainManagerRegistryPassTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Unit\Bundle\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\Foundry\Bundle\DependencyInjection\ChainManagerRegistryPass;
+use Zenstruck\Foundry\ChainManagerRegistry;
+
+class ChainManagerRegistryPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * @test
+     */
+    public function add_both_odm_and_orm_if_present(): void
+    {
+        $this->setDefinition(ChainManagerRegistry::class, new Definition());
+
+        $this->setDefinition('doctrine', new Definition());
+        $this->setDefinition('doctrine_mongodb', new Definition());
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            ChainManagerRegistry::class,
+            '$managerRegistries',
+            [new Reference('doctrine'), new Reference('doctrine_mongodb')]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function only_add_orm(): void
+    {
+        $this->setDefinition(ChainManagerRegistry::class, new Definition());
+
+        $this->setDefinition('doctrine', new Definition());
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            ChainManagerRegistry::class,
+            '$managerRegistries',
+            [new Reference('doctrine')]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new ChainManagerRegistryPass());
+    }
+}

--- a/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
+++ b/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
@@ -8,6 +8,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ZenstruckFoundryExtension;
 use Zenstruck\Foundry\Bundle\Maker\MakeFactory;
 use Zenstruck\Foundry\Bundle\Maker\MakeStory;
+use Zenstruck\Foundry\ChainManagerRegistry;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Instantiator;
 use Zenstruck\Foundry\ModelFactoryManager;
@@ -28,7 +29,7 @@ final class ZenstruckFoundryExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(Configuration::class);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setInstantiator', ['zenstruck_foundry.default_instantiator']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setFaker', ['zenstruck_foundry.faker']);
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setManagerRegistry', ['doctrine']);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setManagerRegistry', [ChainManagerRegistry::class]);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setStoryManager', [StoryManager::class]);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(Configuration::class, 'setModelFactoryManager', [ModelFactoryManager::class]);
         $this->assertCount(5, $this->container->findDefinition(Configuration::class)->getMethodCalls());

--- a/tests/Unit/ChainManagerRegistryTest.php
+++ b/tests/Unit/ChainManagerRegistryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Unit;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\ChainManagerRegistry;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+
+final class ChainManagerRegistryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_get_repository(): void
+    {
+        $managerRegistry1 = $this->createMock(ManagerRegistry::class);
+        $managerRegistry2 = $this->createMock(ManagerRegistry::class);
+
+        $managerRegistry2->expects($this->once())->method('getRepository')->willReturn(
+            $repository = $this->createMock(ObjectRepository::class)
+        );
+
+        $chainManagerRegistry = new ChainManagerRegistry([$managerRegistry1, $managerRegistry2]);
+
+        $this->assertSame($repository, $chainManagerRegistry->getRepository(Post::class));
+    }
+
+    /**
+     * @test
+     */
+    public function throws_exception_if_repository_not_found(): void
+    {
+        $class = Post::class;
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Cannot find repository for class {$class}");
+
+        $managerRegistry1 = $this->createMock(ManagerRegistry::class);
+        $managerRegistry2 = $this->createMock(ManagerRegistry::class);
+
+        $chainManagerRegistry = new ChainManagerRegistry([$managerRegistry1, $managerRegistry2]);
+
+        $chainManagerRegistry->getRepository($class);
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_manager_from_class(): void
+    {
+        $managerRegistry1 = $this->createMock(ManagerRegistry::class);
+        $managerRegistry2 = $this->createMock(ManagerRegistry::class);
+
+        $managerRegistry2->expects($this->once())->method('getManagerForClass')->willReturn(
+            $objectManager = $this->createMock(ObjectManager::class)
+        );
+
+        $chainManagerRegistry = new ChainManagerRegistry([$managerRegistry1, $managerRegistry2]);
+
+        $this->assertSame($objectManager, $chainManagerRegistry->getManagerForClass(Post::class));
+    }
+
+    /**
+     * @test
+     */
+    public function returns_null_if_no_manager_found(): void
+    {
+        $managerRegistry1 = $this->createMock(ManagerRegistry::class);
+        $managerRegistry2 = $this->createMock(ManagerRegistry::class);
+
+        $chainManagerRegistry = new ChainManagerRegistry([$managerRegistry1, $managerRegistry2]);
+
+        $this->assertNull($chainManagerRegistry->getManagerForClass(Post::class));
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_managers(): void
+    {
+        $managerRegistry1 = $this->createMock(ManagerRegistry::class);
+        $managerRegistry2 = $this->createMock(ManagerRegistry::class);
+
+        $managerRegistry1->expects($this->once())->method('getManagers')->willReturn(
+            [$objectManager1 = $this->createMock(ObjectManager::class)]
+        );
+
+        $managerRegistry2->expects($this->once())->method('getManagers')->willReturn(
+            [
+                $objectManager2 = $this->createMock(ObjectManager::class),
+                $objectManager3 = $this->createMock(ObjectManager::class),
+            ]
+        );
+
+        $chainManagerRegistry = new ChainManagerRegistry([$managerRegistry1, $managerRegistry2]);
+
+        $this->assertSame(
+            [$objectManager1, $objectManager2, $objectManager3],
+            $chainManagerRegistry->getManagers()
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,9 @@ require \dirname(__DIR__).'/vendor/autoload.php';
 (new Filesystem())->remove(__DIR__.'/../var');
 
 TestState::disableDefaultProxyAutoRefresh();
-TestState::addGlobalState(static function() {
-    TagStory::load();
-});
+
+if (\getenv('DATABASE_URL')) {
+    TestState::addGlobalState(static function() {
+        TagStory::load();
+    });
+}


### PR DESCRIPTION
- [x] #151 
- [x] #152
- [x] Re-enable code coverage (#156)
- [x] Re-enable and fix psalm
- [x] `EmbedOne`/`EmbedMany `support (#157)
- [x] Tests to ensure `make:factory` lists and can create both documents and embedded documents (#237)
- [x] Global state issue when using ODM and ORM with Dama (#168). A possibility is not supporting Dama/mongo/global state together.
- [x] Make compatible with #145
- [x] ~Re-enable dev stability in gh action text matrix~ *this was disabled in master so I'll handle there*
- [x] remove 0a5ca11b059dd368f798e41d638ef4d66df4a65f (setting `fast-fail: false`)
- [x] Documentation (#241)

Test with your app:

```
composer require zenstruck/foundry:dev-mongo-support
```