### PR TITLE
Be able to remove most of method annotations on user factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,18 +196,7 @@ use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 
 /**
- * @method static Post|Proxy createOne(array $attributes = [])
- * @method static Post[]|Proxy[] createMany(int $number, $attributes = [])
- * @method static Post|Proxy find($criteria)
- * @method static Post|Proxy findOrCreate(array $attributes)
- * @method static Post|Proxy first(string $sortedField = 'id')
- * @method static Post|Proxy last(string $sortedField = 'id')
- * @method static Post|Proxy random(array $attributes = [])
- * @method static Post|Proxy randomOrCreate(array $attributes = []))
- * @method static Post[]|Proxy[] all()
- * @method static Post[]|Proxy[] findBy(array $attributes)
- * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
- * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @extends ModelFactory<\App\Entity\Post>
  * @method static PostRepository|RepositoryProxy repository()
  * @method Post|Proxy create($attributes = [])
  */

--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ use Zenstruck\Foundry\Proxy;
  * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
  * @method static PostRepository|RepositoryProxy repository()
  * @method Post|Proxy create(array|callable $attributes = [])
- * @method Post[]|Proxy[] many(int $number, array|callable $attributes = [])
  */
 final class PostFactory extends ModelFactory
 {

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ use Zenstruck\Foundry\Proxy;
  * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
  * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
  * @method static PostRepository|RepositoryProxy repository()
- * @method Post|Proxy create($attributes = [])
+ * @method Post|Proxy create(array|callable $attributes = [])
+ * @method Post[]|Proxy[] many(int $number, array|callable $attributes = [])
  */
 final class PostFactory extends ModelFactory
 {

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ use Zenstruck\Foundry\Proxy;
 /**
  * @extends ModelFactory<\App\Entity\Post>
  * @method static PostRepository|RepositoryProxy repository()
+ * @method static Post[]|Proxy[] createMany(int $number, $attributes = [])
  * @method Post|Proxy create($attributes = [])
  */
 final class PostFactory extends ModelFactory

--- a/README.md
+++ b/README.md
@@ -196,9 +196,21 @@ use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 
 /**
- * @extends ModelFactory<\App\Entity\Post>
- * @method static PostRepository|RepositoryProxy repository()
+ * @extends ModelFactory<Post>
+ *
+ * @method static Post|Proxy createOne(array $attributes = [])
  * @method static Post[]|Proxy[] createMany(int $number, $attributes = [])
+ * @method static Post|Proxy find($criteria)
+ * @method static Post|Proxy findOrCreate(array $attributes)
+ * @method static Post|Proxy first(string $sortedField = 'id')
+ * @method static Post|Proxy last(string $sortedField = 'id')
+ * @method static Post|Proxy random(array $attributes = [])
+ * @method static Post|Proxy randomOrCreate(array $attributes = []))
+ * @method static Post[]|Proxy[] all()
+ * @method static Post[]|Proxy[] findBy(array $attributes)
+ * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
+ * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @method static PostRepository|RepositoryProxy repository()
  * @method Post|Proxy create($attributes = [])
  */
 final class PostFactory extends ModelFactory

--- a/src/AnonymousFactory.php
+++ b/src/AnonymousFactory.php
@@ -22,8 +22,7 @@ final class AnonymousFactory extends Factory implements \Countable, \IteratorAgg
      * Try and find existing object for the given $attributes. If not found,
      * instantiate and persist.
      *
-     * @return Proxy|object
-     *
+     * @return Proxy&TModel
      * @psalm-return Proxy<TModel>
      */
     public function findOrCreate(array $attributes): Proxy
@@ -74,8 +73,7 @@ final class AnonymousFactory extends Factory implements \Countable, \IteratorAgg
     /**
      * Fetch one random object and create a new object if none exists.
      *
-     * @return Proxy|object
-     *
+     * @return Proxy&TModel
      * @psalm-return Proxy<TModel>
      */
     public function randomOrCreate(array $attributes = []): Proxy

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -5,7 +5,7 @@ namespace Zenstruck\Foundry;
 use Faker;
 
 /**
- * @template TObject as object
+ * @template TObject of object
  * @abstract
  *
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -68,8 +68,7 @@ class Factory
     /**
      * @param array|callable $attributes
      *
-     * @return Proxy|object
-     *
+     * @return Proxy<TObject>&TObject
      * @psalm-return Proxy<TObject>
      */
     final public function create($attributes = []): Proxy
@@ -119,7 +118,7 @@ class Factory
     /**
      * @see FactoryCollection::__construct()
      *
-     * @psalm-return FactoryCollection<TObject>
+     * @return FactoryCollection<TObject>
      */
     final public function many(int $min, ?int $max = null): FactoryCollection
     {

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -37,7 +37,7 @@ final class FactoryCollection
     /**
      * @param array|callable $attributes
      *
-     * @return Proxy[]|object[]
+     * @return list<TObject&Proxy<TObject>>
      *
      * @psalm-suppress InvalidReturnType
      * @psalm-return list<Proxy<TObject>>

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -3,7 +3,7 @@
 namespace Zenstruck\Foundry;
 
 /**
- * @template TObject as object
+ * @template TObject of object
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -19,11 +19,9 @@ abstract class ModelFactory extends Factory
      * @return list<TModel&Proxy<TModel>>
      * @psalm-return list<Proxy<TModel>>
      */
-    public static function createMany(): array
+    public static function createMany(int $number, callable $attributes = []): array
     {
-        $arguments = \func_get_args();
-
-        return static::new()->many($arguments[0])->create($arguments[1] ?? []);
+        return static::new()->many($number)->create($attributes);
     }
 
     /**

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -4,10 +4,7 @@ namespace Zenstruck\Foundry;
 
 /**
  * @template TModel of object
- * @template-extends Factory<TModel>
- *
- * @method static Proxy[]|object[] createMany(int $number, array|callable $attributes = [])
- * @psalm-method static list<Proxy<TModel>> createMany(int $number, array|callable $attributes = [])
+ * @extends Factory<TModel>
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -18,11 +15,13 @@ abstract class ModelFactory extends Factory
         parent::__construct(static::getClass());
     }
 
-    public static function __callStatic(string $name, array $arguments)
+    /**
+     * @return list<TModel&Proxy<TModel>>
+     * @psalm-return list<Proxy<TModel>>
+     */
+    public static function createMany(): array
     {
-        if ('createMany' !== $name) {
-            throw new \BadMethodCallException(\sprintf('Call to undefined static method "%s::%s".', static::class, $name));
-        }
+        $arguments = \func_get_args();
 
         return static::new()->many($arguments[0])->create($arguments[1] ?? []);
     }
@@ -66,8 +65,7 @@ abstract class ModelFactory extends Factory
     /**
      * A shortcut to create a single model without states.
      *
-     * @return Proxy|object
-     *
+     * @return Proxy<TModel>&TModel
      * @psalm-return Proxy<TModel>
      */
     final public static function createOne(array $attributes = []): Proxy
@@ -79,8 +77,7 @@ abstract class ModelFactory extends Factory
      * Try and find existing object for the given $attributes. If not found,
      * instantiate and persist.
      *
-     * @return Proxy|object
-     *
+     * @return Proxy<TModel>&TModel
      * @psalm-return Proxy<TModel>
      */
     final public static function findOrCreate(array $attributes): Proxy
@@ -94,6 +91,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::first()
+     *
+     * @return Proxy<TModel>&TModel
+     * @psalm-return Proxy<TModel>
      *
      * @throws \RuntimeException If no entities exist
      */
@@ -109,6 +109,9 @@ abstract class ModelFactory extends Factory
     /**
      * @see RepositoryProxy::last()
      *
+     * @return Proxy<TModel>&TModel
+     * @psalm-return Proxy<TModel>
+     *
      * @throws \RuntimeException If no entities exist
      */
     final public static function last(string $sortedField = 'id'): Proxy
@@ -122,6 +125,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::random()
+     *
+     * @return Proxy<TModel>&TModel
+     * @psalm-return Proxy<TModel>
      */
     final public static function random(array $attributes = []): Proxy
     {
@@ -131,8 +137,7 @@ abstract class ModelFactory extends Factory
     /**
      * Fetch one random object and create a new object if none exists.
      *
-     * @return Proxy|object
-     *
+     * @return Proxy<TModel>&TModel
      * @psalm-return Proxy<TModel>
      */
     final public static function randomOrCreate(array $attributes = []): Proxy
@@ -146,6 +151,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::randomSet()
+     *
+     * @return list<TModel&Proxy<TModel>>
+     * @psalm-return list<Proxy<TModel>>
      */
     final public static function randomSet(int $number, array $attributes = []): array
     {
@@ -154,6 +162,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::randomRange()
+     *
+     * @return list<TModel&Proxy<TModel>>
+     * @psalm-return list<Proxy<TModel>>
      */
     final public static function randomRange(int $min, int $max, array $attributes = []): array
     {
@@ -178,6 +189,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::findAll()
+     *
+     * @return list<TModel&Proxy<TModel>>
+     * @psalm-return list<Proxy<TModel>>
      */
     final public static function all(): array
     {
@@ -186,6 +200,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::find()
+     *
+     * @return Proxy<TModel>&TModel
+     * @psalm-return Proxy<TModel>
      *
      * @throws \RuntimeException If no entity found
      */
@@ -200,6 +217,9 @@ abstract class ModelFactory extends Factory
 
     /**
      * @see RepositoryProxy::findBy()
+     *
+     * @return list<TModel&Proxy<TModel>>
+     * @psalm-return list<Proxy<TModel>>
      */
     final public static function findBy(array $attributes): array
     {

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -4,7 +4,10 @@ namespace Zenstruck\Foundry;
 
 /**
  * @template TModel of object
- * @extends Factory<TModel>
+ * @template-extends Factory<TModel>
+ *
+ * @method static Proxy[]|TModel[] createMany(int $number, array|callable $attributes = [])
+ * @psalm-method static list<Proxy<TModel>> createMany(int $number, array|callable $attributes = [])
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -15,15 +15,13 @@ abstract class ModelFactory extends Factory
         parent::__construct(static::getClass());
     }
 
-    /**
-     * @param array|callable $attributes
-     *
-     * @return list<TModel&Proxy<TModel>>
-     * @psalm-return list<Proxy<TModel>>
-     */
-    public static function createMany(int $number, $attributes = []): array
+    public static function __callStatic(string $name, array $arguments)
     {
-        return static::new()->many($number)->create($attributes);
+        if ('createMany' !== $name) {
+            throw new \BadMethodCallException(\sprintf('Call to undefined static method "%s::%s".', static::class, $name));
+        }
+
+        return static::new()->many($arguments[0])->create($arguments[1] ?? []);
     }
 
     /**

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -16,10 +16,12 @@ abstract class ModelFactory extends Factory
     }
 
     /**
+     * @param array|callable $attributes
+     *
      * @return list<TModel&Proxy<TModel>>
      * @psalm-return list<Proxy<TModel>>
      */
-    public static function createMany(int $number, callable $attributes = []): array
+    public static function createMany(int $number, $attributes = []): array
     {
         return static::new()->many($number)->create($attributes);
     }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -87,7 +87,7 @@ final class Proxy
     /**
      * @internal
      *
-     * @template TObject as object
+     * @template TObject of object
      * @psalm-param TObject $object
      * @psalm-return Proxy<TObject>
      */
@@ -105,7 +105,7 @@ final class Proxy
     }
 
     /**
-     * @psalm-return TProxiedObject
+     * @return TProxiedObject
      */
     public function object(): object
     {

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -164,7 +164,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
     }
 
     /**
-     * @return Proxy|object|null
+     * @return Proxy&TProxiedObject|null
      *
      * @psalm-return Proxy<TProxiedObject>|null
      */
@@ -174,7 +174,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
     }
 
     /**
-     * @return Proxy|object|null
+     * @return Proxy&TProxiedObject|null
      *
      * @psalm-return Proxy<TProxiedObject>|null
      */
@@ -208,7 +208,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
      *
      * @param array $attributes The findBy criteria
      *
-     * @return Proxy|object
+     * @return Proxy&TProxiedObject
      *
      * @throws \RuntimeException if no objects are persisted
      *
@@ -276,7 +276,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
     /**
      * @param object|array|mixed $criteria
      *
-     * @return Proxy|object|null
+     * @return Proxy&TProxiedObject|null
      *
      * @psalm-param Proxy<TProxiedObject>|array|mixed $criteria
      * @psalm-return Proxy<TProxiedObject>|null
@@ -314,7 +314,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
     /**
      * @param array|null $orderBy Some ObjectRepository's (ie Doctrine\ORM\EntityRepository) add this optional parameter
      *
-     * @return Proxy|object|null
+     * @return Proxy&TProxiedObject|null
      *
      * @throws \RuntimeException if the wrapped ObjectRepository does not have the $orderBy parameter
      *

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@ function factory(string $class, $defaultAttributes = []): AnonymousFactory
 /**
  * @see Factory::create()
  *
- * @return Proxy|object
+ * @return Proxy&TObject
  *
  * @template TObject of object
  * @psalm-param class-string<TObject> $class
@@ -47,7 +47,7 @@ function create_many(int $number, string $class, $attributes = []): array
 /**
  * Instantiate object without persisting.
  *
- * @return Proxy|object "unpersisted" Proxy wrapping the instantiated object
+ * @return Proxy&TObject "unpersisted" Proxy wrapping the instantiated object
  *
  * @template TObject of object
  * @psalm-param class-string<TObject> $class

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,7 +7,7 @@ use Faker;
 /**
  * @see Factory::__construct()
  *
- * @template TObject as object
+ * @template TObject of object
  * @psalm-param class-string<TObject> $class
  * @psalm-return AnonymousFactory<TObject>
  */


### PR DESCRIPTION
PHPStorm 2021.2 supports generics just like psalm. 

It make sure we can use `@extends ModelFactory<\App\Entity\Post>` to remove the long list of annotations. 