### PR TITLE
chore: fix docker cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,12 +221,12 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Create cache directory
-        run: mkdir -p var/cache-docker
+        run: mkdir -p cache-docker
 
       - id: cache-docker
         uses: actions/cache@v3
         with:
-          path: var/cache-docker
+          path: cache-docker
           key: ${{ hashFiles('docker/*') }}
 
       - name: Docker build
@@ -235,14 +235,14 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          outputs: type=docker,dest=var/cache-docker/php.tar
+          outputs: type=docker,dest=cache-docker/php.tar
           tags: |
             foundry_php:ci
           push: false
 
       - name: Load docker context
         run: |
-          docker load < var/cache-docker/php.tar
+          docker load < cache-docker/php.tar
 
       - name: Run test suite with docker
         run: |


### PR DESCRIPTION
I was using `./var` to store cache, but this directory is being removed in the bootstrap of the tests :facepalm: 

![Capture d’écran du 2022-11-16 20-22-41](https://user-images.githubusercontent.com/10139766/202274695-296937b5-baa1-4749-9e9b-d3a916552cf0.png)
