### PR TITLE
dependencies: allow symfony/string 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "fakerphp/faker": "^1.5",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/property-access": "^3.4|^4.4|^5.0|^6.0",
-        "symfony/string": "^6.0",
+        "symfony/string": "^5.4|^6.0",
         "zenstruck/assert": "^1.0",
         "zenstruck/callback": "^1.1"
     },
@@ -32,7 +32,7 @@
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",
         "symfony/maker-bundle": "^1.30",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/translation-contracts": "^3.0"
+        "symfony/translation-contracts": "^2.5|^3.0"
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
Currently it's not possible to install the latest version of foundry with Symfony 5.4 if you're using Symfony Flex & the `extra.symfony.require` composer option:

```sh
symfony new foundry-test --version=5.4 --webapp
cd foundry-test/
composer require --dev foundry
```
Result:
```
Using version ^1.24 for zenstruck/foundry
./composer.json has been updated
Running composer update zenstruck/foundry
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires zenstruck/foundry ^1.24 -> satisfiable by zenstruck/foundry[v1.24.0].
    - zenstruck/foundry v1.24.0 requires symfony/string ^6.0 -> found symfony/string[v6.0.0, ..., v6.1.7] but it conflicts with your root composer.json require (5.4.*).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
You can also try re-running composer require with an explicit version constraint, e.g. "composer require zenstruck/foundry:*" to figure out if any version is installable, or "composer require zenstruck/foundry:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Since I can't find any technical reason not to allow `symfony/string` version `5.4.*` I'd suggest adding it to `composer.json` to fix this issue.