### PR TITLE
Add missing ->expectDeprecation() to legacy tests

### DIFF
--- a/tests/Functional/RepositoryProxyTest.php
+++ b/tests/Functional/RepositoryProxyTest.php
@@ -31,11 +31,36 @@ final class RepositoryProxyTest extends KernelTestCase
 
     /**
      * @test
-     * @group legacy
      */
     public function assertions(): void
     {
         $repository = repository(Category::class);
+
+        $repository->assert()->empty();
+
+        CategoryFactory::createMany(2);
+
+        $repository->assert()->count(2);
+        $repository->assert()->countGreaterThan(1);
+        $repository->assert()->countGreaterThanOrEqual(2);
+        $repository->assert()->countLessThan(3);
+        $repository->assert()->countLessThanOrEqual(2);
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function assertions_legacy(): void
+    {
+        $repository = repository(Category::class);
+
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertEmpty() is deprecated, use RepositoryProxy::assert()->empty().');
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertCount() is deprecated, use RepositoryProxy::assert()->count().');
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertCountGreaterThan() is deprecated, use RepositoryProxy::assert()->countGreaterThan().');
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertCountGreaterThanOrEqual() is deprecated, use RepositoryProxy::assert()->countGreaterThanOrEqual().');
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertCountLessThan() is deprecated, use RepositoryProxy::assert()->countLessThan().');
+        $this->expectDeprecation('Since zenstruck\foundry 1.8.0: Using RepositoryProxy::assertCountLessThanOrEqual() is deprecated, use RepositoryProxy::assert()->countLessThanOrEqual().');
 
         $repository->assertEmpty();
 

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 
@@ -11,7 +12,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
  */
 final class ModelFactoryTest extends TestCase
 {
-    use Factories;
+    use ExpectDeprecationTrait, Factories;
 
     /**
      * @test
@@ -46,6 +47,8 @@ final class ModelFactoryTest extends TestCase
      */
     public function can_instantiate_many_legacy(): void
     {
+        $this->expectDeprecation(\sprintf('Since zenstruck/foundry 1.7: Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s:createMany()" method instead.', PostFactory::class));
+
         $objects = PostFactory::new(['body' => 'body'])->createMany(2, ['title' => 'title']);
 
         $this->assertCount(2, $objects);


### PR DESCRIPTION
Reference: https://github.com/zenstruck/foundry/pull/187#issuecomment-902867973.