### PR TITLE
Fix smallint generated Faker

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -40,7 +40,7 @@ final class MakeFactory extends AbstractMaker
         'JSON' => '[],',
         'JSON_ARRAY' => '[],',
         'SIMPLE_ARRAY' => '[],',
-        'SMALLINT' => 'self::faker()->randomNumber(1, 32767),',
+        'SMALLINT' => 'self::faker()->numberBetween(1, 32767),',
         'STRING' => 'self::faker()->text(),',
         'TEXT' => 'self::faker()->text(),',
         'TIME_MUTABLE' => 'self::faker()->datetime(),',


### PR DESCRIPTION
Hi,

The currently configured default faker for smallints is wrong, it should be numberBetween() for specifying an int range instead of randomNumber().

Very small PR :) 