### PR TITLE
chore: change test context with .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,51 @@
 .PHONY: $(filter-out vendor bin/tools/phpstan/vendor bin/tools/cs-fixer/vendor,$(MAKECMDGOALS))
 
+.DEFAULT_GOAL := help
+
+# DB variables
 MYSQL_URL="mysql://root:root@mysql:3306/zenstruck_foundry?charset=utf8"
 MONGO_URL="mongodb://mongo:mongo@mongo:27017/mongo?compressors=disabled&amp;gssapiServiceName=mongodb&authSource=mongo"
 
+# Default test context variables
+USE_FOUNDRY_BUNDLE=1
+USE_ORM=1
+USE_ODM=1
+USE_DAMA_DOCTRINE_TEST_BUNDLE=1
+SYMFONY_REQUIRE=6.0.*
+
+# Override test context variables with `.env` file
+ifneq (,$(wildcard .env))
+	include .env
+	export $(shell sed 's/=.*//' .env)
+endif
+
+ifeq ($(USE_DAMA_DOCTRINE_TEST_BUNDLE),1)
+	PHPUNIT_CONFIG_FILE='phpunit-dama-doctrine.xml.dist'
+else
+	PHPUNIT_CONFIG_FILE='phpunit.xml.dist'
+endif
+
+# Define docker executable
 ifeq ($(shell docker --help | grep "compose"),)
 	DOCKER_COMPOSE_BIN=docker-compose
 else
 	DOCKER_COMPOSE_BIN=docker compose
 endif
 
+# Create special context for CI
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
 ifdef INTERACTIVE
 	CI='false'
 	DOCKER_COMPOSE=$(DOCKER_COMPOSE_BIN)
-	DC_EXEC=$(DOCKER_COMPOSE) exec -e USE_FOUNDRY_BUNDLE=1 -e DATABASE_URL=${MYSQL_URL} -e MONGO_URL=${MONGO_URL}
+	DC_EXEC=$(DOCKER_COMPOSE) exec -e USE_FOUNDRY_BUNDLE=${USE_FOUNDRY_BUNDLE} -e DATABASE_URL=${MYSQL_URL} -e MONGO_URL=${MONGO_URL}
 else
 	CI='true'
 	DOCKER_COMPOSE=$(DOCKER_COMPOSE_BIN) -f docker-compose.yaml -f docker-compose.ci.yaml
-	DC_EXEC=$(DOCKER_COMPOSE) exec -e USE_FOUNDRY_BUNDLE=1 -e DATABASE_URL=${MYSQL_URL} -e MONGO_URL=${MONGO_URL} -T
+	# CI needs to be ran in no-tty mode
+	DC_EXEC=$(DOCKER_COMPOSE) exec -e USE_FOUNDRY_BUNDLE=${USE_FOUNDRY_BUNDLE} -e DATABASE_URL=${MYSQL_URL} -e MONGO_URL=${MONGO_URL} -T
 endif
 
 DOCKER_PHP=${DC_EXEC} php
-
-.DEFAULT_GOAL := help
-
-UID = $(shell id -u)
-
-DOCKER_IS_UP = $(shell $(DOCKER_COMPOSE) ps | grep "Up (healthy)")
-
-ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-$(eval $(RUN_ARGS):;@:)
 
 # From inside the containers, docker host ip is different in linux and macos
 UNAME_S := $(shell uname -s)
@@ -43,19 +59,11 @@ endif
 help:
 	@fgrep -h "###" $(MAKEFILE_LIST) | fgrep -v fgrep | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-validate: fixcs sca test-full database-validate-mapping ### Run fixcs, sca, full test suite and validate migrations
+validate: fixcs sca test database-validate-mapping ### Run fixcs, sca, full test suite and validate migrations
 
-test-full: docker-start vendor ### Run full PHPUnit (MySQL + Mongo)
+test: docker-start vendor ### Run PHPUnit tests suite
 	@$(eval filter ?= '.')
-	@${DC_EXEC} -e USE_ORM=1 -e USE_ODM=1 php vendor/bin/simple-phpunit --configuration phpunit-dama-doctrine.xml.dist --filter=$(filter)
-
-test-mysql: docker-start vendor ### Run PHPUnit with MySQL
-	@$(eval filter ?= '.')
-	@${DC_EXEC} -e USE_ORM=1 php vendor/bin/simple-phpunit --configuration phpunit-dama-doctrine.xml.dist --filter=$(filter)
-
-test-mongo: docker-start vendor ### Run PHPUnit with Mongo
-	@$(eval filter ?= '.')
-	@${DC_EXEC} -e USE_ODM=1 php vendor/bin/simple-phpunit --configuration phpunit.xml.dist --filter=$(filter)
+	@${DC_EXEC} -e USE_ORM=${USE_ORM} -e USE_ODM=${USE_ODM} php vendor/bin/simple-phpunit --configuration ${PHPUNIT_CONFIG_FILE} --filter=$(filter)
 
 fixcs: docker-start bin/tools/cs-fixer/vendor ### Run PHP-CS-Fixer
 	@${DOCKER_PHP} bin/tools/cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer --no-interaction --diff -v fix
@@ -84,8 +92,11 @@ database-drop-schema: docker-start vendor ### Drop database schema
 	@${DOCKER_PHP} vendor/bin/doctrine-migrations migrations:sync-metadata-storage # prevents the next command to fail if migrations table does not exist
 	@${DOCKER_PHP} bin/doctrine dbal:run-sql "TRUNCATE doctrine_migration_versions" --quiet
 
-vendor: composer.json $(wildcard composer.lock)
-	@${DOCKER_PHP} composer update
+vendor:  composer.json $(wildcard composer.lock) $(wildcard .env)
+	@${DC_EXEC} -e SYMFONY_REQUIRE=${SYMFONY_REQUIRE} php composer update --prefer-dist
+
+UID = $(shell id -u)
+DOCKER_IS_UP = $(shell $(DOCKER_COMPOSE) ps | grep "Up (healthy)")
 
 docker-start: ### Build and run containers
 ifeq ($(DOCKER_IS_UP),)
@@ -103,6 +114,9 @@ docker-stop: ### Stop containers
 
 docker-purge: docker-stop ### Purge containers
 	@$(DOCKER_COMPOSE) down --volumes
+
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(eval $(RUN_ARGS):;@:)
 
 composer: ### Run composer command
 	@${DC_EXEC} php composer $(ARGS)

--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ Each target will build and start the docker stack and install composer only if n
 ```shell
 $ make help
 validate                       Run fixcs, sca, full test suite and validate migrations
-test-full                      Run full PHPunit (MySQL + Mongo)
-test-fast                      Run PHPUnit with SQLite
-test-mysql                     Run PHPUnit with MySQL
-test-postgresql                Run PHPUnit with PostgreSQL
-test-mongo                     Run PHPUnit with Mongo
+test                           Run PHPUnit tests suite
 fixcs                          Run PHP-CS-Fixer
 sca                            Run static analysis
 database-generate-migration    Generate new migration based on mapping in Zenstruck\Foundry\Tests\Fixtures\Entity
@@ -62,16 +58,26 @@ composer                       Run composer command
 clear                          Start from a fresh install (needed if vendors have already been installed with another php version)
 ```
 
-You can run each `test-*` target with a special argument `filter`:
+You can run each `make test` target with a special argument `filter`:
 ```shell
-$ make test-mysql filter=FactoryTest
+$ make test filter=FactoryTest
 ```
 
 which will use PHPUnit's `--filter` option.
 
+#### Run tests in different environments
+
+You can create a `.env` file to change the context in which tests will execute:
+```dotenv
+USE_ORM=1
+USE_ODM=1
+USE_DAMA_DOCTRINE_TEST_BUNDLE=1
+SYMFONY_REQUIRE=6.0.*
+```
+
 ### Change docker's ports
 
-You can create a `.env` file to change the ports used by docker:
+You can also add these variables to the `.env` file to change the ports used by docker:
 ```dotenv
 MYSQL_PORT=3307
 POSTGRES_PORT=5434
@@ -91,11 +97,6 @@ The php container is shipped with xdebug activated. You can use step by step deb
 create a server called `FOUNDRY` in your PHP Remote Debug, with the IDE key `xdebug_foundry`
 
 ![PhpStorm with xdebug](docs/phpstorm-xdebug-config.png)
-
-### Run tests without docker
-
-If for any reason docker is not available on your computer, the target `make test-fast` will run tests with your local
-php version, and sqlite will be used as database. Results may differ from the CI!
 
 ## Migrations
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,4 +47,7 @@ RUN addgroup --system --gid ${UID} ${USER} \
     && chown -R ${USER}:${USER} /app
 USER ${USER}
 
+RUN composer global require --no-progress --no-scripts --no-plugins symfony/flex ; \
+    composer global config --no-plugins allow-plugins.symfony/flex true
+
 CMD tail -f /dev/null


### PR DESCRIPTION
related to https://github.com/zenstruck/foundry/issues/358 (but it does not fixes everything)

I wanted to make this move from a long time: now, when a problem occurs in a specific case, it is possible to easily reproduce the error in local with the same context.

I'd also like to provide a way to easily change the php version used :star_struck: 