### PR TITLE
feat: add return type for command (deprecated in symfony 6)

### DIFF
--- a/src/Bundle/Command/StubCommand.php
+++ b/src/Bundle/Command/StubCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class StubCommand extends Command
 {
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         (new SymfonyStyle($input, $output))
             ->error(


### PR DESCRIPTION
`Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Zenstruck\Foundry\Bundle\Command\StubCommand" now to avoid errors or add an explicit @return annotation to suppress this message.`