### PR TITLE
Add `Story::getPool()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1731,6 +1731,7 @@ Objects can be fetched from pools in your tests, fixtures or other stories:
     ProvinceStory::getRandom('be'); // random Province|Proxy from "be" pool
     ProvinceStory::getRandomSet('be', 3); // 3 random Province|Proxy's from "be" pool
     ProvinceStory::getRandomRange('be', 1, 4); // between 1 and 4 random Province|Proxy's from "be" pool
+    ProvinceStory::getPool('be'); // all Province|Proxy's from "be" pool
 
 Bundle Configuration
 --------------------

--- a/src/Story.php
+++ b/src/Story.php
@@ -32,6 +32,16 @@ abstract class Story
     }
 
     /**
+     * Get all the items in a pool.
+     *
+     * @return Proxy[]
+     */
+    final public static function getPool(string $pool): array
+    {
+        return static::load()->pools[$pool] ?? [];
+    }
+
+    /**
      * Get a random item from a pool.
      */
     final public static function getRandom(string $pool): Proxy
@@ -68,8 +78,7 @@ abstract class Story
             throw new \InvalidArgumentException(\sprintf('$max (%d) cannot be less than $min (%d).', $max, $min));
         }
 
-        $story = static::load();
-        $values = $story->pools[$pool] ?? [];
+        $values = static::getPool($pool);
 
         \shuffle($values);
 


### PR DESCRIPTION
Adds method to retrieve all items stored in a Story pool.

Closes #281.