### PR TITLE
Add a `LazyValue` to create attribute values as late as possible

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -83,6 +83,12 @@ class Factory
         // normalize each attribute set and collapse
         $attributes = \array_merge(...\array_map(fn(callable|array $attributes): array => $this->normalizeAttributes($attributes), $attributeSet));
 
+        foreach ($attributes as $name => $value) {
+            if ($value instanceof LazyValue) {
+                $attributes[$name] = $value($attributes);
+            }
+        }
+
         foreach ($this->beforeInstantiate as $callback) {
             $attributes = $callback($attributes);
 

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+/**
+ * @template Ttype
+ */
+class LazyValue
+{
+    /** @var callable(array):Ttype */
+    private $cb;
+
+    /**
+     * @param callable(array):Ttype $cb
+     */
+    public static function with(callable $cb): self
+    {
+        return new self($cb);
+    }
+
+    private function __construct(callable $cb)
+    {
+        $this->cb = $cb;
+    }
+
+    /**
+     * @return Ttype
+     */
+    public function __invoke(array $attributes)
+    {
+        $cb = $this->cb;
+        return $cb($attributes);
+    }
+}

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -10,14 +10,6 @@ class LazyValue
     /** @var callable(array):Ttype */
     private $cb;
 
-    /**
-     * @param callable(array):Ttype $cb
-     */
-    public static function with(callable $cb): self
-    {
-        return new self($cb);
-    }
-
     private function __construct(callable $cb)
     {
         $this->cb = $cb;
@@ -29,6 +21,15 @@ class LazyValue
     public function __invoke(array $attributes)
     {
         $cb = $this->cb;
+
         return $cb($attributes);
+    }
+
+    /**
+     * @param callable(array):Ttype $cb
+     */
+    public static function with(callable $cb): self
+    {
+        return new self($cb);
     }
 }


### PR DESCRIPTION
I am new to Foundry and trying to push the envelope by using it to replace a hand-written, lots-of-boilerplate collection of test helper classes in a few of my projects.

One pattern I have come across repeatedly is that I have two objects that somehow need to be connected to each other, but the exact details of these objects are subject to the particular test case at hand. Thus, I would like to be able to make this "connection" in a centralized place like a `setUp()` method. But, individual test cases should still be able to modify/configure the exact object details.

For explanation, assume I have a `PriceCalculator` class. It operates on an `Order` object, which in turn contains one or several `OrderLineItem`s. The various tests cover how `PriceCalculator` computes its result based on `Order` properties (e. g. `Order::getDate()` indicating a Black Friday special promotion) as well as `OrderLineItem` (e. g. `OrderLineItem::getQuantity()` or `OrderLineItem::getUnitPrice()`).

PHPUnit test classes may look like this:

```php
class PriceCalculatorTest ...
{
    private OrderFactory $orderFactory;
    private OrderLineItemFactory $orderLineItemFactory;

    protected function setUp(): void
    {
        $this->orderFactory = OrderFactory::new();
        // add OrderLineItem to Order here?
        $this->orderLineItemFactory = OrderLineItemFactory::new()->withAttributes([
            'title' => 'Flux compensator',
            'quantity' => 1,
            'unitPrice' => 99.5
        ]);
    }

    protected function testSomething(): void
    {
        $this->orderFactory = $this->orderFactory->placedOnBlackFridaySale();
        $this->orderLineItemFactory = $this->orderLineItemFactory->withAttributes(['quantity' => 2]);

        $priceCalculator = new PriceCalculator($this->orderFactory->create()->object());
        // ...
    }
```

As you can see, I would like to make the `OrderLineItem` a part of the `Order` in the setup method, and in fact, the list of `OrderLineItems` might even be a constructor paramter for `Order`. But, I cannot instantiate neither `Order` nor `OrderLineItem` that early because the particular test method still needs to set additional attributes.

To solve this, I'd like to discuss a `LazyValue` suggested in this PR. The `LazyValue` can be used as an attribute value and will be recognized by `Factory::create()`. It will be resolved as late as possible. Since arguments are available at that point, they will even be passed into the given closure, although I don't have a reasonable use case yet.

With that, I can write:

```php
... Test class as before

protected function setUp(): void
{
    $this->orderFactory = OrderFactory::new([
        'items' => LazyValue::with(fn () => [$this->orderLineItemFactory->create()->object()])
    ]);
    $this->orderLineItemFactory = OrderLineItemFactory::new([
        'title' => 'Flux compensator',
        'quantity' => 1,
        'unitPrice' => 99.5
    ]);
}
```

Something similar can possibly be achieved by registering a `beforeInstantiate` hook function on the `OrderFactory`. However, assuming that one test case might want to override/set the `items` attribute on the `OrderFactory` later on, that hook function would still be pending and might re-set the `items` to an undesired value once it is executed. The `LazyAttribute`, however, will automatically be replaced once a new attribute value for `items` is set.

As a remark to the implementation, I chose to use the `LazyValue` class to make it clearly recognizable which attributes need to be resolved that way. After all, it might well be that a closure is passed as a regular (plain) attribute value to some object, so the factory cannot simply invoke all callable it sees. The `LazyValue`, however, serves as a clear marker so we know we shall resolve it.
