### PR TITLE
Adds an 'All' option to factory generation that creates all uncreated factories.

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -104,7 +104,7 @@ final class MakeFactory extends AbstractMaker
         }
 
         $entity_argument = $command->getDefinition()->getArgument('entity');
-        $choices = array_merge($this->entityChoices(), ['All']);
+        $choices = \array_merge($this->entityChoices(), ['All']);
         $entity = $io->choice($entity_argument->getDescription(), $choices);
 
         $input->setArgument('entity', $entity);
@@ -115,7 +115,7 @@ final class MakeFactory extends AbstractMaker
         $class_or_all = $input->getArgument('entity');
         switch ($class_or_all) {
             case 'All':
-                foreach($this->entityChoices() as $class) {
+                foreach ($this->entityChoices() as $class) {
                     $this->generateEntity($class, $input, $io, $generator);
                 }
                 break;
@@ -125,10 +125,16 @@ final class MakeFactory extends AbstractMaker
         }
     }
 
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+        // noop
+    }
+
     /**
      * Generates a single entity factory.
      */
-    private function generateEntity(string $class, InputInterface $input, ConsoleStyle $io, Generator $generator) {
+    private function generateEntity(string $class, InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
         if (!\class_exists($class)) {
             $class = $generator->createClassNameDetails($class, 'Entity\\')->getFullName();
         }
@@ -179,11 +185,6 @@ final class MakeFactory extends AbstractMaker
             'Next: Open your new factory and set default values/states.',
             'Find the documentation at https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories',
         ]);
-    }
-
-    public function configureDependencies(DependencyBuilder $dependencies): void
-    {
-        // noop
     }
 
     private function entityChoices(): array

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -74,6 +74,11 @@ final class MakeFactory extends AbstractMaker
         return 'Creates a Foundry model factory for a Doctrine entity class';
     }
 
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+        // noop
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
@@ -174,11 +179,6 @@ final class MakeFactory extends AbstractMaker
             'Next: Open your new factory and set default values/states.',
             'Find the documentation at https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories',
         ]);
-    }
-
-    public function configureDependencies(DependencyBuilder $dependencies): void
-    {
-        // noop
     }
 
     private function entityChoices(): array

--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -103,37 +103,26 @@ final class MakeFactory extends AbstractMaker
             $io->newLine();
         }
 
-        $entity_argument = $command->getDefinition()->getArgument('entity');
-        $choices = \array_merge($this->entityChoices(), ['All']);
-        $entity = $io->choice($entity_argument->getDescription(), $choices);
+        $argument = $command->getDefinition()->getArgument('entity');
+        $entity = $io->choice($argument->getDescription(), \array_merge($this->entityChoices(), ['All']));
 
         $input->setArgument('entity', $entity);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
-        $class_or_all = $input->getArgument('entity');
-        switch ($class_or_all) {
-            case 'All':
-                foreach ($this->entityChoices() as $class) {
-                    $this->generateEntity($class, $input, $io, $generator);
-                }
-                break;
-            default:
-                $this->generateEntity($class_or_all, $input, $io, $generator);
-                break;
-        }
-    }
+        $entity = $input->getArgument('entity');
+        $classes = 'All' === $entity ? $this->entityChoices() : [$entity];
 
-    public function configureDependencies(DependencyBuilder $dependencies): void
-    {
-        // noop
+        foreach ($classes as $class) {
+            $this->generateFactory($class, $input, $io, $generator);
+        }
     }
 
     /**
      * Generates a single entity factory.
      */
-    private function generateEntity(string $class, InputInterface $input, ConsoleStyle $io, Generator $generator)
+    private function generateFactory(string $class, InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         if (!\class_exists($class)) {
             $class = $generator->createClassNameDetails($class, 'Entity\\')->getFullName();
@@ -185,6 +174,11 @@ final class MakeFactory extends AbstractMaker
             'Next: Open your new factory and set default values/states.',
             'Find the documentation at https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories',
         ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+        // noop
     }
 
     private function entityChoices(): array

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -410,6 +410,29 @@ EOF
 
     /**
      * @test
+     */
+    public function can_create_factory_with_all_interactively(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+
+        $this->assertFileDoesNotExist(self::tempFile('src/Factory/CategoryFactory.php'));
+        $this->assertFileDoesNotExist(self::tempFile('src/Factory/TagFactory.php'));
+
+        $tester->setInputs(['All']);
+
+        try {
+            $tester->execute([]);
+        } catch (RuntimeCommandException $e) {
+            // todo find a better solution
+            // because we have fixtures with the same name, the maker will fail when creating the duplicate
+        }
+
+        $this->assertFileExists(self::tempFile('src/Factory/CategoryFactory.php'));
+        $this->assertFileExists(self::tempFile('src/Factory/TagFactory.php'));
+    }
+
+    /**
+     * @test
      * @dataProvider documentProvider
      */
     public function can_create_factory_for_odm(string $class, string $file): void

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -416,7 +416,7 @@ EOF
         $tester = new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
 
         $this->assertFileDoesNotExist(self::tempFile('src/Factory/CategoryFactory.php'));
-        $this->assertFileDoesNotExist(self::tempFile('src/Factory/TagFactory.php'));
+        $this->assertFileDoesNotExist(self::tempFile('src/Factory/PostFactory.php'));
 
         $tester->setInputs(['All']);
 
@@ -428,7 +428,7 @@ EOF
         }
 
         $this->assertFileExists(self::tempFile('src/Factory/CategoryFactory.php'));
-        $this->assertFileExists(self::tempFile('src/Factory/TagFactory.php'));
+        $this->assertFileExists(self::tempFile('src/Factory/PostFactory.php'));
     }
 
     /**


### PR DESCRIPTION
Would address https://github.com/zenstruck/foundry/issues/15

Tests still TBD.   What's the default testing mechanism?

**Edit: Looking at the existing tests, I'm a bit unsure how to proceed.  I found `\Zenstruck\Foundry\Tests\Unit\Bundle\DependencyInjection\ZenstruckFoundryExtensionTest`, but I'm not seeing where you tested that existing entities showed up as options, and that maker output was actually generated?  If you don't consider that needing testing, let me know - I think this works, otherwise.