### PR TITLE
Suppress psalm error

### DIFF
--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -280,6 +280,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      *
      * @psalm-param Proxy<TProxiedObject>|array|mixed $criteria
      * @psalm-return Proxy<TProxiedObject>|null
+     * @psalm-suppress ParamNameMismatch
      */
     public function find($criteria)
     {


### PR DESCRIPTION
At this time, the policy of this library is to not support named parameters unless a method/function explicitly states they are supported.