### PR TITLE
Ensure legacy test works as expected

### DIFF
--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -46,10 +46,11 @@ final class ModelFactoryTest extends TestCase
      */
     public function can_instantiate_many_legacy(): void
     {
-        $objects = PostFactory::createMany(2, ['title' => 'title']);
+        $objects = PostFactory::new(['body' => 'body'])->createMany(2, ['title' => 'title']);
 
         $this->assertCount(2, $objects);
         $this->assertSame('title', $objects[0]->getTitle());
+        $this->assertSame('body', $objects[1]->getBody());
     }
 
     /**


### PR DESCRIPTION
This fixes a typo in a legacy test introduced in #111. It wasn't actually triggering the deprecation.