### PR TITLE
Allow passing full namespace with make:factory

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -88,12 +88,22 @@ final class MakeFactory extends AbstractMaker
             throw new RuntimeCommandException(\sprintf('Entity "%s" not found.', $input->getArgument('entity')));
         }
 
+        $namespace = $input->getOption('namespace');
+
+        // strip maker's root namespace if set
+        if (0 === \mb_strpos($namespace, $generator->getRootNamespace())) {
+            $namespace = \mb_substr($namespace, \mb_strlen($generator->getRootNamespace()));
+        }
+
+        $namespace = \trim($namespace, '\\');
+
+        // if creating in tests dir, ensure namespace prefixed with Tests\
+        if ($input->getOption('test') && 0 !== \mb_strpos($namespace, 'Tests\\')) {
+            $namespace = 'Tests\\'.$namespace;
+        }
+
         $entity = new \ReflectionClass($class);
-        $factory = $generator->createClassNameDetails(
-            $entity->getShortName(),
-            $input->getOption('test') ? 'Tests\\'.$input->getOption('namespace') : $input->getOption('namespace'),
-            'Factory'
-        );
+        $factory = $generator->createClassNameDetails($entity->getShortName(), $namespace, 'Factory');
 
         $repository = new \ReflectionClass($this->managerRegistry->getRepository($entity->getName()));
 

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -332,13 +332,15 @@ EOF
     public function can_customize_namespace(): void
     {
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+        $expectedFile = self::tempFile('src/My/Namespace/TagFactory.php');
 
-        $this->assertFileDoesNotExist(self::tempFile('src/My/Namespace/TagFactory.php'));
+        $this->assertFileDoesNotExist($expectedFile);
 
         $tester->setInputs([Tag::class]);
         $tester->execute(['--namespace' => 'My\\Namespace']);
 
-        $this->assertFileExists(self::tempFile('src/My/Namespace/TagFactory.php'));
+        $this->assertFileExists($expectedFile);
+        $this->assertStringContainsString('namespace App\\My\\Namespace;', \file_get_contents($expectedFile));
     }
 
     /**
@@ -347,12 +349,48 @@ EOF
     public function can_customize_namespace_with_test_flag(): void
     {
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+        $expectedFile = self::tempFile('tests/My/Namespace/TagFactory.php');
 
-        $this->assertFileDoesNotExist(self::tempFile('tests/My/Namespace/TagFactory.php'));
+        $this->assertFileDoesNotExist($expectedFile);
 
         $tester->setInputs([Tag::class]);
         $tester->execute(['--namespace' => 'My\\Namespace', '--test' => true]);
 
-        $this->assertFileExists(self::tempFile('tests/My/Namespace/TagFactory.php'));
+        $this->assertFileExists($expectedFile);
+        $this->assertStringContainsString('namespace App\\Tests\\My\\Namespace;', \file_get_contents($expectedFile));
+    }
+
+    /**
+     * @test
+     */
+    public function can_customize_namespace_with_root_namespace_prefix(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+        $expectedFile = self::tempFile('src/My/Namespace/TagFactory.php');
+
+        $this->assertFileDoesNotExist($expectedFile);
+
+        $tester->setInputs([Tag::class]);
+        $tester->execute(['--namespace' => 'App\\My\\Namespace']);
+
+        $this->assertFileExists($expectedFile);
+        $this->assertStringContainsString('namespace App\\My\\Namespace;', \file_get_contents($expectedFile));
+    }
+
+    /**
+     * @test
+     */
+    public function can_customize_namespace_with_test_flag_with_root_namespace_prefix(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+        $expectedFile = self::tempFile('tests/My/Namespace/TagFactory.php');
+
+        $this->assertFileDoesNotExist($expectedFile);
+
+        $tester->setInputs([Tag::class]);
+        $tester->execute(['--namespace' => 'App\\Tests\\My\\Namespace', '--test' => true]);
+
+        $this->assertFileExists($expectedFile);
+        $this->assertStringContainsString('namespace App\\Tests\\My\\Namespace;', \file_get_contents($expectedFile));
     }
 }


### PR DESCRIPTION
Fixes bug where if you pass the full namespace: `bin/console make:factory --namespace=App\\My\\Factory\\Path` your factory has the namespace `App\App\My\Factory\Path` (note the double `App`). 

_Closes #169_