### PR TITLE
Improve deprecation message for createMany().

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -66,7 +66,7 @@ class Factory
             throw new \BadMethodCallException(\sprintf('Call to undefined method "%s::%s".', static::class, $name));
         }
 
-        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use e.g. "%1$s::new()->stateAdapter()->many()->create()" instead.', static::class, $arguments[0]);
+        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use e.g. "%1$s::new()->stateAdapter()->many(%2$d)->create()" instead.', static::class, $arguments[0]);
 
         return $this->many($arguments[0])->create($arguments[1] ?? []);
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -66,7 +66,7 @@ class Factory
             throw new \BadMethodCallException(\sprintf('Call to undefined method "%s::%s".', static::class, $name));
         }
 
-        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s:createMany()" method instead.', static::class);
+        trigger_deprecation('zenstruck/foundry', '1.7', 'Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use e.g. "%1$s::new()->stateAdapter()->many()->create()" instead.', static::class, $arguments[0]);
 
         return $this->many($arguments[0])->create($arguments[1] ?? []);
     }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -6,7 +6,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Faker;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Factory;
@@ -20,7 +19,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
  */
 final class FactoryTest extends TestCase
 {
-    use ExpectDeprecationTrait, Factories;
+    use Factories;
 
     /**
      * @test
@@ -46,8 +45,6 @@ final class FactoryTest extends TestCase
      */
     public function can_instantiate_many_objects_legacy(): void
     {
-        $this->expectDeprecation('Since zenstruck/foundry 1.7: Calling instance method "'.Factory::class.'::createMany()" is deprecated and will be removed in 2.0, use the static "'.Factory::class.':createMany()" method instead.');
-
         $attributeArray = ['title' => 'title', 'body' => 'body'];
         $attributeCallback = static function(Faker\Generator $faker) {
             return ['title' => 'title', 'body' => 'body'];
@@ -273,8 +270,6 @@ final class FactoryTest extends TestCase
      */
     public function can_create_many_objects_legacy(): void
     {
-        $this->expectDeprecation('Since zenstruck/foundry 1.7: Calling instance method "'.Factory::class.'::createMany()" is deprecated and will be removed in 2.0, use the static "'.Factory::class.':createMany()" method instead.');
-
         $registry = $this->createMock(ManagerRegistry::class);
         $registry
             ->method('getManagerForClass')

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -50,7 +50,7 @@ final class ModelFactoryTest extends TestCase
      */
     public function can_instantiate_many_legacy(): void
     {
-        $this->expectDeprecation(\sprintf('Since zenstruck/foundry 1.7: Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use the static "%1$s:createMany()" method instead.', PostFactory::class));
+        $this->expectDeprecation(\sprintf('Since zenstruck/foundry 1.7: Calling instance method "%1$s::createMany()" is deprecated and will be removed in 2.0, use e.g. "%1$s::new()->stateAdapter()->many(2)->create()" instead.', PostFactory::class));
 
         $objects = PostFactory::new(['body' => 'body'])->createMany(2, ['title' => 'title']);
 


### PR DESCRIPTION
#288 Message now suggests to use the decomposed functions many() and create() instead of createMany() and gives an example showing how this would look with a common use case, that of adding state.

Fixes #288.