### PR TITLE
Add all-fields option to MakeFactory

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -99,7 +99,7 @@ final class MakeFactory extends AbstractMaker
         }
 
         if (!$input->getOption('all-fields')) {
-            $io->text('// Note: pass <fg=yellow>--all-fields</> if you want to generate default values for all entity fields, not only required fields');
+            $io->text('// Note: pass <fg=yellow>--all-fields</> if you want to generate default values for all fields, not only required fields');
             $io->newLine();
         }
 

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -98,6 +98,11 @@ final class MakeFactory extends AbstractMaker
             $io->newLine();
         }
 
+        if (!$input->getOption('all-fields')) {
+            $io->text('// Note: pass <fg=yellow>--all-fields</> if you want to generate default values for all entity fields, not only required fields');
+            $io->newLine();
+        }
+
         $argument = $command->getDefinition()->getArgument('entity');
         $entity = $io->choice($argument->getDescription(), $this->entityChoices());
 

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -81,6 +81,7 @@ final class MakeFactory extends AbstractMaker
             ->addArgument('entity', InputArgument::OPTIONAL, 'Entity class to create a factory for')
             ->addOption('namespace', null, InputOption::VALUE_REQUIRED, 'Customize the namespace for generated factories', 'Factory')
             ->addOption('test', null, InputOption::VALUE_NONE, 'Create in <fg=yellow>tests/</> instead of <fg=yellow>src/</>')
+            ->addOption('all-fields', null, InputOption::VALUE_NONE, 'Create defaults for all entity fields, not only required fields')
         ;
 
         $inputConfig->setArgumentAsNonInteractive('entity');
@@ -144,7 +145,7 @@ final class MakeFactory extends AbstractMaker
             __DIR__.'/../Resources/skeleton/Factory.tpl.php',
             [
                 'entity' => $entity,
-                'defaultProperties' => $this->defaultPropertiesFor($entity->getName()),
+                'defaultProperties' => $this->defaultPropertiesFor($entity->getName(), $input->getOption('all-fields')),
                 'repository' => $repository,
             ]
         );
@@ -185,7 +186,7 @@ final class MakeFactory extends AbstractMaker
         return $choices;
     }
 
-    private function defaultPropertiesFor(string $class): iterable
+    private function defaultPropertiesFor(string $class, bool $allFields): iterable
     {
         $em = $this->managerRegistry->getManagerForClass($class);
 
@@ -198,7 +199,7 @@ final class MakeFactory extends AbstractMaker
 
         foreach ($metadata->fieldMappings as $property) {
             // ignore identifiers and nullable fields
-            if (($property['nullable'] ?? false) || \in_array($property['fieldName'], $ids, true)) {
+            if ((!$allFields && ($property['nullable'] ?? false)) || \in_array($property['fieldName'], $ids, true)) {
                 continue;
             }
 


### PR DESCRIPTION
This PR adds the option to tell MakeFactory that it must create default values for all required and nullable fields of the entity, not only required fields.

It's easier to manually remove unwanted defaults than it is to manually add additional defaults.

The default behavior of MakeFactory has not changed. Without the option on the command line, MakeFactory will create defaults only for required fields.

If the PR is approved, I will make a Symfony documentation PR to add the option there as well.