### PR TITLE
fix: multiple relationships with same entity

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -94,12 +94,11 @@ class Factory
         }
 
         // filter each attribute to convert proxies and factories to objects
-        $attributes = \array_map(
-            function($value) {
-                return $this->normalizeAttribute($value);
-            },
-            $attributes
-        );
+        $mappedAttributes = [];
+        foreach ($attributes as $name => $value) {
+            $mappedAttributes[$name] = $this->normalizeAttribute($value, $name);
+        }
+        $attributes = $mappedAttributes;
 
         // instantiate the object with the users instantiator or if not set, the default instantiator
         $object = ($this->instantiator ?? self::configuration()->instantiator())($attributes, $this->class);
@@ -292,14 +291,14 @@ class Factory
      *
      * @return mixed
      */
-    private function normalizeAttribute($value)
+    private function normalizeAttribute($value, ?string $name = null)
     {
         if ($value instanceof Proxy) {
             return $value->isPersisted() ? $value->refresh()->object() : $value->object();
         }
 
         if ($value instanceof FactoryCollection) {
-            $value = $this->normalizeCollection($value);
+            $value = $this->normalizeCollection($name, $value);
         }
 
         if (\is_array($value)) {
@@ -323,7 +322,7 @@ class Factory
 
         // Check if the attribute is cascade persist
         if (self::configuration()->hasManagerRegistry()) {
-            $relationField = $this->relationshipField($value);
+            $relationField = $this->relationshipField($name, $value);
             $value->cascadePersist = $this->hasCascadePersist($value, $relationField);
         }
 
@@ -339,10 +338,10 @@ class Factory
         }
     }
 
-    private function normalizeCollection(FactoryCollection $collection): array
+    private function normalizeCollection(?string $fieldName, FactoryCollection $collection): array
     {
         if ($this->isPersisting()) {
-            $field = $this->inverseRelationshipField($collection->factory());
+            $field = $this->inverseRelationshipField($fieldName, $collection->factory());
             $cascadePersist = $this->hasCascadePersist($collection->factory(), $field);
 
             if ($field && false === $cascadePersist) {
@@ -366,7 +365,7 @@ class Factory
         );
     }
 
-    private function relationshipField(self $factory): ?string
+    private function relationshipField(?string $relationName, self $factory): ?string
     {
         $factoryClass = $this->class;
         $relationClass = $factory->class;
@@ -378,17 +377,32 @@ class Factory
             return null;
         }
 
+        try {
+            // Check mappedBy side ($factory is the owner of the relation)
+            $relationClassMetadata = self::configuration()->objectManagerFor($relationClass)->getClassMetadata($relationClass);
+        } catch (\RuntimeException $e) {
+            // relation not managed - could be embeddable
+            $relationClassMetadata = null;
+        }
+
+        if (null !== $relationName && $factoryClassMetadata->hasAssociation($relationName) && \is_a($factory->class, $factoryClassMetadata->getAssociationTargetclass($relationName), true)) {
+            if ($factoryClassMetadata->isAssociationInverseSide($relationName)) {
+                $mappedBy = $factoryClassMetadata->getAssociationMappedByTargetField($relationName);
+                if (null !== $relationClassMetadata && $relationClassMetadata->hasAssociation($mappedBy) && ($relationClassMetadata->isSingleValuedAssociation($mappedBy) || $relationClassMetadata->isCollectionValuedAssociation($mappedBy)) && \is_a($factoryClass, $relationClassMetadata->getAssociationTargetClass($mappedBy), true)) {
+                    return $mappedBy;
+                }
+            } else {
+                return $relationName;
+            }
+        }
+
         foreach ($factoryClassMetadata->getAssociationNames() as $field) {
             if (!$factoryClassMetadata->isAssociationInverseSide($field) && $factoryClassMetadata->getAssociationTargetClass($field) === $relationClass) {
                 return $field;
             }
         }
 
-        try {
-            // Check mappedBy side ($factory is the owner of the relation)
-            $relationClassMetadata = self::configuration()->objectManagerFor($relationClass)->getClassMetadata($relationClass);
-        } catch (\RuntimeException $e) {
-            // relation not managed - could be embeddable
+        if (null === $relationClassMetadata) {
             return null;
         }
 
@@ -401,10 +415,18 @@ class Factory
         return null; // no relationship found
     }
 
-    private function inverseRelationshipField(self $factory): ?string
+    private function inverseRelationshipField(?string $relationName, self $factory): ?string
     {
+        $factoryClass = $this->class;
         $collectionClass = $factory->class;
+        $factoryClassMetadata = self::configuration()->objectManagerFor($factoryClass)->getMetadataFactory()->getMetadataFor($factoryClass);
         $collectionMetadata = self::configuration()->objectManagerFor($collectionClass)->getClassMetadata($collectionClass);
+
+        if (null !== $relationName && $factoryClassMetadata instanceof ORMClassMetadata && $factoryClassMetadata->hasAssociation($relationName) && \is_a($factory->class, $factoryClassMetadata->getAssociationTargetclass($relationName), true) && null !== $mappedBy = $factoryClassMetadata->getAssociationMappedByTargetField($relationName)) {
+            if ($collectionMetadata->isSingleValuedAssociation($mappedBy)) {
+                return $mappedBy;
+            }
+        }
 
         foreach ($collectionMetadata->getAssociationNames() as $field) {
             // ensure 1-n and associated class matches

--- a/tests/Fixtures/Entity/Category.php
+++ b/tests/Fixtures/Entity/Category.php
@@ -28,9 +28,15 @@ class Category
      */
     private $posts;
 
+    /**
+     * @ORM\OneToMany(targetEntity=Post::class, mappedBy="secondaryCategory")
+     */
+    private $secondaryPosts;
+
     public function __construct()
     {
         $this->posts = new ArrayCollection();
+        $this->secondaryPosts = new ArrayCollection();
     }
 
     public function getId()
@@ -68,6 +74,30 @@ class Category
             // set the owning side to null (unless already changed)
             if ($post->getCategory() === $this) {
                 $post->setCategory(null);
+            }
+        }
+    }
+
+    public function getSecondaryPosts()
+    {
+        return $this->posts;
+    }
+
+    public function addSecondaryPost(Post $secondaryPost)
+    {
+        if (!$this->secondaryPosts->contains($secondaryPost)) {
+            $this->secondaryPosts[] = $secondaryPost;
+            $secondaryPost->setCategory($this);
+        }
+    }
+
+    public function removeSecondaryPost(Post $secondaryPost)
+    {
+        if ($this->secondaryPosts->contains($secondaryPost)) {
+            $this->secondaryPosts->removeElement($secondaryPost);
+            // set the owning side to null (unless already changed)
+            if ($secondaryPost->getCategory() === $this) {
+                $secondaryPost->setCategory(null);
             }
         }
     }

--- a/tests/Fixtures/Entity/Post.php
+++ b/tests/Fixtures/Entity/Post.php
@@ -55,14 +55,46 @@ class Post
     private $category;
 
     /**
+     * @ORM\ManyToOne(targetEntity=Category::class, inversedBy="secondaryPosts")
+     * @ORM\JoinColumn(name="secondary_category_id")
+     */
+    private $secondaryCategory;
+
+    /**
      * @ORM\ManyToMany(targetEntity=Tag::class, inversedBy="posts")
      */
     private $tags;
 
     /**
+     * @ORM\ManyToMany(targetEntity=Tag::class, inversedBy="secondaryPosts")
+     * @ORM\JoinTable(name="post_tag_secondary")
+     */
+    private $secondaryTags;
+
+    /**
      * @ORM\OneToMany(targetEntity=Comment::class, mappedBy="post")
      */
     private $comments;
+
+    /**
+     * @ORM\OneToOne(targetEntity=Post::class, inversedBy="mostRelevantRelatedToPost")
+     */
+    private $mostRelevantRelatedPost;
+
+    /**
+     * @ORM\OneToOne(targetEntity=Post::class, mappedBy="mostRelevantRelatedPost")
+     */
+    private $mostRelevantRelatedToPost;
+
+    /**
+     * @ORM\OneToOne(targetEntity=Post::class, inversedBy="lessRelevantRelatedToPost")
+     */
+    private $lessRelevantRelatedPost;
+
+    /**
+     * @ORM\OneToOne(targetEntity=Post::class, mappedBy="lessRelevantRelatedPost")
+     */
+    private $lessRelevantRelatedToPost;
 
     public function __construct(string $title, string $body, ?string $shortDescription = null)
     {
@@ -71,6 +103,7 @@ class Post
         $this->shortDescription = $shortDescription;
         $this->createdAt = new \DateTime('now');
         $this->tags = new ArrayCollection();
+        $this->secondaryTags = new ArrayCollection();
         $this->comments = new ArrayCollection();
     }
 
@@ -134,6 +167,16 @@ class Post
         $this->category = $category;
     }
 
+    public function getSecondaryCategory(): ?Category
+    {
+        return $this->secondaryCategory;
+    }
+
+    public function setSecondaryCategory(?Category $secondaryCategory)
+    {
+        $this->secondaryCategory = $secondaryCategory;
+    }
+
     public function isPublished(): bool
     {
         return null !== $this->publishedAt;
@@ -157,6 +200,25 @@ class Post
     }
 
     public function removeTag(Tag $tag)
+    {
+        if ($this->tags->contains($tag)) {
+            $this->tags->removeElement($tag);
+        }
+    }
+
+    public function getSecondaryTags()
+    {
+        return $this->secondaryTags;
+    }
+
+    public function addSecondaryTag(Tag $secondaryTag)
+    {
+        if (!$this->secondaryTags->contains($secondaryTag)) {
+            $this->secondaryTags[] = $secondaryTag;
+        }
+    }
+
+    public function removeSecondaryTag(Tag $tag)
     {
         if ($this->tags->contains($tag)) {
             $this->tags->removeElement($tag);
@@ -189,5 +251,45 @@ class Post
         }
 
         return $this;
+    }
+
+    public function getMostRelevantRelatedPost(): ?self
+    {
+        return $this->mostRelevantRelatedPost;
+    }
+
+    public function setMostRelevantRelatedPost(?self $mostRelevantRelatedPost)
+    {
+        $this->mostRelevantRelatedPost = $mostRelevantRelatedPost;
+    }
+
+    public function getMostRelevantRelatedToPost(): ?self
+    {
+        return $this->mostRelevantRelatedToPost;
+    }
+
+    public function setMostRelevantRelatedToPost(?self $mostRelevantRelatedToPost)
+    {
+        $this->mostRelevantRelatedToPost = $mostRelevantRelatedToPost;
+    }
+
+    public function getLessRelevantRelatedPost(): ?self
+    {
+        return $this->lessRelevantRelatedPost;
+    }
+
+    public function setLessRelevantRelatedPost(?self $lessRelevantRelatedPost)
+    {
+        $this->lessRelevantRelatedPost = $lessRelevantRelatedPost;
+    }
+
+    public function getLessRelevantRelatedToPost(): ?self
+    {
+        return $this->lessRelevantRelatedToPost;
+    }
+
+    public function setLessRelevantRelatedToPost(?self $lessRelevantRelatedToPost)
+    {
+        $this->lessRelevantRelatedToPost = $lessRelevantRelatedToPost;
     }
 }

--- a/tests/Fixtures/Entity/Tag.php
+++ b/tests/Fixtures/Entity/Tag.php
@@ -28,9 +28,15 @@ class Tag
      */
     private $posts;
 
+    /**
+     * @ORM\ManyToMany(targetEntity=Post::class, mappedBy="secondaryTags")
+     */
+    private $secondaryPosts;
+
     public function __construct()
     {
         $this->posts = new ArrayCollection();
+        $this->secondaryPosts = new ArrayCollection();
     }
 
     public function getName(): ?string
@@ -61,6 +67,27 @@ class Tag
         if ($this->posts->contains($post)) {
             $this->posts->removeElement($post);
             $post->removeTag($this);
+        }
+    }
+
+    public function getSecondaryPosts()
+    {
+        return $this->secondaryPosts;
+    }
+
+    public function addSecondaryPost(Post $secondaryPost)
+    {
+        if (!$this->secondaryPosts->contains($secondaryPost)) {
+            $this->secondaryPosts[] = $secondaryPost;
+            $secondaryPost->addTag($this);
+        }
+    }
+
+    public function removeSecondaryPost(Post $secondaryPost)
+    {
+        if ($this->secondaryPosts->contains($secondaryPost)) {
+            $this->secondaryPosts->removeElement($secondaryPost);
+            $secondaryPost->removeTag($this);
         }
     }
 }

--- a/tests/Fixtures/Migrations/Version20220925092226.php
+++ b/tests/Fixtures/Migrations/Version20220925092226.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220925092226 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE posts ADD mostRelevantRelatedPost_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE posts ADD CONSTRAINT FK_885DBAFAD126F51 FOREIGN KEY (mostRelevantRelatedPost_id) REFERENCES posts (id)');
+        $this->addSql('CREATE INDEX IDX_885DBAFAD126F51 ON posts (mostRelevantRelatedPost_id)');
+        $this->addSql('ALTER TABLE posts ADD lessRelevantRelatedPost_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE posts ADD CONSTRAINT FK_985DBAFAD126F52 FOREIGN KEY (lessRelevantRelatedPost_id) REFERENCES posts (id)');
+        $this->addSql('CREATE INDEX IDX_985DBAFAD126F52 ON posts (lessRelevantRelatedPost_id)');
+
+        $this->addSql('CREATE TABLE post_tag_secondary (post_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_1515F0214B89032C (post_id), INDEX IDX_1515F021BAD26311 (tag_id), PRIMARY KEY(post_id, tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE post_tag_secondary ADD CONSTRAINT FK_1515F0214B89032C FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE post_tag_secondary ADD CONSTRAINT FK_1515F021BAD26311 FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE posts ADD secondary_category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE posts ADD CONSTRAINT FK_885DBAFAEA0D7566 FOREIGN KEY (secondary_category_id) REFERENCES categories (id)');
+        $this->addSql('CREATE INDEX IDX_885DBAFAEA0D7566 ON posts (secondary_category_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_985DBAFAD126F52');
+        $this->addSql('DROP INDEX IDX_985DBAFAD126F52 ON posts');
+        $this->addSql('ALTER TABLE posts DROP lessRelevantRelatedPost_id');
+        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFAD126F51');
+        $this->addSql('DROP INDEX IDX_885DBAFAD126F51 ON posts');
+        $this->addSql('ALTER TABLE posts DROP mostRelevantRelatedPost_id');
+
+        $this->addSql('ALTER TABLE post_tag_secondary DROP FOREIGN KEY FK_1515F0214B89032C');
+        $this->addSql('ALTER TABLE post_tag_secondary DROP FOREIGN KEY FK_1515F021BAD26311');
+        $this->addSql('DROP TABLE post_tag_secondary');
+
+        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFAEA0D7566');
+        $this->addSql('DROP INDEX IDX_885DBAFAEA0D7566 ON posts');
+        $this->addSql('ALTER TABLE posts DROP secondary_category_id');
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -76,6 +76,74 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     /**
      * @test
      */
+    public function one_to_many_with_two_relationships_same_entity(): void
+    {
+        $category = CategoryFactory::createOne([
+            'posts' => PostFactory::new()->many(4),
+            'secondaryPosts' => PostFactory::new()->many(4),
+        ]);
+
+        $this->assertCount(4, $category->getPosts());
+        $this->assertCount(4, $category->getSecondaryPosts());
+        PostFactory::assert()->count(8);
+        CategoryFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_one_with_two_relationships_same_entity(): void
+    {
+        $post = PostFactory::createOne([
+            'category' => CategoryFactory::new(['name' => 'foo']),
+            'secondaryCategory' => CategoryFactory::new(['name' => 'bar']),
+        ]);
+
+        $this->assertNotNull($category = $post->getCategory());
+        $this->assertNotNull($secondaryCategory = $post->getSecondaryCategory());
+        $this->assertSame('foo', $category->getName());
+        $this->assertSame('bar', $secondaryCategory->getName());
+        PostFactory::assert()->count(1);
+        CategoryFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_one_with_two_relationships_same_entity(): void
+    {
+        $post = PostFactory::createOne([
+            'mostRelevantRelatedPost' => PostFactory::new(['title' => 'foo']),
+            'lessRelevantRelatedPost' => PostFactory::new(['title' => 'bar']),
+        ]);
+
+        $this->assertNotNull($mostRelevantRelatedPost = $post->getMostRelevantRelatedPost());
+        $this->assertNotNull($lessRelevantRelatedPost = $post->getLessRelevantRelatedPost());
+        $this->assertSame('foo', $mostRelevantRelatedPost->getTitle());
+        $this->assertSame('bar', $lessRelevantRelatedPost->getTitle());
+        PostFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
+    public function inverse_one_to_one_with_two_relationships_same_entity(): void
+    {
+        $post = PostFactory::createOne([
+            'mostRelevantRelatedToPost' => PostFactory::new(['title' => 'foo']),
+            'lessRelevantRelatedToPost' => PostFactory::new(['title' => 'bar']),
+        ]);
+
+        $this->assertNotNull($mostRelevantRelatedToPost = $post->getMostRelevantRelatedToPost());
+        $this->assertNotNull($lessRelevantRelatedToPost = $post->getLessRelevantRelatedToPost());
+        $this->assertSame('foo', $mostRelevantRelatedToPost->getTitle());
+        $this->assertSame('bar', $lessRelevantRelatedToPost->getTitle());
+        PostFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
     public function create_multiple_one_to_many_with_nested_collection_relationship(): void
     {
         $user = UserFactory::createOne();
@@ -107,6 +175,22 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     /**
      * @test
      */
+    public function many_to_many_with_two_relationships_same_entity(): void
+    {
+        $post = PostFactory::createOne([
+            'tags' => TagFactory::new()->many(3),
+            'secondaryTags' => TagFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $post->getTags());
+        $this->assertCount(3, $post->getSecondaryTags());
+        TagFactory::assert()->count(8); // 3 created by this test and 2 in global state
+        PostFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
     public function inverse_many_to_many_with_nested_collection_relationship(): void
     {
         $tag = TagFactory::createOne([
@@ -116,6 +200,22 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         $this->assertCount(3, $tag->getPosts());
         TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
         PostFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
+    public function inverse_many_to_many_with_two_relationships_same_entity(): void
+    {
+        $tag = TagFactory::createOne([
+            'posts' => PostFactory::new()->many(3),
+            'secondaryPosts' => PostFactory::new()->many(3),
+        ]);
+
+        $this->assertCount(3, $tag->getPosts());
+        $this->assertCount(3, $tag->getSecondaryPosts());
+        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
+        PostFactory::assert()->count(6);
     }
 
     /**


### PR DESCRIPTION
Hello again,

I have confirmed there is an issue when an entity have two not owned relationships with the same target entity. (Mentionned it in #300).

```php
class Post {
    // many to one, owner, mapped by authoredPosts
    private User $author;
    // many to one, owner, mapped by readingPosts
    private User $reader;

    // one to one, owner, mapped by oneToOnePost
    private User $oneToOneUser;

    // many to many, owner, mapped by readPosts
    private Collection $readers;
    // many to many, owner, mapped by likedPosts
    private Collection $likers;
}

class User {
    private Collection $authoredPosts;
    private Collection $readingPosts;
    
    private Post $oneToOnePost;

    private Collection $readPosts;
    private Collection $likedPosts;
}

UserFactory::new([
  // will set author
  'readerPosts' => PostFactory::new()->many(5),
  // will ALSO set author
  'authoredPosts' => PostFactory::new()->many(5),
  // will ALSO set author
  'oneToOnePost' => PostFactory::new(),
  // will set readPosts
  'readPosts' => PostFactory::new()->many(5),
  // I think it will ALSO set readPosts but not sure there
  'likedPosts' => PostFactory::new()->many(5),
]);
```

I have implemented the corresponding tests and proposed a fix. The necessary migration for the tests is missing, as I would need #301 to have a correct environment. **EDIT** Nevermind, I have managed to add the migration.