### PR TITLE
Clarifying deprecation of non-static createMany()

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -66,7 +66,7 @@ class Factory
             throw new \BadMethodCallException(\sprintf('Call to undefined method "%s::%s".', static::class, $name));
         }
 
-        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s:createMany()" method instead.', static::class);
+        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s::createMany()" method or "%1$s->many()->create()" instead.', static::class);
 
         return $this->many($arguments[0])->create($arguments[1] ?? []);
     }


### PR DESCRIPTION
If you're using, for example, a state method, then you want to instantiate the factory, call `->many()` and then `->create()`

Based on feedback over at - https://symfonycasts.com/screencast/symfony-doctrine/foundry-tricks#comment-5925292669 - from our deprecated code usage there :).

Cheers!