### PR TITLE
feat(make:factory): auto create missing factories

### DIFF
--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -25,6 +25,7 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load('services.xml');
+        $loader->load('maker.xml');
 
         $container->registerForAutoconfiguration(Story::class)
             ->addTag('foundry.story')

--- a/src/Bundle/Maker/Factory/DefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/DefaultPropertiesGuesser.php
@@ -2,12 +2,14 @@
 
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
+use Symfony\Component\Console\Style\SymfonyStyle;
+
 /**
  * @internal
  */
 interface DefaultPropertiesGuesser
 {
-    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void;
+    public function __invoke(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery): void;
 
     public function supports(MakeFactoryData $makeFactoryData): bool;
 }

--- a/src/Bundle/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
@@ -1,11 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
@@ -21,6 +20,7 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
         'DATE' => 'self::faker()->dateTime(),',
         'DATE_MUTABLE' => 'self::faker()->dateTime(),',
         'DATE_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
+        'DATETIME' => 'self::faker()->dateTime(),',
         'DATETIME_MUTABLE' => 'self::faker()->dateTime(),',
         'DATETIME_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
         'DATETIMETZ_MUTABLE' => 'self::faker()->dateTime(),',
@@ -39,7 +39,7 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
         'TIME_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->datetime()),',
     ];
 
-    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void
+    public function __invoke(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery): void
     {
         /** @var ODMClassMetadata|ORMClassMetadata $metadata */
         $metadata = $this->getClassMetadata($makeFactoryData);
@@ -60,7 +60,7 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
             }
 
             // ignore identifiers and nullable fields
-            if ((!$allFields && ($property['nullable'] ?? false)) || \in_array($fieldName, $ids, true)) {
+            if ((!$makeFactoryQuery->isAllFields() && ($property['nullable'] ?? false)) || \in_array($fieldName, $ids, true)) {
                 continue;
             }
 

--- a/src/Bundle/Maker/Factory/FactoryClassMap.php
+++ b/src/Bundle/Maker/Factory/FactoryClassMap.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -9,7 +7,7 @@ use Zenstruck\Foundry\ModelFactory;
 /**
  * @internal
  */
-final class FactoryFinder
+final class FactoryClassMap
 {
     /**
      * @var array<class-string, class-string> factory classes as keys, object class as values
@@ -49,5 +47,18 @@ final class FactoryFinder
         $factories = \array_flip($this->classesWithFactories);
 
         return $factories[$class] ?? null;
+    }
+
+    /**
+     * @param class-string $factoryClass
+     * @param class-string $class
+     */
+    public function addFactoryForClass(string $factoryClass, string $class): void
+    {
+        if (\array_key_exists($factoryClass, $this->classesWithFactories)) {
+            throw new \InvalidArgumentException("Factory \"{$factoryClass}\" already exists.");
+        }
+
+        $this->classesWithFactories[$factoryClass] = $class;
     }
 }

--- a/src/Bundle/Maker/Factory/FactoryGenerator.php
+++ b/src/Bundle/Maker/Factory/FactoryGenerator.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @internal
+ */
+final class FactoryGenerator
+{
+    /** @param \Traversable<int, DefaultPropertiesGuesser> $defaultPropertiesGuessers */
+    public function __construct(private ManagerRegistry $managerRegistry, private KernelInterface $kernel, private \Traversable $defaultPropertiesGuessers, private FactoryClassMap $factoryClassMap)
+    {
+    }
+
+    /**
+     * @return class-string The factory's FQCN
+     */
+    public function generateFactory(SymfonyStyle $io, MakeFactoryQuery $makeFactoryQuery): string
+    {
+        $class = $makeFactoryQuery->getClass();
+        $generator = $makeFactoryQuery->getGenerator();
+
+        if (!\class_exists($class)) {
+            $class = $generator->createClassNameDetails($class, 'Entity\\')->getFullName();
+        }
+
+        if (!\class_exists($class)) {
+            throw new RuntimeCommandException(\sprintf('Class "%s" not found.', $makeFactoryQuery->getClass()));
+        }
+
+        $makeFactoryData = $this->createMakeFactoryData($generator, $class, $makeFactoryQuery);
+
+        /** @var class-string $factoryClass */
+        $factoryClass = $makeFactoryData->getFactoryClassNameDetails()->getFullName();
+
+        if (!$this->factoryClassMap->classHasFactory($class)) {
+            $this->factoryClassMap->addFactoryForClass($factoryClass, $class);
+        }
+
+        foreach ($this->defaultPropertiesGuessers as $defaultPropertiesGuesser) {
+            if ($defaultPropertiesGuesser->supports($makeFactoryData)) {
+                $defaultPropertiesGuesser($io, $makeFactoryData, $makeFactoryQuery);
+            }
+        }
+
+        $generator->generateClass(
+            $factoryClass,
+            __DIR__.'/../../Resources/skeleton/Factory.tpl.php',
+            [
+                'makeFactoryData' => $makeFactoryData,
+            ]
+        );
+
+        return $factoryClass;
+    }
+
+    /** @param class-string $class */
+    private function createMakeFactoryData(Generator $generator, string $class, MakeFactoryQuery $makeFactoryQuery): MakeFactoryData
+    {
+        $object = new \ReflectionClass($class);
+
+        $factory = $generator->createClassNameDetails(
+            $object->getShortName(),
+            $this->guessNamespace($generator, $makeFactoryQuery->getNamespace(), $makeFactoryQuery->isTest()),
+            'Factory'
+        );
+
+        if ($makeFactoryQuery->isPersisted()) {
+            $repository = new \ReflectionClass($this->managerRegistry->getRepository($object->getName()));
+
+            if (\str_starts_with($repository->getName(), 'Doctrine')) {
+                // not using a custom repository
+                $repository = null;
+            }
+        }
+
+        return new MakeFactoryData(
+            $object,
+            $factory,
+            $repository ?? null,
+            $this->phpstanEnabled(),
+            $makeFactoryQuery->isPersisted()
+        );
+    }
+
+    private function guessNamespace(Generator $generator, string $namespace, bool $test): string
+    {
+        // strip maker's root namespace if set
+        if (0 === \mb_strpos($namespace, $generator->getRootNamespace())) {
+            $namespace = \mb_substr($namespace, \mb_strlen($generator->getRootNamespace()));
+        }
+
+        $namespace = \trim($namespace, '\\');
+
+        // if creating in tests dir, ensure namespace prefixed with Tests\
+        if ($test && 0 !== \mb_strpos($namespace, 'Tests\\')) {
+            $namespace = 'Tests\\'.$namespace;
+        }
+
+        return $namespace;
+    }
+
+    private function phpstanEnabled(): bool
+    {
+        return \file_exists("{$this->kernel->getProjectDir()}/vendor/phpstan/phpstan/phpstan");
+    }
+}

--- a/src/Bundle/Maker/Factory/MakeFactoryQuery.php
+++ b/src/Bundle/Maker/Factory/MakeFactoryQuery.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory;
+
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+final class MakeFactoryQuery
+{
+    private function __construct(private string $namespace, private bool $test, private bool $persisted, private bool $allFields, private string $class, private bool $generateAllFactories, private Generator $generator)
+    {
+    }
+
+    public static function fromInput(InputInterface $input, string $class, bool $generateAllFactories, Generator $generator): self
+    {
+        return new self(
+            namespace: $input->getOption('namespace'),
+            test: (bool) $input->getOption('test'),
+            persisted: !$input->getOption('no-persistence'),
+            allFields: (bool) $input->getOption('all-fields'),
+            class: $class,
+            generateAllFactories: $generateAllFactories,
+            generator: $generator
+        );
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function isTest(): bool
+    {
+        return $this->test;
+    }
+
+    public function isPersisted(): bool
+    {
+        return $this->persisted;
+    }
+
+    public function isAllFields(): bool
+    {
+        return $this->allFields;
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function generateAllFactories(): bool
+    {
+        return $this->generateAllFactories;
+    }
+
+    public function getGenerator(): Generator
+    {
+        return $this->generator;
+    }
+
+    public function withClass(string $class): self
+    {
+        $clone = clone $this;
+        $clone->class = $class;
+
+        return $clone;
+    }
+}

--- a/src/Bundle/Maker/Factory/ORMDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/ORMDefaultPropertiesGuesser.php
@@ -3,13 +3,14 @@
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
  */
 class ORMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuesser
 {
-    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void
+    public function __invoke(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery): void
     {
         $metadata = $this->getClassMetadata($makeFactoryData);
 
@@ -17,8 +18,8 @@ class ORMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuess
             throw new \InvalidArgumentException("\"{$makeFactoryData->getObjectFullyQualifiedClassName()}\" is not a valid ORM class.");
         }
 
-        $this->guessDefaultValueForORMAssociativeFields($makeFactoryData, $metadata);
-        $this->guessDefaultValueForEmbedded($makeFactoryData, $metadata, $allFields);
+        $this->guessDefaultValueForORMAssociativeFields($io, $makeFactoryData, $makeFactoryQuery, $metadata);
+        $this->guessDefaultValueForEmbedded($io, $makeFactoryData, $makeFactoryQuery, $metadata);
     }
 
     public function supports(MakeFactoryData $makeFactoryData): bool
@@ -32,7 +33,7 @@ class ORMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuess
         }
     }
 
-    private function guessDefaultValueForORMAssociativeFields(MakeFactoryData $makeFactoryData, ORMClassMetadata $metadata): void
+    private function guessDefaultValueForORMAssociativeFields(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery, ORMClassMetadata $metadata): void
     {
         foreach ($metadata->associationMappings as $item) {
             // if joinColumns is not written entity is default nullable ($nullable = true;)
@@ -45,20 +46,20 @@ class ORMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuess
                 continue;
             }
 
-            $this->addDefaultValueUsingFactory($makeFactoryData, $item['fieldName'], $item['targetEntity']);
+            $this->addDefaultValueUsingFactory($io, $makeFactoryData, $makeFactoryQuery, $item['fieldName'], $item['targetEntity']);
         }
     }
 
-    private function guessDefaultValueForEmbedded(MakeFactoryData $makeFactoryData, ORMClassMetadata $metadata, bool $allFields): void
+    private function guessDefaultValueForEmbedded(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery, ORMClassMetadata $metadata): void
     {
         foreach ($metadata->embeddedClasses as $fieldName => $item) {
             $isNullable = $makeFactoryData->getObject()->getProperty($fieldName)->getType()?->allowsNull() ?? true;
 
-            if (!$allFields && $isNullable) {
+            if (!$makeFactoryQuery->isAllFields() && $isNullable) {
                 continue;
             }
 
-            $this->addDefaultValueUsingFactory($makeFactoryData, $fieldName, $item['class']);
+            $this->addDefaultValueUsingFactory($io, $makeFactoryData, $makeFactoryQuery, $fieldName, $item['class']);
         }
     }
 }

--- a/src/Bundle/Maker/Factory/ObjectDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/ObjectDefaultPropertiesGuesser.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
+use Symfony\Component\Console\Style\SymfonyStyle;
+
 /**
  * @internal
  */
@@ -17,11 +19,11 @@ class ObjectDefaultPropertiesGuesser implements DefaultPropertiesGuesser
         \DateTimeImmutable::class => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
     ];
 
-    public function __invoke(MakeFactoryData $makeFactoryData, bool $allFields): void
+    public function __invoke(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery): void
     {
         foreach ($makeFactoryData->getObject()->getProperties() as $property) {
             // ignore identifiers and nullable fields
-            if (!$allFields && ($property->hasDefaultValue() || !$property->hasType() || $property->getType()?->allowsNull())) {
+            if (!$makeFactoryQuery->isAllFields() && ($property->hasDefaultValue() || !$property->hasType() || $property->getType()?->allowsNull())) {
                 continue;
             }
 

--- a/src/Bundle/Resources/config/maker.xml
+++ b/src/Bundle/Resources/config/maker.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id=".zenstruck_foundry.maker.factory" class="Zenstruck\Foundry\Bundle\Maker\MakeFactory">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+            <argument type="service" id="kernel" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <tag name="maker.command" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.orm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ORMDefaultPropertiesGuesser">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.odm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ODMDefaultPropertiesGuesser">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.doctrine_scalar_fields_default_properties_guesser" class="\Zenstruck\Foundry\Bundle\Maker\Factory\DoctrineScalarFieldsDefaultPropertiesGuesser">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.object_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ObjectDefaultPropertiesGuesser">
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.story" class="Zenstruck\Foundry\Bundle\Maker\MakeStory">
+            <tag name="maker.command" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.factory_class_map" class="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryClassMap">
+            <argument type="tagged_iterator" tag="foundry.factory" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.generator" class="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryGenerator">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id="kernel" />
+            <argument type="tagged_iterator" tag="foundry.make_factory.default_properties_guesser" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+        </service>
+    </services>
+</container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -40,48 +40,10 @@
             <argument type="tagged_iterator" tag="foundry.factory" />
         </service>
 
-        <service id=".zenstruck_foundry.maker.factory" class="Zenstruck\Foundry\Bundle\Maker\MakeFactory">
-            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
-            <argument type="service" id=".zenstruck_foundry.maker.factory.finder" />
-            <argument type="service" id="kernel" />
-            <argument type="tagged_iterator" tag="foundry.make_factory.default_properties_guesser" />
-            <tag name="maker.command" />
-        </service>
-
-        <service id=".zenstruck_foundry.maker.factory.orm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ORMDefaultPropertiesGuesser">
-            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
-            <argument type="service" id=".zenstruck_foundry.maker.factory.finder" />
-            <tag name="foundry.make_factory.default_properties_guesser" />
-        </service>
-
-        <service id=".zenstruck_foundry.maker.factory.odm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ODMDefaultPropertiesGuesser">
-            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
-            <argument type="service" id=".zenstruck_foundry.maker.factory.finder" />
-            <tag name="foundry.make_factory.default_properties_guesser" />
-        </service>
-
-        <service id=".zenstruck_foundry.maker.factory.doctrine_scalar_fields_default_properties_guesser" class="\Zenstruck\Foundry\Bundle\Maker\Factory\DoctrineScalarFieldsDefaultPropertiesGuesser">
-            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
-            <argument type="service" id=".zenstruck_foundry.maker.factory.finder" />
-            <tag name="foundry.make_factory.default_properties_guesser" />
-        </service>
-
-        <service id=".zenstruck_foundry.maker.factory.object_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ObjectDefaultPropertiesGuesser">
-            <tag name="foundry.make_factory.default_properties_guesser" />
-        </service>
-
-        <service id=".zenstruck_foundry.maker.story" class="Zenstruck\Foundry\Bundle\Maker\MakeStory">
-            <tag name="maker.command" />
-        </service>
-
         <service id=".zenstruck_foundry.chain_manager_registry" class="Zenstruck\Foundry\ChainManagerRegistry">
             <argument/> <!-- list<ManagerRegistry> set by compiler pass -->
         </service>
 
         <service id=".zenstruck_foundry.global_state_registry" class="Zenstruck\Foundry\Test\GlobalStateRegistry" public="true" />
-
-        <service id=".zenstruck_foundry.maker.factory.finder" class="Zenstruck\Foundry\Bundle\Maker\Factory\FactoryFinder">
-            <argument type="tagged_iterator" tag="foundry.factory" />
-        </service>
     </services>
 </container>

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository.php
@@ -64,7 +64,7 @@ final class PostFactory extends ModelFactory
     {
         return [
             'body' => self::faker()->text(),
-            'createdAt' => null, // TODO add DATETIME type manually
+            'createdAt' => self::faker()->dateTime(),
             'title' => self::faker()->text(255),
             'viewCount' => self::faker()->randomNumber(),
         ];

--- a/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
@@ -4,27 +4,27 @@ namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Comment;
 
 /**
- * @extends ModelFactory<Tag>
+ * @extends ModelFactory<Comment>
  *
- * @method        Tag|Proxy create(array|callable $attributes = [])
- * @method static Tag|Proxy createOne(array $attributes = [])
- * @method static Tag|Proxy find(object|array|mixed $criteria)
- * @method static Tag|Proxy findOrCreate(array $attributes)
- * @method static Tag|Proxy first(string $sortedField = 'id')
- * @method static Tag|Proxy last(string $sortedField = 'id')
- * @method static Tag|Proxy random(array $attributes = [])
- * @method static Tag|Proxy randomOrCreate(array $attributes = [])
- * @method static Tag[]|Proxy[] all()
- * @method static Tag[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Tag[]|Proxy[] createSequence(array|callable $sequence)
- * @method static Tag[]|Proxy[] findBy(array $attributes)
- * @method static Tag[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Tag[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method        Comment|Proxy create(array|callable $attributes = [])
+ * @method static Comment|Proxy createOne(array $attributes = [])
+ * @method static Comment|Proxy find(object|array|mixed $criteria)
+ * @method static Comment|Proxy findOrCreate(array $attributes)
+ * @method static Comment|Proxy first(string $sortedField = 'id')
+ * @method static Comment|Proxy last(string $sortedField = 'id')
+ * @method static Comment|Proxy random(array $attributes = [])
+ * @method static Comment|Proxy randomOrCreate(array $attributes = [])
+ * @method static Comment[]|Proxy[] all()
+ * @method static Comment[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @method static Comment[]|Proxy[] createSequence(array|callable $sequence)
+ * @method static Comment[]|Proxy[] findBy(array $attributes)
+ * @method static Comment[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
+ * @method static Comment[]|Proxy[] randomSet(int $number, array $attributes = [])
  */
-final class TagFactory extends ModelFactory
+final class CommentFactory extends ModelFactory
 {
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
@@ -44,7 +44,11 @@ final class TagFactory extends ModelFactory
     protected function getDefaults(): array
     {
         return [
-            'name' => self::faker()->text(255),
+            'approved' => self::faker()->boolean(),
+            'body' => self::faker()->text(),
+            'createdAt' => self::faker()->dateTime(),
+            'post' => PostFactory::new(),
+            'user' => null, // TODO add Zenstruck\Foundry\Tests\Fixtures\Entity\User type manually
         ];
     }
 
@@ -54,12 +58,12 @@ final class TagFactory extends ModelFactory
     protected function initialize(): self
     {
         return $this
-            // ->afterInstantiate(function(Tag $tag): void {})
+            // ->afterInstantiate(function(Comment $comment): void {})
         ;
     }
 
     protected static function getClass(): string
     {
-        return Tag::class;
+        return Comment::class;
     }
 }

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
@@ -5,8 +5,6 @@ namespace App\Factory;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CommentFactory;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\UserFactory;
 
 /**
  * @extends ModelFactory<ODMPost>
@@ -47,12 +45,11 @@ final class ODMPostFactory extends ModelFactory
     {
         return [
             'body' => self::faker()->text(),
-            'comments' => CommentFactory::new()->many(5),
             'createdAt' => self::faker()->dateTime(),
             'publishedAt' => self::faker()->dateTime(),
             'shortDescription' => self::faker()->text(),
             'title' => self::faker()->text(),
-            'user' => UserFactory::new(),
+            'user' => ODMUserFactory::new(),
             'viewCount' => self::faker()->randomNumber(),
         ];
     }

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
@@ -5,7 +5,6 @@ namespace App\Factory;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 
 /**
  * @extends ModelFactory<Contact>

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
@@ -46,7 +46,7 @@ final class EntityWithRelationsFactory extends ModelFactory
     {
         return [
             'manyToOne' => CategoryFactory::new(),
-            'manyToOneWithNotExistingFactory' => null, // TODO add Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Brand type manually
+            'manyToOneWithNotExistingFactory' => BrandFactory::new(),
             'oneToOne' => CategoryFactory::new(),
         ];
     }

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
@@ -46,7 +46,7 @@ final class EntityWithRelationsFactory extends ModelFactory
     {
         return [
             'manyToOne' => CategoryFactory::new(),
-            'manyToOneWithNotExistingFactory' => null, // TODO add Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Brand type manually
+            'manyToOneWithNotExistingFactory' => BrandFactory::new(),
             'oneToOne' => CategoryFactory::new(),
         ];
     }

--- a/tests/Fixtures/Migrations/Version20221204165429.php
+++ b/tests/Fixtures/Migrations/Version20221204165429.php
@@ -52,38 +52,6 @@ final class Version20221204165429 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE comments DROP FOREIGN KEY FK_5F9E962AA76ED395');
-        $this->addSql('ALTER TABLE comments DROP FOREIGN KEY FK_5F9E962A4B89032C');
-        $this->addSql('ALTER TABLE entity_for_relations DROP FOREIGN KEY FK_C63B81552E3A088A');
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC969017888C');
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC96DA2BFB84');
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC962E3A088A');
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC968097B86C');
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC968572C13C');
-        $this->addSql('ALTER TABLE entitywithrelations_category DROP FOREIGN KEY FK_CD6EBFAB337AA4F7');
-        $this->addSql('ALTER TABLE entitywithrelations_category DROP FOREIGN KEY FK_CD6EBFAB12469DE2');
-        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFA12469DE2');
-        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFAEA0D7566');
-        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFAD126F51');
-        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFA20DBE482');
-        $this->addSql('ALTER TABLE post_tag DROP FOREIGN KEY FK_5ACE3AF04B89032C');
-        $this->addSql('ALTER TABLE post_tag DROP FOREIGN KEY FK_5ACE3AF0BAD26311');
-        $this->addSql('ALTER TABLE post_tag_secondary DROP FOREIGN KEY FK_1515F0214B89032C');
-        $this->addSql('ALTER TABLE post_tag_secondary DROP FOREIGN KEY FK_1515F021BAD26311');
-        $this->addSql('ALTER TABLE post_post DROP FOREIGN KEY FK_93DF0B866FA89B16');
-        $this->addSql('ALTER TABLE post_post DROP FOREIGN KEY FK_93DF0B86764DCB99');
-        $this->addSql('DROP TABLE categories');
-        $this->addSql('DROP TABLE comments');
-        $this->addSql('DROP TABLE contacts');
-        $this->addSql('DROP TABLE entity_for_relations');
-        $this->addSql('DROP TABLE entity_with_relations');
-        $this->addSql('DROP TABLE entitywithrelations_category');
-        $this->addSql('DROP TABLE posts');
-        $this->addSql('DROP TABLE post_tag');
-        $this->addSql('DROP TABLE post_tag_secondary');
-        $this->addSql('DROP TABLE post_post');
-        $this->addSql('DROP TABLE tags');
-        $this->addSql('DROP TABLE users');
     }
 
     public function isTransactional(): bool

--- a/tests/Fixtures/Migrations/Version20221204165430.php
+++ b/tests/Fixtures/Migrations/Version20221204165430.php
@@ -38,24 +38,6 @@ final class Version20221204165430 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE entity_with_relations DROP FOREIGN KEY FK_A9C9EC96FF92FDCA');
-        $this->addSql('ALTER TABLE productcategory_product DROP FOREIGN KEY FK_5BC2A6A2E26A32B1');
-        $this->addSql('ALTER TABLE productcategory_product DROP FOREIGN KEY FK_5BC2A6A24584665A');
-        $this->addSql('ALTER TABLE product_cascade DROP FOREIGN KEY FK_D7FE16D844F5D008');
-        $this->addSql('ALTER TABLE product_producttag DROP FOREIGN KEY FK_B32B4BC24584665A');
-        $this->addSql('ALTER TABLE product_producttag DROP FOREIGN KEY FK_B32B4BC291B6F4D1');
-        $this->addSql('ALTER TABLE review_cascade DROP FOREIGN KEY FK_9DC9B99F4584665A');
-        $this->addSql('ALTER TABLE variant_cascade DROP FOREIGN KEY FK_6982202E4584665A');
-        $this->addSql('ALTER TABLE variant_cascade DROP FOREIGN KEY FK_6982202E3DA5256D');
-        $this->addSql('DROP TABLE brand_cascade');
-        $this->addSql('DROP TABLE category_cascade');
-        $this->addSql('DROP TABLE productcategory_product');
-        $this->addSql('DROP TABLE image_cascade');
-        $this->addSql('DROP TABLE product_cascade');
-        $this->addSql('DROP TABLE product_producttag');
-        $this->addSql('DROP TABLE review_cascade');
-        $this->addSql('DROP TABLE tag_cascade');
-        $this->addSql('DROP TABLE variant_cascade');
     }
 
     public function isTransactional(): bool

--- a/tests/Functional/ORMDatabaseResetterTest.php
+++ b/tests/Functional/ORMDatabaseResetterTest.php
@@ -30,13 +30,10 @@ final class ORMDatabaseResetterTest extends KernelTestCase
      */
     public function it_resets_database_correctly(string $resetMode): void
     {
-        $kernel = static::createKernel(['ormResetMode' => $resetMode]);
-        $kernel->boot();
-
-        $container = $kernel->getContainer();
-
-        $application = new Application($kernel);
+        $application = new Application(self::bootKernel(['ormResetMode' => $resetMode]));
         $application->setAutoExit(false);
+
+        $container = self::$kernel->getContainer();
 
         $resetter = new ORMDatabaseResetter($application, $container->get('doctrine'), [], [], $resetMode);
 


### PR DESCRIPTION
:warning: based on https://github.com/zenstruck/foundry/pull/374

Here is a first draft which auto creates "missing" factories. 
We only create a missing factory if its related field if `ManyToOne` or `OneToOne` and not nullable.

I don't compute any "graph" for the relationships, I don't think it is needed, even with the `All` option.

The CI only passes for "ODM only" tests because in `ORM` cases we have multiple entities called `Category`, resulting to the same file name, and we still don't handle this case. I'm afraid I'll have to fix this bug before finishing this PR.

I also need to manually test this new behavior in a project with some entities and relationships