### PR TITLE
[feature] allow creating "rich domain models"

### DIFF
--- a/tests/Fixtures/Entity/Cascade/CascadeRichComment.php
+++ b/tests/Fixtures/Entity/Cascade/CascadeRichComment.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CascadeRichComment
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    private string $body;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=CascadeRichPost::class, inversedBy="comments", cascade={"persist"})
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private CascadeRichPost $post;
+
+    public function __construct(string $body, CascadeRichPost $post)
+    {
+        $this->body = $body;
+        $this->post = $post;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getPost(): CascadeRichPost
+    {
+        return $this->post;
+    }
+}

--- a/tests/Fixtures/Entity/Cascade/CascadeRichPost.php
+++ b/tests/Fixtures/Entity/Cascade/CascadeRichPost.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CascadeRichPost
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private string $title;
+
+    /**
+     * @ORM\OneToMany(targetEntity=CascadeRichComment::class, mappedBy="post", orphanRemoval=true, cascade={"persist"})
+     */
+    private Collection $comments;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+        $this->comments = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return Collection<CascadeRichComment>
+     */
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
+
+    public function addComment(CascadeRichComment $comment): void
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments->add($comment);
+        }
+    }
+
+    public function removeComment(CascadeRichComment $comment): void
+    {
+        if ($this->comments->contains($comment)) {
+            $this->comments->removeElement($comment);
+        }
+    }
+}

--- a/tests/Fixtures/Entity/RichComment.php
+++ b/tests/Fixtures/Entity/RichComment.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class RichComment
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    private string $body;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=RichPost::class, inversedBy="comments")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private RichPost $post;
+
+    public function __construct(string $body, RichPost $post)
+    {
+        $this->body = $body;
+        $this->post = $post;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getPost(): RichPost
+    {
+        return $this->post;
+    }
+}

--- a/tests/Fixtures/Entity/RichPost.php
+++ b/tests/Fixtures/Entity/RichPost.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class RichPost
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private string $title;
+
+    /**
+     * @ORM\OneToMany(targetEntity=RichComment::class, mappedBy="post", orphanRemoval=true)
+     */
+    private Collection $comments;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+        $this->comments = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return Collection<RichComment>
+     */
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
+
+    public function addComment(RichComment $comment): void
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments->add($comment);
+        }
+    }
+
+    public function removeComment(RichComment $comment): void
+    {
+        if ($this->comments->contains($comment)) {
+            $this->comments->removeElement($comment);
+        }
+    }
+}

--- a/tests/Fixtures/Factories/CascadeRichCommentFactory.php
+++ b/tests/Fixtures/Factories/CascadeRichCommentFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\CascadeRichComment;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CascadeRichCommentFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return CascadeRichComment::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'body' => self::faker()->text(),
+            'post' => CascadeRichPostFactory::new(),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/CascadeRichPostFactory.php
+++ b/tests/Fixtures/Factories/CascadeRichPostFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\CascadeRichPost;
+
+final class CascadeRichPostFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return CascadeRichPost::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'title' => self::faker()->text(),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/RichCommentFactory.php
+++ b/tests/Fixtures/Factories/RichCommentFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\RichComment;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RichCommentFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return RichComment::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'body' => self::faker()->text(),
+            'post' => RichPostFactory::new(),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/RichPostFactory.php
+++ b/tests/Fixtures/Factories/RichPostFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\RichPost;
+
+final class RichPostFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return RichPost::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'title' => self::faker()->text(),
+        ];
+    }
+}

--- a/tests/Fixtures/Migrations/Version20230109210404.php
+++ b/tests/Fixtures/Migrations/Version20230109210404.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230109210404 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE CascadeRichComment (id INT AUTO_INCREMENT NOT NULL, post_id INT NOT NULL, body LONGTEXT NOT NULL, INDEX IDX_A4B2EA424B89032C (post_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE CascadeRichPost (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE RichComment (id INT AUTO_INCREMENT NOT NULL, post_id INT NOT NULL, body LONGTEXT NOT NULL, INDEX IDX_C6E248524B89032C (post_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE RichPost (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE CascadeRichComment ADD CONSTRAINT FK_A4B2EA424B89032C FOREIGN KEY (post_id) REFERENCES CascadeRichPost (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE RichComment ADD CONSTRAINT FK_C6E248524B89032C FOREIGN KEY (post_id) REFERENCES RichPost (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE CascadeRichComment DROP FOREIGN KEY FK_A4B2EA424B89032C');
+        $this->addSql('ALTER TABLE RichComment DROP FOREIGN KEY FK_C6E248524B89032C');
+        $this->addSql('DROP TABLE CascadeRichComment');
+        $this->addSql('DROP TABLE CascadeRichPost');
+        $this->addSql('DROP TABLE RichComment');
+        $this->addSql('DROP TABLE RichPost');
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -12,8 +12,11 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Zenstruck\Foundry\Instantiator;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CascadeRichCommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CascadeRichPostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ContactFactory;
@@ -21,6 +24,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\RichCommentFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\RichPostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\SpecificPostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
@@ -538,6 +543,102 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         PostFactory::assert()->count(4);
         PostFactory::assert()->count(2, ['category' => $category]);
         self::assertSame(2, PostFactory::count(['category' => $category]));
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_factories_for_rich_domain_models(): void
+    {
+        $post = RichPostFactory::createOne([
+            'comments' => RichCommentFactory::new()->many(5),
+        ]);
+
+        RichPostFactory::assert()->count(1);
+        RichCommentFactory::assert()->count(5);
+        $this->assertCount(5, $post->getComments());
+
+        foreach (RichCommentFactory::all() as $comment) {
+            $this->assertSame($post->object(), $comment->getPost());
+        }
+
+        $post->removeComment(RichCommentFactory::first()->object());
+        $post->save();
+
+        RichPostFactory::assert()->count(1);
+        RichCommentFactory::assert()->count(4);
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_factories_for_rich_domain_models_using_force(): void
+    {
+        $post = RichPostFactory::new()->instantiateWith((new Instantiator())->alwaysForceProperties())->create([
+            'comments' => RichCommentFactory::new()->many(5),
+        ]);
+
+        RichPostFactory::assert()->count(1);
+        RichCommentFactory::assert()->count(5);
+        $this->assertCount(5, $post->getComments());
+
+        foreach (RichCommentFactory::all() as $comment) {
+            $this->assertSame($post->object(), $comment->getPost());
+        }
+
+        $post->removeComment(RichCommentFactory::first()->object());
+        $post->save();
+
+        RichPostFactory::assert()->count(1);
+        RichCommentFactory::assert()->count(4);
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_factories_for_cascade_rich_domain_models(): void
+    {
+        $post = CascadeRichPostFactory::createOne([
+            'comments' => CascadeRichCommentFactory::new()->many(5),
+        ]);
+
+        CascadeRichPostFactory::assert()->count(1);
+        CascadeRichCommentFactory::assert()->count(5);
+        $this->assertCount(5, $post->getComments());
+
+        foreach (CascadeRichCommentFactory::all() as $comment) {
+            $this->assertSame($post->object(), $comment->getPost());
+        }
+
+        $post->removeComment(CascadeRichCommentFactory::first()->object());
+        $post->save();
+
+        CascadeRichPostFactory::assert()->count(1);
+        CascadeRichCommentFactory::assert()->count(4);
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_factories_for_cascade_rich_domain_models_using_force(): void
+    {
+        $post = CascadeRichPostFactory::new()->instantiateWith((new Instantiator())->alwaysForceProperties())->create([
+            'comments' => CascadeRichCommentFactory::new()->many(5),
+        ]);
+
+        CascadeRichPostFactory::assert()->count(1);
+        CascadeRichCommentFactory::assert()->count(5);
+        $this->assertCount(5, $post->getComments());
+
+        foreach (CascadeRichCommentFactory::all() as $comment) {
+            $this->assertSame($post->object(), $comment->getPost());
+        }
+
+        $post->removeComment(CascadeRichCommentFactory::first()->object());
+        $post->save();
+
+        CascadeRichPostFactory::assert()->count(1);
+        CascadeRichCommentFactory::assert()->count(4);
     }
 
     protected function categoryClass(): string


### PR DESCRIPTION
Possible solution for #305. When forcing properties with the `Instantiator`, covert `array`'s to `ArrayCollection`'s if the typehint demands it.

Not a huge fan of this solution... I think I'd prefer `FactoryCollection` generate an `ArrayCollection` and then it can be set directly. I'll explore this option.