### PR TITLE
[chore] adjust `.symfony.bundle.yaml` for new branch

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,6 +1,3 @@
-branches: ['master']
-maintained_branches: ['master']
-current_branch: "master"
-dev_branch: "master"
-doc_dir: 'docs/'
-dev_branch_alias: '1.x'
+branches: ["1.x", "1.23.x"]
+maintained_branches: ["1.x", "1.23.x"]
+doc_dir: "docs/"


### PR DESCRIPTION
Part of requiring php8+. We're going to maintain `1.23.x` as a bug fix branch.