### PR TITLE
Check for is persisting first

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -325,17 +325,19 @@ class Factory
 
     private function normalizeCollection(FactoryCollection $collection): array
     {
-        $field = $this->inverseRelationshipField($collection->factory());
-        $cascadePersist = $this->hasCascadePersist($collection->factory(), $field);
+        if ($this->isPersisting()) {
+            $field = $this->inverseRelationshipField($collection->factory());
+            $cascadePersist = $this->hasCascadePersist($collection->factory(), $field);
 
-        if ($this->isPersisting() && $field && false === $cascadePersist) {
-            $this->afterPersist[] = static function(Proxy $proxy) use ($collection, $field) {
-                $collection->create([$field => $proxy]);
-                $proxy->refresh();
-            };
+            if ($field && false === $cascadePersist) {
+                $this->afterPersist[] = static function(Proxy $proxy) use ($collection, $field) {
+                    $collection->create([$field => $proxy]);
+                    $proxy->refresh();
+                };
 
-            // creation delegated to afterPersist event - return empty array here
-            return [];
+                // creation delegated to afterPersist event - return empty array here
+                return [];
+            }
         }
 
         return \array_map(

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -79,6 +79,11 @@ class Post
         return $this->title;
     }
 
+    public function getId()
+    {
+        return $this->id;
+    }
+
     public function getTitle(): ?string
     {
         return $this->title;

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -5,7 +5,10 @@ namespace Zenstruck\Foundry\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -65,5 +68,43 @@ final class ModelFactoryTest extends TestCase
 
         $this->assertCount(2, $objects);
         $this->assertSame('title', $objects[0]->getTitle());
+    }
+
+    /**
+     * @test
+     */
+    public function create_with_many_to_one_relation(): void
+    {
+        $object = PostFactory::createOne(['category' => CategoryFactory::new(['name' => 'My Name'])]);
+
+        $this->assertNull($object->getId());
+        $this->assertNull($object->getCategory()->getId());
+        $this->assertSame('My Name', $object->getCategory()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function create_with_one_to_many_relation(): void
+    {
+        $post = PostFactory::new()->create([
+            'comments' => CommentFactory::new()->many(4),
+        ]);
+
+        $this->assertNull($post->getId());
+        $this->assertCount(4, $post->getComments());
+    }
+
+    /**
+     * @test
+     */
+    public function create_with_many_to_many_relation(): void
+    {
+        $post = PostFactory::createOne([
+            'tags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertNull($post->getId());
+        $this->assertCount(3, $post->getTags());
     }
 }


### PR DESCRIPTION
Without this change:

```
4) Runroom\SeoBundle\Tests\Unit\MetaInformationBuilderTest::itBuildsMetaInformationViewModel
RuntimeException: Foundry was booted without doctrine. Ensure your TestCase extends Symfony\Bundle\FrameworkBundle\Test\KernelTestCase

/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Configuration.php:173
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Configuration.php:156
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Factory.php:385
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Factory.php:328
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Factory.php:286
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Factory.php:97
/Users/jsala/Repository/Contributions/runroom-packages/vendor/zenstruck/foundry/src/Factory.php:99
/Users/jsala/Repository/Contributions/runroom-packages/packages/seo-bundle/tests/Unit/MetaInformationBuilderTest.php:56
```

This is the test class: https://github.com/Runroom/runroom-packages/blob/master/packages/seo-bundle/tests/Unit/MetaInformationBuilderTest.php

It happens on test that want to use the factories but not persist them, and extending the base TestCase from phpunit.