### PR TITLE
refactor(make:factory): split command with DefaultPropertiesGuesser

### DIFF
--- a/src/Bundle/Maker/Factory/DefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/DefaultPropertiesGuesser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+/**
+ * @internal
+ */
+interface DefaultPropertiesGuesser
+{
+    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void;
+
+    public function supports(bool $persisted): bool;
+}

--- a/src/Bundle/Maker/Factory/DoctrineObjectDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/DoctrineObjectDefaultPropertiesGuesser.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * @internal
+ */
+class DoctrineObjectDefaultPropertiesGuesser implements DefaultPropertiesGuesser
+{
+    private const DEFAULTS = [
+        'ARRAY' => '[],',
+        'ASCII_STRING' => 'self::faker()->text({length}),',
+        'BIGINT' => 'self::faker()->randomNumber(),',
+        'BLOB' => 'self::faker()->text(),',
+        'BOOLEAN' => 'self::faker()->boolean(),',
+        'DATE' => 'self::faker()->dateTime(),',
+        'DATE_MUTABLE' => 'self::faker()->dateTime(),',
+        'DATE_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
+        'DATETIME_MUTABLE' => 'self::faker()->dateTime(),',
+        'DATETIME_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
+        'DATETIMETZ_MUTABLE' => 'self::faker()->dateTime(),',
+        'DATETIMETZ_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
+        'DECIMAL' => 'self::faker()->randomFloat(),',
+        'FLOAT' => 'self::faker()->randomFloat(),',
+        'INTEGER' => 'self::faker()->randomNumber(),',
+        'JSON' => '[],',
+        'JSON_ARRAY' => '[],',
+        'SIMPLE_ARRAY' => '[],',
+        'SMALLINT' => 'self::faker()->numberBetween(1, 32767),',
+        'STRING' => 'self::faker()->text({length}),',
+        'TEXT' => 'self::faker()->text({length}),',
+        'TIME_MUTABLE' => 'self::faker()->datetime(),',
+        'TIME_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->datetime()),',
+    ];
+
+    public function __construct(private ManagerRegistry $managerRegistry, private FactoryFinder $factoryFinder)
+    {
+    }
+
+    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void
+    {
+        $class = $makeFactoryData->getObjectFullyQualifiedClassName();
+
+        $em = $this->managerRegistry->getManagerForClass($class);
+
+        if (!$em instanceof ObjectManager) {
+            return;
+        }
+
+        /** @var ORMClassMetadata|ODMClassMetadata $metadata */
+        $metadata = $em->getClassMetadata($class);
+
+        $dbType = $em instanceof EntityManagerInterface ? 'ORM' : 'ODM';
+
+        $this->guessDefaultValueForAssociativeFields($makeFactoryData, $metadata, $dbType, $allFields);
+        $this->guessDefaultValueForScalarFields($makeFactoryData, $metadata, $dbType, $allFields);
+    }
+
+    public function supports(bool $persisted): bool
+    {
+        return true === $persisted;
+    }
+
+    private function guessDefaultValueForAssociativeFields(MakeFactoryData $makeFactoryData, ODMClassMetadata|ORMClassMetadata $metadata, string $dbType, bool $allFields): void
+    {
+        foreach ($metadata->associationMappings as $item) {
+            // if joinColumns is not written entity is default nullable ($nullable = true;)
+            if (!\array_key_exists('joinColumns', $item)) {
+                continue;
+            }
+
+            if (!\array_key_exists('nullable', $item['joinColumns'][0] ?? [])) {
+                continue;
+            }
+
+            if (true === $item['joinColumns'][0]['nullable']) {
+                continue;
+            }
+
+            $fieldName = $item['fieldName'];
+
+            if (!$factoryClass = $this->factoryFinder->getFactoryForClass($item['targetEntity'])) {
+                $makeFactoryData->addDefaultProperty(\lcfirst($fieldName), "null, // TODO add {$item['targetEntity']} {$dbType} type manually");
+
+                continue;
+            }
+
+            $factory = new \ReflectionClass($factoryClass);
+            $makeFactoryData->addUse($factory->getName());
+            $makeFactoryData->addDefaultProperty(\lcfirst($fieldName), "{$factory->getShortName()}::new(),");
+        }
+    }
+
+    private function guessDefaultValueForScalarFields(MakeFactoryData $makeFactoryData, ODMClassMetadata|ORMClassMetadata $metadata, string $dbType, bool $allFields): void
+    {
+        $ids = $metadata->getIdentifierFieldNames();
+
+        foreach ($metadata->fieldMappings as $property) {
+            // ignore identifiers and nullable fields
+            if ((!$allFields && ($property['nullable'] ?? false)) || \in_array($property['fieldName'], $ids, true)) {
+                continue;
+            }
+
+            $type = \mb_strtoupper($property['type']);
+            $value = "null, // TODO add {$type} {$dbType} type manually";
+            $length = $property['length'] ?? '';
+
+            if (\array_key_exists($type, self::DEFAULTS)) {
+                $value = self::DEFAULTS[$type];
+            }
+
+            $makeFactoryData->addDefaultProperty($property['fieldName'], \str_replace('{length}', (string) $length, $value));
+        }
+    }
+}

--- a/src/Bundle/Maker/Factory/FactoryFinder.php
+++ b/src/Bundle/Maker/Factory/FactoryFinder.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+use Zenstruck\Foundry\ModelFactory;
+
+/**
+ * @internal
+ */
+final class FactoryFinder
+{
+    /**
+     * @var array<class-string, class-string> factory classes as keys, object class as values
+     */
+    private array $classesWithFactories;
+
+    /** @param \Traversable<ModelFactory> $factories */
+    public function __construct(\Traversable $factories)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->classesWithFactories = \array_unique(
+            \array_reduce(
+                \iterator_to_array($factories, preserve_keys: true),
+                static function(array $carry, ModelFactory $factory): array {
+                    $carry[\get_class($factory)] = $factory::getEntityClass();
+
+                    return $carry;
+                },
+                []
+            )
+        );
+    }
+
+    /** @param class-string $class */
+    public function classHasFactory(string $class): bool
+    {
+        return \in_array($class, $this->classesWithFactories, true);
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return class-string|null
+     */
+    public function getFactoryForClass(string $class): ?string
+    {
+        $factories = \array_flip($this->classesWithFactories);
+
+        return $factories[$class] ?? null;
+    }
+}

--- a/src/Bundle/Maker/Factory/MakeFactoryData.php
+++ b/src/Bundle/Maker/Factory/MakeFactoryData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zenstruck\Foundry\Bundle\Maker;
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;

--- a/src/Bundle/Maker/Factory/MakeFactoryPHPDocMethod.php
+++ b/src/Bundle/Maker/Factory/MakeFactoryPHPDocMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zenstruck\Foundry\Bundle\Maker;
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 /**
  * @internal

--- a/src/Bundle/Maker/Factory/ObjectDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/ObjectDefaultPropertiesGuesser.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+/**
+ * @internal
+ */
+class ObjectDefaultPropertiesGuesser implements DefaultPropertiesGuesser
+{
+    private const DEFAULTS_FOR_NOT_PERSISTED = [
+        'array' => '[],',
+        'string' => 'self::faker()->sentence(),',
+        'int' => 'self::faker()->randomNumber(),',
+        'float' => 'self::faker()->randomFloat(),',
+        'bool' => 'self::faker()->boolean(),',
+        \DateTime::class => 'self::faker()->dateTime(),',
+        \DateTimeImmutable::class => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
+    ];
+
+    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void
+    {
+        foreach ($makeFactoryData->getObject()->getProperties() as $property) {
+            // ignore identifiers and nullable fields
+            if (!$allFields && ($property->hasDefaultValue() || !$property->hasType() || $property->getType()?->allowsNull())) {
+                continue;
+            }
+
+            $type = null;
+            $reflectionType = $property->getType();
+            if ($reflectionType instanceof \ReflectionNamedType) {
+                $type = $reflectionType->getName();
+            }
+
+            $value = \sprintf('null, // TODO add %svalue manually', $type ? "{$type} " : '');
+
+            if (\array_key_exists($type ?? '', self::DEFAULTS_FOR_NOT_PERSISTED)) {
+                $value = self::DEFAULTS_FOR_NOT_PERSISTED[$type];
+            }
+
+            $makeFactoryData->addDefaultProperty($property->getName(), $value);
+        }
+    }
+
+    public function supports(bool $persisted): bool
+    {
+        return false === $persisted;
+    }
+}

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -42,10 +42,20 @@
 
         <service id="Zenstruck\Foundry\Bundle\Maker\MakeFactory">
             <argument type="service" id="Zenstruck\Foundry\ChainManagerRegistry" />
-            <argument type="tagged_iterator" tag="foundry.factory" />
-            <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryFinder" />
             <argument type="service" id="kernel" />
+            <argument type="tagged_iterator" tag="foundry.make_factory.default_properties_guesser" />
             <tag name="maker.command" />
+        </service>
+
+        <service id="Zenstruck\Foundry\Bundle\Maker\Factory\DoctrineObjectDefaultPropertiesGuesser">
+            <argument type="service" id="Zenstruck\Foundry\ChainManagerRegistry" />
+            <argument type="service" id="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryFinder" />
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
+        <service id="Zenstruck\Foundry\Bundle\Maker\Factory\ObjectDefaultPropertiesGuesser">
+            <tag name="foundry.make_factory.default_properties_guesser" />
         </service>
 
         <service id="Zenstruck\Foundry\Bundle\Maker\MakeStory">
@@ -57,6 +67,10 @@
         </service>
 
         <service id="Zenstruck\Foundry\Test\GlobalStateRegistry" public="true">
+        </service>
+
+        <service id="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryFinder">
+            <argument type="tagged_iterator" tag="foundry.factory" />
         </service>
     </services>
 </container>

--- a/src/Bundle/Resources/skeleton/Factory.tpl.php
+++ b/src/Bundle/Resources/skeleton/Factory.tpl.php
@@ -1,4 +1,4 @@
-<?php /** @var \Zenstruck\Foundry\Bundle\Maker\MakeFactoryData $makeFactoryData */?><?= "<?php\n" ?>
+<?php /** @var \Zenstruck\Foundry\Bundle\Maker\Factory\MakeFactoryData $makeFactoryData */?><?= "<?php\n" ?>
 
 namespace <?= $namespace ?>;
 

--- a/src/Test/GlobalStateRegistry.php
+++ b/src/Test/GlobalStateRegistry.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Zenstruck\Foundry\Test;
 
 use Zenstruck\Foundry\Story;


### PR DESCRIPTION
just splitting the command, using `DefaultPropertiesGuesser`

from there I'd like to:
- handle `--all-fields` option for join columns
- use existing factories for embeddables
- go a little bit further in how we guess types for "not persisted" objects
- handle `x-to-many` relationships? we could use `Factory::new()->many()`

BTW, I'm still looking for a better name than `not-persisted` :innocent: 
