### PR TITLE
minor: meaningful error for faker in data provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
         "doctrine/mongodb-odm-bundle": "^3.1|^4.2",
+        "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.7",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1472,6 +1472,28 @@ It is possible to use factories in
     For the same reason as above, it is not possible to use `Factories as Services`_ with required
     constructor arguments (the container is not yet available).
 
+.. note::
+
+    Still for the same reason, if `Faker`_ is needed along with ``->withAttributes()`` within a data provider, you'll need
+    to pass attributes as a *callable*.
+
+    Given the data provider of the previous example, here is ``PostFactory::published()``
+
+    .. code-block:: php
+
+        public function published(): self
+        {
+            // This won't work in a data provider!
+            // return $this->withAttributes(['published_at' => self::faker()->dateTime()]);
+
+            // use this instead:
+            return $this->withAttributes(
+                static fn() => [
+                    'published_at' => self::faker()->dateTime()
+                ]
+            );
+        }
+
 .. tip::
 
     ``ModelFactory::new()->many()`` and ``ModelFactory::new()->sequence()`` return a special ``FactoryCollection`` object

--- a/src/Bundle/Maker/Factory/NoPersistanceObjectsAutoCompleter.php
+++ b/src/Bundle/Maker/Factory/NoPersistanceObjectsAutoCompleter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the zenstruck/foundry package.
  *

--- a/src/Exception/FoundryNotBootedException.php
+++ b/src/Exception/FoundryNotBootedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Zenstruck\Foundry\Exception;
+
+/**
+ * @internal
+ */
+final class FoundryNotBootedException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Foundry is not yet booted. Using in a test: is your Test case using the Factories trait? Using in a fixture: is ZenstruckFoundryBundle enabled for this environment?'
+        );
+    }
+}


### PR DESCRIPTION
related to #397 

a more opinionated solution would be to deprecate the usage of `array` parameters in `withAttributes()`
but I don't know if it is worth it