### PR TITLE
test: assert make:factory can create both documents and embedded documents

### DIFF
--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Zenstruck\Foundry\Tests\Fixtures\Document\Comment;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
 
@@ -407,7 +408,11 @@ EOF
         $this->assertStringContainsString('namespace App\\Tests\\My\\Namespace;', \file_get_contents($expectedFile));
     }
 
-    public function can_create_factory_for_embedded_document(): void
+    /**
+     * @test
+     * @dataProvider documentProvider
+     */
+    public function can_create_factory_for_odm(string $class, string $file): void
     {
         if (false === \getenv('MONGO_URL')) {
             self::markTestSkipped('doctrine/odm not enabled.');
@@ -415,11 +420,17 @@ EOF
 
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
 
-        $this->assertFileDoesNotExist(self::tempFile('src/Factory/CommentFactory.php'));
+        $this->assertFileDoesNotExist(self::tempFile("src/Factory/$file.php"));
 
-        $tester->setInputs([Comment::class]);
+        $tester->setInputs([$class]);
         $tester->execute([]);
 
-        $this->assertFileExists(self::tempFile('src/Factory/CommentFactory.php'));
+        $this->assertFileExists(self::tempFile("src/Factory/$file.php"));
+    }
+
+    public function documentProvider(): iterable
+    {
+        yield 'document' => [Post::class, 'PostFactory'];
+        yield 'embedded document' => [Comment::class, 'CommentFactory'];
     }
 }


### PR DESCRIPTION
other tests are fixed in https://github.com/zenstruck/foundry/pull/236