### PR TITLE
feat(make:factory): use autocompletion for no persistence classes

### DIFF
--- a/src/Bundle/Maker/MakeFactory.php
+++ b/src/Bundle/Maker/MakeFactory.php
@@ -13,10 +13,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Bundle\Maker\Factory\FactoryClassMap;
 use Zenstruck\Foundry\Bundle\Maker\Factory\FactoryGenerator;
 use Zenstruck\Foundry\Bundle\Maker\Factory\MakeFactoryQuery;
+use Zenstruck\Foundry\Bundle\Maker\Factory\NoPersistanceObjectsAutoCompleter;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -25,7 +27,7 @@ final class MakeFactory extends AbstractMaker
 {
     private const GENERATE_ALL_FACTORIES = 'All';
 
-    public function __construct(private ManagerRegistry $managerRegistry, private FactoryClassMap $factoryClassMap, private KernelInterface $kernel, private FactoryGenerator $factoryGenerator)
+    public function __construct(private ManagerRegistry $managerRegistry, private FactoryClassMap $factoryClassMap, private KernelInterface $kernel, private FactoryGenerator $factoryGenerator, private NoPersistanceObjectsAutoCompleter $noPersistanceObjectsAutoCompleter)
     {
     }
 
@@ -82,9 +84,9 @@ final class MakeFactory extends AbstractMaker
         }
 
         if ($input->getOption('no-persistence')) {
-            $class = $io->ask(
-                'Not persisted class to create a factory for',
-                validator: static function(string $class) {
+            $question = new Question('Not persisted fully qualified class name to create a factory for');
+            $question->setValidator(
+                static function(string $class) {
                     if (!\class_exists($class)) {
                         throw new RuntimeCommandException("Given class \"{$class}\" does not exist.");
                     }
@@ -92,6 +94,8 @@ final class MakeFactory extends AbstractMaker
                     return $class;
                 }
             );
+            $question->setAutocompleterValues($this->noPersistanceObjectsAutoCompleter->getAutocompleteValues());
+            $class = $io->askQuestion($question);
         } else {
             $argument = $command->getDefinition()->getArgument('class');
 

--- a/src/Bundle/Resources/config/maker.xml
+++ b/src/Bundle/Resources/config/maker.xml
@@ -10,6 +10,7 @@
             <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
             <argument type="service" id="kernel" />
             <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.autoCompleter" />
             <tag name="maker.command" />
         </service>
 
@@ -51,6 +52,10 @@
             <argument type="service" id="kernel" />
             <argument type="tagged_iterator" tag="foundry.make_factory.default_properties_guesser" />
             <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+        </service>
+
+        <service id=".zenstruck_foundry.maker.factory.autoCompleter" class="Zenstruck\Foundry\Bundle\Maker\Factory\NoPersistanceObjectsAutoCompleter">
+            <argument>%kernel.project_dir%</argument>
         </service>
     </services>
 </container>

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -205,7 +205,7 @@ final class MakeFactoryTest extends MakerTestCase
 
         $output = $tester->getDisplay();
 
-        $this->assertStringContainsString('Not persisted class to create a factory for:', $output);
+        $this->assertStringContainsString('Not persisted fully qualified class name to create a factory for:', $output);
         $this->assertStringContainsString('[ERROR] Given class "Foo" does not exist', $output);
 
         $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/SomeObjectFactory.php'));

--- a/tests/Unit/Bundle/Maker/Factory/NoPersistanceObjectsAutoCompleterTest.php
+++ b/tests/Unit/Bundle/Maker/Factory/NoPersistanceObjectsAutoCompleterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Unit\Bundle\Maker\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Bundle\Maker\Factory\NoPersistanceObjectsAutoCompleter;
+
+final class NoPersistanceObjectsAutoCompleterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_get_class_names_from_src_directory()
+    {
+        $classNames = (new NoPersistanceObjectsAutoCompleter(\realpath(__DIR__.'/../../../../../')))->getAutocompleteValues();
+
+        // this is an arbitrary number, to ensure we propose enough classes
+        // this check should not be "assertSame()" otherwise it should be updated as soon as a new class is added in src
+        self::assertGreaterThan(30, \count($classNames));
+
+        foreach ($classNames as $class) {
+            if ('Zenstruck\Foundry\functions' === $class) {
+                continue;
+            }
+
+            self::assertTrue(\class_exists($class));
+            self::assertFalse(\trait_exists($class));
+            self::assertFalse(\interface_exists($class));
+        }
+    }
+}


### PR DESCRIPTION
related to #336 

When no `--no-persistence` is passed we ask for a FQCN, which could be cumbersome to write.

Then this PRs proposes as autocomplete all classes found in compoer's PSR-4 config

![Peek 14-12-2022 09-01](https://user-images.githubusercontent.com/10139766/207543006-3806ef22-d9ca-4470-8ae7-1ea491d1b8b1.gif)

