### PR TITLE
Re-save created object after "afterPersist" events called

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -114,11 +114,20 @@ class Factory
             return $proxy;
         }
 
-        return $proxy->save()->withoutAutoRefresh(function(Proxy $proxy) use ($attributes) {
-            foreach ($this->afterPersist as $callback) {
-                $proxy->executeCallback($callback, $attributes);
-            }
-        });
+        return $proxy
+            ->save()
+            ->withoutAutoRefresh(function(Proxy $proxy) use ($attributes) {
+                if (!$this->afterPersist) {
+                    return;
+                }
+
+                foreach ($this->afterPersist as $callback) {
+                    $proxy->executeCallback($callback, $attributes);
+                }
+
+                $proxy->save(); // save again as afterPersist events may have modified
+            })
+        ;
     }
 
     /**

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -277,6 +277,24 @@ abstract class ModelFactoryTest extends KernelTestCase
         $this->assertSame('name2', $categories[1]->getName());
     }
 
+    /**
+     * @test
+     */
+    public function resave_after_persist_events(): void
+    {
+        $categoryFactoryClass = $this->categoryFactoryClass();
+
+        $categoryFactoryClass::new()
+            ->afterPersist(function($category) {
+                $category->setName('new');
+            })
+            ->create(['name' => 'original'])
+        ;
+
+        $categoryFactoryClass::assert()->exists(['name' => 'new']);
+        $categoryFactoryClass::assert()->notExists(['name' => 'original']);
+    }
+
     abstract protected function categoryClass(): string;
 
     abstract protected function categoryFactoryClass(): string;


### PR DESCRIPTION
The `afterPersist` events may be used to modify the created object. Let's re-save after so these changes are flushed.

Fixes #278.