### PR TITLE
fix: discover relations with inheritance

### DIFF
--- a/tests/Fixtures/Entity/Comment.php
+++ b/tests/Fixtures/Entity/Comment.php
@@ -61,6 +61,13 @@ class Comment
         return $this->user;
     }
 
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
     public function getBody(): ?string
     {
         return $this->body;

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -8,6 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity(repositoryClass="Zenstruck\Foundry\Tests\Fixtures\Repository\PostRepository")
  * @ORM\Table(name="posts")
+ * @ORM\InheritanceType(value="SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="type")
+ * @ORM\DiscriminatorMap({"simple": Post::class, "specific": SpecificPost::class})
  */
 class Post
 {
@@ -96,6 +99,16 @@ class Post
      */
     private $lessRelevantRelatedToPost;
 
+    /**
+     * @ORM\ManyToMany(targetEntity=Post::class, inversedBy="relatedToPosts")
+     */
+    private $relatedPosts;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=Post::class, mappedBy="relatedPosts")
+     */
+    private $relatedToPosts;
+
     public function __construct(string $title, string $body, ?string $shortDescription = null)
     {
         $this->title = $title;
@@ -105,6 +118,8 @@ class Post
         $this->tags = new ArrayCollection();
         $this->secondaryTags = new ArrayCollection();
         $this->comments = new ArrayCollection();
+        $this->relatedPosts = new ArrayCollection();
+        $this->relatedToPosts = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -185,6 +200,46 @@ class Post
     public function setPublishedAt(\DateTime $timestamp)
     {
         $this->publishedAt = $timestamp;
+    }
+
+    public function getRelatedPosts()
+    {
+        return $this->relatedPosts;
+    }
+
+    public function addRelatedPost(self $relatedPost)
+    {
+        if (!$this->relatedPosts->contains($relatedPost)) {
+            $this->relatedPosts[] = $relatedPost;
+        }
+    }
+
+    public function removeRelatedPost(self $relatedPost)
+    {
+        if ($this->relatedPosts->contains($relatedPost)) {
+            $this->relatedPosts->removeElement($relatedPost);
+        }
+    }
+
+    public function getRelatedToPosts()
+    {
+        return $this->relatedToPosts;
+    }
+
+    public function addRelatedToPost(self $relatedToPost)
+    {
+        if (!$this->relatedToPosts->contains($relatedToPost)) {
+            $this->relatedToPosts[] = $relatedToPost;
+            $relatedToPost->addRelatedPost($this);
+        }
+    }
+
+    public function removeRelatedToPost(self $relatedToPost)
+    {
+        if ($this->relatedToPosts->contains($relatedToPost)) {
+            $this->relatedToPosts->removeElement($relatedToPost);
+            $relatedToPost->removeRelatedPost($this);
+        }
     }
 
     public function getTags()

--- a/tests/Fixtures/Entity/SpecificPost.php
+++ b/tests/Fixtures/Entity/SpecificPost.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class SpecificPost extends Post
+{
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $specificProperty;
+
+    public function getSpecificProperty()
+    {
+        return $this->specificProperty;
+    }
+
+    public function setSpecificProperty($specificProperty)
+    {
+        $this->specificProperty = $specificProperty;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Entity/User.php
+++ b/tests/Fixtures/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -22,6 +23,16 @@ class User
      */
     private $name;
 
+    /**
+     * @ORM\OneToMany(targetEntity=Comment::class, mappedBy="user", orphanRemoval=true)
+     */
+    private $comments;
+
+    public function __construct()
+    {
+        $this->comments = new ArrayCollection();
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -37,5 +48,29 @@ class User
         $this->name = $name;
 
         return $this;
+    }
+
+    public function getComments()
+    {
+        return $this->comments;
+    }
+
+    public function addComment(Comment $comment)
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments[] = $comment;
+            $comment->setUser($this);
+        }
+    }
+
+    public function removeComment(Comment $comment)
+    {
+        if ($this->comments->contains($comment)) {
+            $this->comments->removeElement($comment);
+            // set the owning side to null (unless already changed)
+            if ($comment->getUser() === $this) {
+                $comment->setUser(null);
+            }
+        }
     }
 }

--- a/tests/Fixtures/Factories/SpecificPostFactory.php
+++ b/tests/Fixtures/Factories/SpecificPostFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\Tests\Fixtures\Entity\SpecificPost;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class SpecificPostFactory extends PostFactory
+{
+    protected static function getClass(): string
+    {
+        return SpecificPost::class;
+    }
+}

--- a/tests/Fixtures/Migrations/Version20220925092634.php
+++ b/tests/Fixtures/Migrations/Version20220925092634.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220925092634 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE post_post (post_source INT NOT NULL, post_target INT NOT NULL, INDEX IDX_93DF0B866FA89B16 (post_source), INDEX IDX_93DF0B86764DCB99 (post_target), PRIMARY KEY(post_source, post_target)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE post_post ADD CONSTRAINT FK_93DF0B866FA89B16 FOREIGN KEY (post_source) REFERENCES posts (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE post_post ADD CONSTRAINT FK_93DF0B86764DCB99 FOREIGN KEY (post_target) REFERENCES posts (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE posts ADD type VARCHAR(255) NOT NULL DEFAULT \'simple\', ADD specificProperty VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE post_post DROP FOREIGN KEY FK_93DF0B866FA89B16');
+        $this->addSql('ALTER TABLE post_post DROP FOREIGN KEY FK_93DF0B86764DCB99');
+        $this->addSql('DROP TABLE post_post');
+        $this->addSql('ALTER TABLE posts DROP type, DROP specificProperty');
+    }
+}


### PR DESCRIPTION
Hi,
I have stumbled upon this bug.

In my entities, I have a "polymorphic" relationship which is typed with an Abstract class, implemented by 2 entities. The package is not able to detect their relation and normalize the factories. This fixes it.

I have not added tests because it needs changes in entities and I do not know how you wish to implement it.


```php
abstract class CourseLocation {
#[ORM\OneToMany(mappedBy: 'courseLocation', targetEntity: CourseLocationContact::class, cascade: ['persist'], orphanRemoval: true)]
    protected Collection $contacts;

    /**
     * @return Collection|CourseLocationContact[]
     */
    public function getContacts(): array|Collection
    {
        return $this->contacts;
    }

    public function addContact(CourseLocationContact $contact): static
    {
        if (!$this->contacts->contains($contact)) {
            $this->contacts->add($contact);
            $contact->setCourseLocation($this);
        }

        return $this;
    }

    public function removeContact(CourseLocationContact $contact): static
    {
        if ($this->contacts->removeElement($contact)) {
            // set the owning side to null (unless already changed)
            if ($contact->getCourseLocation() === $this) {
                $contact->setCourseLocation(null);
            }
        }

        return $this;
    }
}

class TrainingCenter extends CourseLocation {}

class TemporarySite extends CourseLocation {}

class CourseLocationContact
{
    #[ORM\ManyToOne(targetEntity: CourseLocation::class, inversedBy: 'contacts')]
    private ?CourseLocation $courseLocation;

    public function getCourseLocation(): ?CourseLocation
    {
        return $this->courseLocation;
    }

    public function setCourseLocation(?CourseLocation $courseLocation): self
    {
        $this->courseLocation = $courseLocation;

        return $this;
    }
}
```

Acutal error : 
> A new entity was found through the relationship 'App\Entity\CourseLocationContact#courseLocation' that was not configured to cascade persist operations for entity: TrainingCenter. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example `@ManyToOne(..,cascade={"persist"})`. 

---
Below will be addressed is addressed in #302.

As a side note, I dont think the actual code (nothing to do with the fix) can work with this situation, as I think it will arbitrary choose the first relation with corresponding type (here `User`) :
```php
class Post {
    private User $author;
    private User $reader;
}

class User {
    private Collection $authoredPosts;
    private Collection $readerPosts;
}

UserFactory::new(['readerPosts' => PostFactory::new()->many(5)]);
```

Is it possible to **also** check the original relation name ?