### PR TITLE
Story pools

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1656,7 +1656,9 @@ Later, you can access the story's state when creating other fixtures:
 
 .. code-block:: php
 
-    PostFactory::createOne(['category' => CategoryStory::load()->get('php')]);
+    PostFactory::createOne([
+        'category' => CategoryStory::load()->get('php') // Category Proxy
+    ]);
 
     // or use the magic method (functionally equivalent to above)
     PostFactory::createOne(['category' => CategoryStory::php()]);
@@ -1664,6 +1666,46 @@ Later, you can access the story's state when creating other fixtures:
 .. note::
 
     Story state is cleared after each test (unless it is a :ref:`Global State Story <global-state>`).
+
+Story Pools
+^^^^^^^^^^^
+
+Stories can store (as state) *pools* of objects:
+
+.. code-block:: php
+
+    // src/Story/ProvinceStory.php
+
+    namespace App\Story;
+
+    use App\Factory\ProvinceFactory;
+    use Zenstruck\Foundry\Story;
+
+    final class ProvinceStory extends Story
+    {
+        public function build(): void
+        {
+            // add collection to a "pool"
+            $this->addToPool('be', ProvinceFactory::createMany(5, ['country' => 'BE']));
+
+            // equivalent to above
+            $this->addToPool('be', ProvinceFactory::new(['country' => 'BE'])->many(5));
+
+            // add single object to a pool
+            $this->addToPool('be', ProvinceFactory::createOne(['country' => 'BE']));
+
+            // add single object to single pool and make available as "state"
+            $this->addState('be-1', ProvinceFactory::createOne(['country' => 'BE']), 'be');
+        }
+    }
+
+Objects can be fetched from pools in your tests, fixtures or other stories:
+
+.. code-block:: php
+
+    ProvinceStory::getRandom('be'); // random Province|Proxy from "be" pool
+    ProvinceStory::getRandomSet('be', 3); // 3 random Province|Proxy's from "be" pool
+    ProvinceStory::getRandomRange('be', 1, 4); // between 1 and 4 random Province|Proxy's from "be" pool
 
 Bundle Configuration
 --------------------

--- a/tests/Fixtures/Stories/CategoryPoolStory.php
+++ b/tests/Fixtures/Stories/CategoryPoolStory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Stories;
+
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CategoryPoolStory extends Story
+{
+    public function build(): void
+    {
+        $this->addToPool('pool-name', CategoryFactory::createMany(2));
+        $this->addToPool('pool-name', CategoryFactory::new()->many(3));
+        $this->addToPool('pool-name', CategoryFactory::createOne());
+        $this->addToPool('pool-name', CategoryFactory::new());
+        $this->addState('state-name', CategoryFactory::new(), 'pool-name');
+    }
+}


### PR DESCRIPTION
Closes #250.

Adds the following API to Story's:

```php
final class ProvinceStory extends Story
{
    public function build(): void
    {
        // add collection to a "pool"
        $this->addToPool('be', ProvinceFactory::createMany(5, ['country' => 'BE']));

        // equivalent to above
        $this->addToPool('be', ProvinceFactory::new(['country' => 'BE'])->many(5));

        // add single object to a pool
        $this->addToPool('be', ProvinceFactory::createOne(['country' => 'BE']));

        // add single object to single pool and make available as "state"
        $this->addState('be-1', ProvinceFactory::createOne(['country' => 'BE']), 'be');
    }
}
```

Usage:

```php
ProvinceStory::getRandom('be'); // random Proxy from "be" pool
ProvinceStory::getRandomSet('be', 3); // 3 random Proxy's from "be" pool
ProvinceStory::getRandomRange('be', 1, 4); // between 1 and 4 random Proxy's from "be" pool
```

TODO:
- [x] Tests
- [x] Docs