### PR TITLE
[feat] pass an index to FactoryCollection attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,13 @@ fixcs: docker-start bin/tools/cs-fixer/vendor ### Run PHP CS-Fixer
 	@${DOCKER_PHP} bin/tools/cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer --no-interaction --diff -v fix
 
 bin/tools/cs-fixer/vendor: vendor bin/tools/cs-fixer/composer.json bin/tools/cs-fixer/composer.lock
-	@${DOCKER_PHP} composer bin cs-fixer update
+	@${DOCKER_PHP} composer bin cs-fixer install
 
 sca: docker-start bin/tools/psalm/vendor ### Run Psalm
 	@${DOCKER_PHP} bin/tools/psalm/vendor/vimeo/psalm/psalm --config=./psalm.xml
 
 bin/tools/psalm/vendor: vendor bin/tools/psalm/composer.json bin/tools/psalm/composer.lock
-	@${DOCKER_PHP} composer bin psalm update
+	@${DOCKER_PHP} composer bin psalm install
 
 database-generate-migration: docker-start vendor ### Generate new migration based on mapping in Zenstruck\Foundry\Tests\Fixtures\Entity
 	@${DC_EXEC} -e DATABASE_URL=${MYSQL_URL} php vendor/bin/doctrine-migrations migrations:migrate --no-interaction --allow-no-migration # first, let's load into db existing migrations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -278,6 +278,14 @@ Using your Factory
     PostFactory::createMany(5); // returns Post[]|Proxy[]
     PostFactory::createMany(5, ['title' => 'My Title']);
 
+    // Create 5 posts with incremental title
+    PostFactory::createMany(
+        5,
+        static function(int $i) {
+            return ['title' => "Title $i"]; // "Title 1", "Title 2", ... "Title 5"
+        }
+    );
+
     // find a persisted object for the given attributes, if not found, create with the attributes
     PostFactory::findOrCreate(['title' => 'My Title']); // returns Post|Proxy
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -307,7 +307,7 @@ class Factory
      */
     private static function normalizeAttributes($attributes): array
     {
-        return \is_callable($attributes) ? $attributes(self::faker()) : $attributes;
+        return \is_callable($attributes) ? $attributes() : $attributes;
     }
 
     /**

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -73,12 +73,14 @@ final class FactoryCollection implements \IteratorAggregate
      */
     public function create($attributes = []): array
     {
-        return \array_map(
-            static function(Factory $factory) use ($attributes) {
-                return $factory->create($attributes);
-            },
-            $this->all()
-        );
+        $objects = [];
+        foreach ($this->all() as $i => $factory) {
+            $objects[] = $factory->create(
+                \is_callable($attributes) ? $attributes($i + 1) : $attributes
+            );
+        }
+
+        return $objects;
     }
 
     /**

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -332,6 +332,22 @@ abstract class ModelFactoryTest extends KernelTestCase
 
     /**
      * @test
+     */
+    public function can_create_many_objects_with_index(): void
+    {
+        $categoryFactoryClass = $this->categoryFactoryClass();
+        $categoryFactoryClass::createMany(2, static function(int $i) {
+            return [
+                'name' => "foo {$i}",
+            ];
+        });
+
+        $categoryFactoryClass::assert()->exists(['name' => 'foo 1']);
+        $categoryFactoryClass::assert()->exists(['name' => 'foo 2']);
+    }
+
+    /**
+     * @test
      * @dataProvider factoryCollectionAsDataProvider
      */
     public function can_use_factory_collection_as_data_provider(FactoryCollection $factoryCollection): void

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -27,7 +27,7 @@ final class FactoryTest extends TestCase
     public function can_instantiate_object(): void
     {
         $attributeArray = ['title' => 'title', 'body' => 'body'];
-        $attributeCallback = static function(Faker\Generator $faker) {
+        $attributeCallback = static function() {
             return ['title' => 'title', 'body' => 'body'];
         };
 
@@ -46,7 +46,7 @@ final class FactoryTest extends TestCase
     public function can_instantiate_many_objects_legacy(): void
     {
         $attributeArray = ['title' => 'title', 'body' => 'body'];
-        $attributeCallback = static function(Faker\Generator $faker) {
+        $attributeCallback = static function() {
             return ['title' => 'title', 'body' => 'body'];
         };
 


### PR DESCRIPTION
fixes #316 

:warning: this PR introduces a *small* BC break: when a callback was passed to `withAttributes()` we were giving it an instance of faker, which is not made anymore. This behavior was not even documented nor tested, and the faker instance can be retrieved in another way