### PR TITLE
[feat] [remove bundleless usge] configure global state with config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-postgresql: docker-start vendor ### Run PHPunit with postgreSQL
 
 test-mongo: docker-start vendor ### Run PHPunit with Mongo
 	@$(eval filter ?= '.')
-	@${DC_EXEC} -e MONGO_URL=${MONGO_URL} php vendor/bin/simple-phpunit --configuration phpunit.xml.dist --filter=$(filter)
+	@${DC_EXEC} -e USE_FOUNDRY_BUNDLE=1 -e MONGO_URL=${MONGO_URL} php vendor/bin/simple-phpunit --configuration phpunit.xml.dist --filter=$(filter)
 
 fixcs: docker-start bin/tools/cs-fixer/vendor ### Run PHP CS-Fixer
 	@${DOCKER_PHP} bin/tools/cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer --no-interaction --diff -v fix

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1397,29 +1397,21 @@ Both object proxies and your ModelFactory have helpful PHPUnit assertions:
 Global State
 ~~~~~~~~~~~~
 
-If you have an initial database state you want for all tests, you can set this in your ``tests/bootstrap.php``:
+If you have an initial database state you want for all tests, you can set this in the config of the bundle. Accepted
+values are: stories as service, "global" stories and invokable services.
 
-.. code-block:: php
+.. configuration-block::
 
-    // tests/bootstrap.php
-    // ...
+    .. code-block:: yaml
 
-    Zenstruck\Foundry\Test\TestState::addGlobalState(function () {
-        CategoryFactory::createOne(['name' => 'php']);
-        CategoryFactory::createOne(['name' => 'symfony']);
-    });
-
-To avoid your bootstrap file from becoming too complex, it is best to wrap your global state into a
-:ref:`Story <stories>`:
-
-.. code-block:: php
-
-    // tests/bootstrap.php
-    // ...
-
-    Zenstruck\Foundry\Test\TestState::addGlobalState(function () {
-        GlobalStory::load();
-    });
+        # config/packages/zenstruck_foundry.yaml
+        when@test: # see Bundle Configuration section about sharing this in the test environment
+            zenstruck_foundry:
+                global_state:
+                    - App\Stories\StoryThatIsAService
+                    - App\Stories\GlobalStory
+                    - invokable.service # just a service with ::invoke()
+                    - ...
 
 .. note::
 
@@ -1954,6 +1946,9 @@ Full Default Bundle Configuration
                     # Object managers to reset. If empty, the default manager is used.
                     object_managers: []
 
+            # Add global state.
+            global_state: []
+
     .. code-block:: php
 
         $config->extension('zenstruck_foundry', [
@@ -2012,6 +2007,9 @@ Full Default Bundle Configuration
                     // Whether or not to allow extra attributes.
                     'object_managers' => false,
                 ],
+
+                // Add global state
+                'global_state' => []
 
             ]
         ]);

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -126,6 +126,10 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('global_state')
+                    ->scalarPrototype()->end()
+                    ->info('Array of stories that should be used as global state.')
+                ->end()
             ->end()
         ;
 

--- a/src/Bundle/DependencyInjection/GlobalStatePass.php
+++ b/src/Bundle/DependencyInjection/GlobalStatePass.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\Foundry\Configuration as FoundryConfiguration;
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\Test\GlobalStateRegistry;
+
+final class GlobalStatePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(FoundryConfiguration::class)) {
+            return;
+        }
+
+        $globalStateRegistryDefinition = $container->getDefinition(GlobalStateRegistry::class);
+
+        foreach ($this->getBundleConfiguration($container)['global_state'] as $globalStateItem) {
+            if ($this->isStoryAsService($container, $globalStateItem)) {
+                $globalStateRegistryDefinition->addMethodCall('addStoryAsService', [new Reference($globalStateItem)]);
+
+                continue;
+            }
+
+            if ($this->isInvokableService($container, $globalStateItem)) {
+                $globalStateRegistryDefinition->addMethodCall('addInvokableService', [new Reference($globalStateItem)]);
+
+                continue;
+            }
+
+            if ($this->isStandaloneStory($container, $globalStateItem)) {
+                $globalStateRegistryDefinition->addMethodCall('addStandaloneStory', [$globalStateItem]);
+
+                continue;
+            }
+
+            throw new \InvalidArgumentException("Given global state \"{$globalStateItem}\" is invalid. Allowed values are invokable services, stories as service or regular stories.");
+        }
+    }
+
+    private function isStoryAsService(ContainerBuilder $container, string $globalStateItem): bool
+    {
+        if (!$container->has($globalStateItem)) {
+            return false;
+        }
+
+        $globalStateItemDefinition = $container->getDefinition($globalStateItem);
+
+        return \count($globalStateItemDefinition->getTag('foundry.story')) > 0;
+    }
+
+    private function isInvokableService(ContainerBuilder $container, string $globalStateItem): bool
+    {
+        if (!$container->has($globalStateItem)) {
+            return false;
+        }
+
+        $globalStateItemDefinition = $container->getDefinition($globalStateItem);
+
+        return (new \ReflectionClass($globalStateItemDefinition->getClass()))->hasMethod('__invoke');
+    }
+
+    private function isStandaloneStory(ContainerBuilder $container, string $globalStateItem): bool
+    {
+        if ($container->has($globalStateItem)) {
+            return false;
+        }
+
+        return \class_exists($globalStateItem) && \is_a($globalStateItem, Story::class, true);
+    }
+
+    private function getBundleConfiguration(ContainerBuilder $container): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), $container->getExtensionConfig('zenstruck_foundry'));
+    }
+}

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -53,5 +53,8 @@
         <service id="Zenstruck\Foundry\ChainManagerRegistry">
             <argument/> <!-- list<ManagerRegistry> set by compiler pass -->
         </service>
+
+        <service id="Zenstruck\Foundry\Test\GlobalStateRegistry" public="true">
+        </service>
     </services>
 </container>

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -76,11 +76,15 @@ final class DatabaseResetter
 
     private static function bootFoundry(KernelInterface $kernel): void
     {
+        $container = $kernel->getContainer();
+
         if (!Factory::isBooted()) {
-            TestState::bootFromContainer($kernel->getContainer());
+            TestState::bootFromContainer($container);
         }
 
-        TestState::flushGlobalState();
+        TestState::flushGlobalState(
+            $container->has(GlobalStateRegistry::class) ? $container->get(GlobalStateRegistry::class) : null
+        );
     }
 
     private static function createApplication(KernelInterface $kernel): Application

--- a/src/Test/GlobalStateRegistry.php
+++ b/src/Test/GlobalStateRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Test;
+
+use Zenstruck\Foundry\Story;
+
+/**
+ * @internal
+ */
+final class GlobalStateRegistry
+{
+    /** @var list<Story> */
+    private $storiesAsService = [];
+
+    /** @var list<callable> */
+    private $invokableServices = [];
+
+    /** @var list<class-string<Story>> */
+    private $standaloneStories = [];
+
+    public function addStoryAsService(Story $storyAsService): void
+    {
+        $this->storiesAsService[] = $storyAsService;
+    }
+
+    public function addInvokableService(callable $invokableService): void
+    {
+        $this->invokableServices[] = $invokableService;
+    }
+
+    /**
+     * @param class-string<Story> $storyClass
+     */
+    public function addStandaloneStory(string $storyClass): void
+    {
+        $this->standaloneStories[] = $storyClass;
+    }
+
+    /**
+     * @return list<callable>
+     */
+    public function getGlobalStates(): array
+    {
+        return \array_merge(
+            \array_map(
+                static function(Story $story) {
+                    return static function() use ($story) {$story->build(); };
+                },
+                $this->storiesAsService
+            ),
+            $this->invokableServices,
+            \array_map(
+                static function(string $storyClassName) {
+                    return static function() use ($storyClassName) {$storyClassName::load(); };
+                },
+                $this->standaloneStories
+            )
+        );
+    }
+}

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -34,6 +34,12 @@ trait ResetDatabase
         $kernel = static::createKernel();
         $kernel->boot();
 
+        try {
+            $kernel->getBundle('ZenstruckFoundryBundle');
+        } catch (\InvalidArgumentException $exception) {
+            trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of ResetDatabase trait without Foundry bundle is deprecated and will create an error in 2.0.');
+        }
+
         if (self::shouldReset($kernel)) {
             DatabaseResetter::resetDatabase($kernel);
         }

--- a/src/Test/TestState.php
+++ b/src/Test/TestState.php
@@ -68,6 +68,8 @@ final class TestState
 
     public static function addGlobalState(callable $callback): void
     {
+        trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of TestState::addGlobalState() is deprecated. Please use bundle configuration under "global_state" key.');
+
         self::$globalStates[] = $callback;
     }
 
@@ -103,7 +105,7 @@ final class TestState
      */
     public static function bootFactory(Configuration $configuration): Configuration
     {
-        trigger_deprecation('zenstruck\foundry', '1.4.0', 'TestState::bootFactory() is deprecated, use TestState::bootFoundry().');
+        trigger_deprecation('zenstruck/foundry', '1.4.0', 'TestState::bootFactory() is deprecated, use TestState::bootFoundry().');
 
         self::bootFoundry($configuration);
 
@@ -158,12 +160,18 @@ final class TestState
     /**
      * @internal
      */
-    public static function flushGlobalState(): void
+    public static function flushGlobalState(?GlobalStateRegistry $globalStateRegistry): void
     {
         StoryManager::globalReset();
 
         foreach (self::$globalStates as $callback) {
             $callback();
+        }
+
+        if ($globalStateRegistry) {
+            foreach ($globalStateRegistry->getGlobalStates() as $callback) {
+                $callback();
+            }
         }
 
         StoryManager::setGlobalState();

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ChainManagerRegistryPass;
+use Zenstruck\Foundry\Bundle\DependencyInjection\GlobalStatePass;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ZenstruckFoundryExtension;
 
 /**
@@ -27,6 +28,7 @@ final class ZenstruckFoundryBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ChainManagerRegistryPass());
+        $container->addCompilerPass(new GlobalStatePass());
     }
 
     protected function createContainerExtension(): ?ExtensionInterface

--- a/tests/Fixtures/Document/Tag.php
+++ b/tests/Fixtures/Document/Tag.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document(collection="tag")
+ */
+class Tag
+{
+    /**
+     * @MongoDB\Id
+     */
+    private $id;
+
+    /**
+     * @MongoDB\Field(type="string")
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Fixtures/Factories/ODM/TagFactory.php
+++ b/tests/Fixtures/Factories/ODM/TagFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\Tag;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class TagFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return Tag::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return ['name' => self::faker()->sentence()];
+    }
+}

--- a/tests/Fixtures/Stories/ODMTagStory.php
+++ b/tests/Fixtures/Stories/ODMTagStory.php
@@ -3,12 +3,9 @@
 namespace Zenstruck\Foundry\Tests\Fixtures\Stories;
 
 use Zenstruck\Foundry\Story;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\TagFactory;
 
-/**
- * @author Kevin Bond <kevinbond@gmail.com>
- */
-final class TagStory extends Story
+final class ODMTagStory extends Story
 {
     public function build(): void
     {

--- a/tests/Fixtures/Stories/ODMTagStoryAsAService.php
+++ b/tests/Fixtures/Stories/ODMTagStoryAsAService.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Stories;
+
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\TagFactory;
+
+final class ODMTagStoryAsAService extends Story
+{
+    public function build(): void
+    {
+        $this->addState('design', TagFactory::new()->create(['name' => 'design']));
+    }
+}

--- a/tests/Fixtures/Stories/TagStoryAsInvokableService.php
+++ b/tests/Fixtures/Stories/TagStoryAsInvokableService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Stories;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
+
+final class TagStoryAsInvokableService
+{
+    public function __invoke()
+    {
+        TagFactory::new()->create(['name' => 'design']);
+    }
+}

--- a/tests/Functional/GlobalStateTest.php
+++ b/tests/Functional/GlobalStateTest.php
@@ -3,23 +3,25 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Story;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Stories\TagStory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class GlobalStateTest extends KernelTestCase
+abstract class GlobalStateTest extends KernelTestCase
 {
     use Factories, ResetDatabase;
 
     protected function setUp(): void
     {
-        if (false === \getenv('DATABASE_URL')) {
-            self::markTestSkipped('doctrine/orm not enabled.');
+        if (!\getenv('USE_FOUNDRY_BUNDLE')) {
+            $this->markTestSkipped('ZenstruckFoundryBundle not enabled.');
         }
+
+        parent::setUp();
     }
 
     /**
@@ -27,9 +29,10 @@ final class GlobalStateTest extends KernelTestCase
      */
     public function tag_story_is_added_as_global_state(): void
     {
-        TagFactory::repository()->assert()->count(2);
-        TagFactory::repository()->assert()->exists(['name' => 'dev']);
-        TagFactory::repository()->assert()->exists(['name' => 'design']);
+        $tagFactoryClass = $this->getTagFactoryClass();
+        $tagFactoryClass::repository()->assert()->count(2);
+        $tagFactoryClass::repository()->assert()->exists(['name' => 'dev']);
+        $tagFactoryClass::repository()->assert()->exists(['name' => 'design']);
     }
 
     /**
@@ -37,9 +40,21 @@ final class GlobalStateTest extends KernelTestCase
      */
     public function ensure_global_story_is_not_loaded_again(): void
     {
-        TagStory::load();
-        TagStory::load();
+        $tagStoryClass = $this->getTagStoryClass();
+        $tagStoryClass::load();
+        $tagStoryClass::load();
 
-        TagFactory::repository()->assert()->count(2);
+        $tagFactoryClass = $this->getTagFactoryClass();
+        $tagFactoryClass::repository()->assert()->count(2);
     }
+
+    /**
+     * @return class-string<Factory>
+     */
+    abstract protected function getTagFactoryClass(): string;
+
+    /**
+     * @return class-string<Story>
+     */
+    abstract protected function getTagStoryClass(): string;
 }

--- a/tests/Functional/ODMGlobalStateTest.php
+++ b/tests/Functional/ODMGlobalStateTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\TagFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Stories\ODMTagStory;
+
+final class ODMGlobalStateTest extends GlobalStateTest
+{
+    protected function setUp(): void
+    {
+        if (!\getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+
+        if (\getenv('USE_DAMA_DOCTRINE_TEST_BUNDLE')) {
+            self::markTestSkipped('ODM Global state cannot be handled with dama/doctrine-test-bundle.');
+        }
+
+        parent::setUp();
+    }
+
+    protected function getTagFactoryClass(): string
+    {
+        return TagFactory::class;
+    }
+
+    protected function getTagStoryClass(): string
+    {
+        return ODMTagStory::class;
+    }
+}

--- a/tests/Functional/ORMGlobalStateTest.php
+++ b/tests/Functional/ORMGlobalStateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Stories\TagStory;
+
+final class ORMGlobalStateTest extends GlobalStateTest
+{
+    protected function setUp(): void
+    {
+        if (false === \getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+
+        parent::setUp();
+    }
+
+    protected function getTagFactoryClass(): string
+    {
+        return TagFactory::class;
+    }
+
+    protected function getTagStoryClass(): string
+    {
+        return TagStory::class;
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -269,7 +269,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         ]);
 
         $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(5); // 3 created by this test and 2 in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 5  // 3 created by this test and 2 in global state
+                : 3
+        );
         PostFactory::assert()->count(1);
     }
 
@@ -285,7 +289,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
 
         $this->assertCount(3, $post->getTags());
         $this->assertCount(3, $post->getSecondaryTags());
-        TagFactory::assert()->count(8); // 3 created by this test and 2 in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 8  // 6 created by this test and 2 in global state
+                : 6
+        );
         PostFactory::assert()->count(1);
     }
 
@@ -327,7 +335,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         ]);
 
         $this->assertCount(3, $tag->getPosts());
-        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 3 // 1 created by this test and 2 in global state
+                : 1
+        );
         PostFactory::assert()->count(3);
     }
 
@@ -343,7 +355,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
 
         $this->assertCount(3, $tag->getPosts());
         $this->assertCount(3, $tag->getSecondaryPosts());
-        TagFactory::assert()->count(3); // 1 created by this test and 2 in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 3 // 1 created by this test and 2 in global state
+                : 1
+        );
         PostFactory::assert()->count(6);
     }
 
@@ -386,7 +402,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
 
         $this->assertCount(3, $posts[0]->getTags());
         $this->assertCount(3, $posts[1]->getTags());
-        TagFactory::assert()->count(8); // 6 created by this test and 2 in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 8  // 6 created by this test and 2 in global state
+                : 6
+        );
         PostFactory::assert()->count(2);
     }
 
@@ -415,7 +435,11 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         ]);
 
         $this->assertCount(3, $post->getTags());
-        TagFactory::assert()->count(2); // 2 created in global state
+        TagFactory::assert()->count(
+            \getenv('USE_FOUNDRY_BUNDLE')
+                ? 2  // 2 created in global state
+                : 0
+        );
         PostFactory::assert()->empty();
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,16 +2,9 @@
 
 use Symfony\Component\Filesystem\Filesystem;
 use Zenstruck\Foundry\Test\TestState;
-use Zenstruck\Foundry\Tests\Fixtures\Stories\TagStory;
 
 require \dirname(__DIR__).'/vendor/autoload.php';
 
 (new Filesystem())->remove(__DIR__.'/../var');
 
 TestState::disableDefaultProxyAutoRefresh();
-
-if (\getenv('DATABASE_URL')) {
-    TestState::addGlobalState(static function() {
-        TagStory::load();
-    });
-}


### PR DESCRIPTION
related to #319

Introduced new configuration:
```yml
zenstruck_foundry:
    global_state:
        - invokable.service # just a service with ::invoke()
        - App\Stories\StoryThatIsAService
        - App\Stories\GlobalStory # if not a service, just run GlobalStory::load()
        - ...
```

- deprecates usage of `TestState::addGlobalState()`
- global state could be used in dev environment
- stories as service could be used as global state
