### PR TITLE
Disable migration tests on php >= 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,14 @@ jobs:
 
       - name: 'Test: MySQL, DoctrineMigrationsBundle'
         run: vendor/bin/simple-phpunit -v
+        if: matrix.php < 8.0
         env:
           FOUNDRY_RESET_MODE: migrate
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
 
       - name: 'Test: MySQL, DoctrineMigrationsBundle, DAMABundle'
         run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist
+        if: matrix.php < 8.0
         env:
           FOUNDRY_RESET_MODE: migrate
           DATABASE_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7


### PR DESCRIPTION
Using foundry with dbal 3/migrations/php8 is currently broken. Disable these tests for now.