### PR TITLE
[doc] mongo-support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ $post = PostFactory::new() // Create the factory for Post objects
 The factories can be used inside [DoctrineFixturesBundle](https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html)
 to load fixtures or inside your tests, [where it has even more features](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#using-in-your-tests).
 
+Foundry supports `doctrine/orm` (with [doctrine/doctrine-bundle](https://github.com/doctrine/doctrinebundle)),
+`doctrine/mongodb-odm` (with [doctrine/mongodb-odm-bundle](https://github.com/doctrine/DoctrineMongoDBBundle))
+or a combination of these.
+
 Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/foundry
 
 **[Read the Documentation](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html)**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Foundry
 =======
 
+Foundry supports ``doctrine/orm`` (with `doctrine/doctrine-bundle <https://github.com/doctrine/doctrinebundle>`_),
+``doctrine/mongodb-odm`` (with `doctrine/mongodb-odm-bundle <https://github.com/doctrine/DoctrineMongoDBBundle>`_)
+or a combination of these.
+
 Installation
 ------------
 
@@ -1381,6 +1385,11 @@ accordingly. Your database is still reset before running your test suite but the
 
     If using `Global State`_, it is persisted to the database (not in a transaction) before your
     test suite is run. This could further improve test speed if you have a complex global state.
+
+.. caution::
+
+    Using `Global State`_ that creates both ORM and ODM factories when using DAMADoctrineTestBundle
+    is not supported.
 
 Miscellaneous
 .............


### PR DESCRIPTION
The integration with ORM/MongoDB/both is pretty seamless. Not much we have to say except "announce" we support these `doctrine/persistence` implementations. @nikophil, wdyt?