### PR TITLE
Deprecate `Story:add()` and add protected `Story::addState()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1645,10 +1645,10 @@ Another feature of *stories* is the ability for them to *remember* the objects t
     {
         public function build(): void
         {
-            $this->add('php', CategoryFactory::createOne(['name' => 'php']));
+            $this->addState('php', CategoryFactory::createOne(['name' => 'php']));
 
             // factories are created when added as state
-            $this->add('symfony', CategoryFactory::new(['name' => 'symfony']));
+            $this->addState('symfony', CategoryFactory::new(['name' => 'symfony']));
         }
     }
 

--- a/src/Story.php
+++ b/src/Story.php
@@ -33,6 +33,24 @@ abstract class Story
      */
     final public function add(string $name, $state): self
     {
+        trigger_deprecation('zenstruck\foundry', '1.17.0', 'Using Story::add() is deprecated, use Story::addState().');
+
+        return $this->addState($name, $state);
+    }
+
+    final public function get(string $name): Proxy
+    {
+        if (!\array_key_exists($name, $this->state)) {
+            throw new \InvalidArgumentException(\sprintf('"%s" was not registered. Did you forget to call "%s::add()"?', $name, static::class));
+        }
+
+        return $this->state[$name];
+    }
+
+    abstract public function build(): void;
+
+    final protected function addState(string $name, $state): self
+    {
         if (\is_object($state)) {
             // ensure factories are persisted
             if ($state instanceof Factory) {
@@ -54,15 +72,4 @@ abstract class Story
 
         return $this;
     }
-
-    final public function get(string $name): Proxy
-    {
-        if (!\array_key_exists($name, $this->state)) {
-            throw new \InvalidArgumentException(\sprintf('"%s" was not registered. Did you forget to call "%s::add()"?', $name, static::class));
-        }
-
-        return $this->state[$name];
-    }
-
-    abstract public function build(): void;
 }

--- a/tests/Fixtures/Stories/CategoryStory.php
+++ b/tests/Fixtures/Stories/CategoryStory.php
@@ -12,7 +12,7 @@ final class CategoryStory extends Story
 {
     public function build(): void
     {
-        $this->add('php', CategoryFactory::new()->create(['name' => 'php']));
-        $this->add('symfony', CategoryFactory::new()->create(['name' => 'symfony']));
+        $this->addState('php', CategoryFactory::new()->create(['name' => 'php']));
+        $this->addState('symfony', CategoryFactory::new()->create(['name' => 'symfony']));
     }
 }

--- a/tests/Fixtures/Stories/PostStory.php
+++ b/tests/Fixtures/Stories/PostStory.php
@@ -12,17 +12,17 @@ final class PostStory extends Story
 {
     public function build(): void
     {
-        $this->add('postA', PostFactory::new()->create([
+        $this->addState('postA', PostFactory::new()->create([
             'title' => 'Post A',
             'category' => CategoryStory::php(),
         ]));
 
-        $this->add('postB', PostFactory::new()->create([
+        $this->addState('postB', PostFactory::new()->create([
             'title' => 'Post B',
             'category' => CategoryStory::php(),
         ])->object());
 
-        $this->add('postC', PostFactory::new([
+        $this->addState('postC', PostFactory::new([
             'title' => 'Post C',
             'category' => CategoryStory::symfony(),
         ]));

--- a/tests/Fixtures/Stories/ServiceStory.php
+++ b/tests/Fixtures/Stories/ServiceStory.php
@@ -21,6 +21,6 @@ final class ServiceStory extends Story
 
     public function build(): void
     {
-        $this->add('post', PostFactory::new()->create(['title' => $this->service->name]));
+        $this->addState('post', PostFactory::new()->create(['title' => $this->service->name]));
     }
 }

--- a/tests/Fixtures/Stories/TagStory.php
+++ b/tests/Fixtures/Stories/TagStory.php
@@ -12,7 +12,7 @@ final class TagStory extends Story
 {
     public function build(): void
     {
-        $this->add('dev', TagFactory::new()->create(['name' => 'dev']));
-        $this->add('design', TagFactory::new()->create(['name' => 'design']));
+        $this->addState('dev', TagFactory::new()->create(['name' => 'dev']));
+        $this->addState('design', TagFactory::new()->create(['name' => 'design']));
     }
 }

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -15,7 +16,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Stories\ServiceStory;
  */
 final class StoryTest extends KernelTestCase
 {
-    use Factories, ResetDatabase;
+    use ExpectDeprecationTrait, Factories, ResetDatabase;
 
     protected function setUp(): void
     {
@@ -89,5 +90,16 @@ final class StoryTest extends KernelTestCase
         $this->expectExceptionMessage('Stories with dependencies (Story services) cannot be used without the foundry bundle.');
 
         ServiceStory::load();
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function calling_add_is_deprecated(): void
+    {
+        $this->expectDeprecation('Since zenstruck\foundry 1.17.0: Using Story::add() is deprecated, use Story::addState().');
+
+        CategoryStory::load()->add('foo', 'bar');
     }
 }


### PR DESCRIPTION
This method was never intended to be called from outside. This is technically a BC break but calling it from outside could do weird things. @wouterj, do you think we should deprecate instead? Is there a deprecation pattern for changing a method's visibility?

Another option could be to deprecate `Story::add()` and add `final protected function addState(string $name)`. This would line up with #252's `Story::addToPool()`.