### PR TITLE
[tests] fixed how tests are skipped

### DIFF
--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -19,7 +19,7 @@ final class FactoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -15,7 +15,7 @@ final class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ModelFactoryServiceTest.php
+++ b/tests/Functional/ModelFactoryServiceTest.php
@@ -15,7 +15,7 @@ final class ModelFactoryServiceTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\Category;
  */
 final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -15,7 +15,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMModelFactoryTest extends ModelFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMProxyTest.php
+++ b/tests/Functional/ODMProxyTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
  */
 final class ODMProxyTest extends ProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ODMRepositoryProxyTest.php
+++ b/tests/Functional/ODMRepositoryProxyTest.php
@@ -10,7 +10,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
  */
 final class ODMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
  */
 final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -18,7 +18,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
  */
 final class ORMModelFactoryTest extends ModelFactoryTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -13,7 +13,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
  */
 final class ORMProxyTest extends ProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -14,7 +14,7 @@ use function Zenstruck\Foundry\repository;
  */
 final class ORMRepositoryProxyTest extends RepositoryProxyTest
 {
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -17,7 +17,7 @@ final class StoryTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         if (false === \getenv('DATABASE_URL')) {
             self::markTestSkipped('doctrine/orm not enabled.');


### PR DESCRIPTION
When a whole test class is skipped with `setUpBeforeClass()`, the first test case inside this class is skipped with the good messages, and all other test cases are skipped with the following error displayed: `Test skipped because of an error in hook method`