### PR TITLE
tests: reactivate self deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=9999&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
         <env name="SHELL_VERBOSITY" value="0"/>
     </php>
 

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -259,7 +259,7 @@ final class FactoryTest extends TestCase
             ->willReturn($this->createMock(ObjectManager::class))
         ;
 
-        Factory::configuration()->setManagerRegistry($registry);
+        Factory::configuration()->setManagerRegistry($registry)->disableDefaultProxyAutoRefresh();
 
         $object = (new AnonymousFactory(Post::class))->create(['title' => 'title', 'body' => 'body']);
 
@@ -305,7 +305,7 @@ final class FactoryTest extends TestCase
             ->willReturn($this->createMock(ObjectManager::class))
         ;
 
-        Factory::configuration()->setManagerRegistry($registry);
+        Factory::configuration()->setManagerRegistry($registry)->disableDefaultProxyAutoRefresh();
 
         $expectedAttributes = ['shortDescription' => 'short desc', 'title' => 'title', 'body' => 'body'];
         $calls = 0;

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -80,7 +80,7 @@ final class FunctionsTest extends TestCase
             ->willReturn($this->createMock(ObjectManager::class))
         ;
 
-        Factory::configuration()->setManagerRegistry($registry);
+        Factory::configuration()->setManagerRegistry($registry)->enableDefaultProxyAutoRefresh();
 
         $object = create(Category::class);
 
@@ -99,7 +99,7 @@ final class FunctionsTest extends TestCase
             ->willReturn($this->createMock(ObjectManager::class))
         ;
 
-        Factory::configuration()->setManagerRegistry($registry);
+        Factory::configuration()->setManagerRegistry($registry)->enableDefaultProxyAutoRefresh();
 
         $objects = create_many(3, Category::class);
 

--- a/tests/Unit/ProxyTest.php
+++ b/tests/Unit/ProxyTest.php
@@ -85,7 +85,7 @@ final class ProxyTest extends TestCase
             ->willReturn($this->createMock(ObjectManager::class))
         ;
 
-        Factory::configuration()->setManagerRegistry($registry);
+        Factory::configuration()->setManagerRegistry($registry)->enableDefaultProxyAutoRefresh();
 
         $category = new Proxy(new Category());
 


### PR DESCRIPTION
actually the only "self deprecation" triggered was:
```
Since zenstruck\foundry 1.9: Not explicitly configuring the default proxy auto-refresh is deprecated and will default to "true" in 2.0. Use "zenstruck_foundry.auto_refresh_proxies" in the bundle config or TestState::enableDefaultProxyAutoRefresh()/disableDefaultProxyAutoRefresh().
```
so I gave a value to `Configuration::$defaultProxyAutoRefresh` for each of these tests