### PR TITLE
[feature] Handle variadic constructor arguments

### DIFF
--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -260,7 +260,11 @@ final class Instantiator
             $name = self::attributeNameForParameter($parameter, $attributes);
 
             if (\array_key_exists($name, $attributes)) {
-                $arguments[] = $attributes[$name];
+                if ($parameter->isVariadic()) {
+                    $arguments = \array_merge($arguments, $attributes[$name]);
+                } else {
+                    $arguments[] = $attributes[$name];
+                }
             } elseif ($parameter->isDefaultValueAvailable()) {
                 $arguments[] = $parameter->getDefaultValue();
             } else {

--- a/tests/Unit/InstantiatorTest.php
+++ b/tests/Unit/InstantiatorTest.php
@@ -515,6 +515,32 @@ final class InstantiatorTest extends TestCase
             'propF' => 'F',
         ], InstantiatorDummy::class);
     }
+
+    /**
+     * @test
+     */
+    public function can_set_variadic_constructor_attributes(): void
+    {
+        $object = (new Instantiator())([
+            'propA' => 'A',
+            'propB' => ['B', 'C', 'D'],
+        ], VariadicInstantiatorDummy::class);
+
+        $this->assertSame('constructor A', $object->getPropA());
+        $this->assertSame(['B', 'C', 'D'], $object->getPropB());
+    }
+
+    /**
+     * @test
+     */
+    public function missing_variadic_argument_thtrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing constructor argument "propB" for "Zenstruck\Foundry\Tests\Unit\VariadicInstantiatorDummy".');
+        $object = (new Instantiator())([
+            'propA' => 'A',
+        ], VariadicInstantiatorDummy::class);
+    }
 }
 
 class InstantiatorDummy
@@ -585,5 +611,27 @@ class PrivateConstructorInstantiatorDummy extends InstantiatorDummy
     private function __construct()
     {
         parent::__construct('B', 'C');
+    }
+}
+
+class VariadicInstantiatorDummy
+{
+    private $propA;
+    private $propB;
+
+    public function __construct($propA, ...$propB)
+    {
+        $this->propA = 'constructor '.$propA;
+        $this->propB = $propB;
+    }
+
+    public function getPropA()
+    {
+        return $this->propA;
+    }
+
+    public function getPropB()
+    {
+        return $this->propB;
     }
 }


### PR DESCRIPTION
When instantiating an object that has variadic constructor arguments, we get an error like the following:

```
TypeError : Foo::__construct(): Argument #3 must be of type string, array given
```

We can use the Reflection API to identify if a parameter is variadic so that we can pass it in correctly.