### PR TITLE
Fix embeddable support when used with file (ie xml) mapping

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -449,7 +449,13 @@ class Factory
             return false;
         }
 
+        if ($classMetadata instanceof ORMClassMetadata && $classMetadata->isEmbeddedClass) {
+            // embedded entity
+            return false;
+        }
+
         if ($classMetadata instanceof ODMClassMetadata && $classMetadata->isEmbeddedDocument) {
+            // embedded document
             return false;
         }
 


### PR DESCRIPTION
The annotaion/attribute drivers do not register embeddables in class metadata but the file drivers do.

Reference: https://github.com/doctrine/orm/pull/8138
Fixes: #270