### PR TITLE
Make `Story::get()` static (implies `Story::load()->get()`)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1789,9 +1789,7 @@ Later, you can access the story's state when creating other fixtures:
 
 .. code-block:: php
 
-    PostFactory::createOne([
-        'category' => CategoryStory::load()->get('php') // Category Proxy
-    ]);
+    PostFactory::createOne(['category' => CategoryStory::get('php')]);
 
     // or use the magic method (functionally equivalent to above)
     PostFactory::createOne(['category' => CategoryStory::php()]);

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -60,11 +60,30 @@ final class StoryTest extends KernelTestCase
     /**
      * @test
      */
+    public function can_access_managed_proxies_static_get(): void
+    {
+        $this->assertSame('php', CategoryStory::get('php')->getName());
+    }
+
+    /**
+     * @test
+     */
     public function cannot_access_invalid_object(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        CategoryStory::load()->get('invalid');
+        CategoryStory::get('invalid');
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function can_access_managed_proxies_instance_get(): void
+    {
+        $this->expectDeprecation(\sprintf('Since zenstruck/foundry 1.24: Calling instance method "%1$s::get()" is deprecated and will be removed in 2.0, use the static "%1$s::get()" method instead.', CategoryStory::class));
+
+        $this->assertSame('php', CategoryStory::load()->get('php')->getName());
     }
 
     /**


### PR DESCRIPTION
Instead of calling `MyStory::load()->get('some-state')`, can call `MyStory::get('some-state')`. This deprecates calling `->get()` instance method.