### PR TITLE
Ignores abstract classes in the maker

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -176,6 +176,9 @@ final class MakeFactory extends AbstractMaker
 
         foreach ($this->managerRegistry->getManagers() as $manager) {
             foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
+                if ($metadata->getReflectionClass()->isAbstract()) {
+                    continue;
+                }
                 if (!\in_array($metadata->getName(), $this->entitiesWithFactories, true)) {
                     $choices[] = $metadata->getName();
                 }


### PR DESCRIPTION
Updates `\Zenstruck\Foundry\Bundle\Maker\MakeFactory::entityChoices` to ignore abstract classes when considering which to generate factories for.  Should close https://github.com/zenstruck/foundry/issues/248