### PR TITLE
feat(make:factory): handle name collision

### DIFF
--- a/src/Bundle/Maker/Factory/Exception/FactoryClassAlreadyExistException.php
+++ b/src/Bundle/Maker/Factory/Exception/FactoryClassAlreadyExistException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Bundle\Maker\Factory\Exception;
+
+final class FactoryClassAlreadyExistException extends \InvalidArgumentException
+{
+    public function __construct(string $factoryClass)
+    {
+        parent::__construct("Factory \"{$factoryClass}\" already exists.");
+    }
+}

--- a/src/Bundle/Maker/Factory/FactoryClassMap.php
+++ b/src/Bundle/Maker/Factory/FactoryClassMap.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
+use Zenstruck\Foundry\Bundle\Maker\Factory\Exception\FactoryClassAlreadyExistException;
 use Zenstruck\Foundry\ModelFactory;
 
 /**
@@ -65,9 +66,14 @@ final class FactoryClassMap
     public function addFactoryForClass(string $factoryClass, string $class): void
     {
         if (\array_key_exists($factoryClass, $this->classesWithFactories)) {
-            throw new \InvalidArgumentException("Factory \"{$factoryClass}\" already exists.");
+            throw new FactoryClassAlreadyExistException($factoryClass);
         }
 
         $this->classesWithFactories[$factoryClass] = $class;
+    }
+
+    public function factoryClassExists(string $factoryClass): bool
+    {
+        return \array_key_exists($factoryClass, $this->classesWithFactories);
     }
 }

--- a/src/Bundle/Maker/Factory/FactoryGenerator.php
+++ b/src/Bundle/Maker/Factory/FactoryGenerator.php
@@ -16,8 +16,11 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\Bundle\Maker\Factory\Exception\FactoryClassAlreadyExistException;
 
 /**
  * @internal
@@ -51,7 +54,31 @@ final class FactoryGenerator
         $factoryClass = $makeFactoryData->getFactoryClassNameDetails()->getFullName();
 
         if (!$this->factoryClassMap->classHasFactory($class)) {
-            $this->factoryClassMap->addFactoryForClass($factoryClass, $class);
+            try {
+                $this->factoryClassMap->addFactoryForClass($factoryClass, $class);
+            } catch (FactoryClassAlreadyExistException) {
+                $question = new Question(
+                    sprintf(
+                        'Class "%s" already exists. Chose another one please (it will be generated in namespace "%s")',
+                        Str::getShortClassName($factoryClass),
+                        Str::getNamespace($factoryClass)
+                    )
+                );
+
+                $question->setValidator(
+                    function(string $newClassName) use ($factoryClass) {
+                        $newFactoryClass = sprintf('%s\\%s', Str::getNamespace($factoryClass), $newClassName);
+                        if ($this->factoryClassMap->factoryClassExists($newFactoryClass)) {
+                            throw new RuntimeCommandException("Class \"$newFactoryClass\" also already exists!");
+                        }
+
+                        return $newFactoryClass;
+                    }
+                );
+                $factoryClass = $io->askQuestion($question);
+
+                $this->factoryClassMap->addFactoryForClass($factoryClass, $class);
+            }
         }
 
         foreach ($this->defaultPropertiesGuessers as $defaultPropertiesGuesser) {

--- a/tests/Fixtures/Entity/Cascade/Product.php
+++ b/tests/Fixtures/Entity/Cascade/Product.php
@@ -40,7 +40,7 @@ class Product
     private Collection $categories;
 
     /**
-     * @ORM\ManyToMany(targetEntity=ProductTag::class, inversedBy="products", cascade={"persist"})
+     * @ORM\ManyToMany(targetEntity=Tag::class, inversedBy="products", cascade={"persist"})
      */
     private Collection $tags;
 
@@ -135,14 +135,14 @@ class Product
         return $this->tags;
     }
 
-    public function addTag(ProductTag $tag): void
+    public function addTag(Tag $tag): void
     {
         if (!$this->tags->contains($tag)) {
             $this->tags[] = $tag;
         }
     }
 
-    public function removeTag(ProductTag $tag): void
+    public function removeTag(Tag $tag): void
     {
         if ($this->tags->contains($tag)) {
             $this->tags->removeElement($tag);

--- a/tests/Fixtures/Entity/Cascade/Tag.php
+++ b/tests/Fixtures/Entity/Cascade/Tag.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="tag_cascade")
  */
-class ProductTag
+class Tag
 {
     /**
      * @ORM\Id

--- a/tests/Fixtures/Migrations/Version20221204165430.php
+++ b/tests/Fixtures/Migrations/Version20221204165430.php
@@ -21,7 +21,7 @@ final class Version20221204165430 extends AbstractMigration
         $this->addSql('CREATE TABLE productcategory_product (productcategory_id INT NOT NULL, product_id INT NOT NULL, INDEX IDX_5BC2A6A2E26A32B1 (productcategory_id), INDEX IDX_5BC2A6A24584665A (product_id), PRIMARY KEY(productcategory_id, product_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE image_cascade (id INT AUTO_INCREMENT NOT NULL, path VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE product_cascade (id INT AUTO_INCREMENT NOT NULL, brand_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, INDEX IDX_D7FE16D844F5D008 (brand_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE product_producttag (product_id INT NOT NULL, producttag_id INT NOT NULL, INDEX IDX_B32B4BC24584665A (product_id), INDEX IDX_B32B4BC291B6F4D1 (producttag_id), PRIMARY KEY(product_id, producttag_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE product_tag (product_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_E3A6E39C4584665A (product_id), INDEX IDX_E3A6E39CBAD26311 (tag_id), PRIMARY KEY(product_id, tag_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE review_cascade (id INT AUTO_INCREMENT NOT NULL, product_id INT DEFAULT NULL, ranking INT NOT NULL, UNIQUE INDEX UNIQ_9DC9B99F4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE tag_cascade (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE variant_cascade (id INT AUTO_INCREMENT NOT NULL, product_id INT DEFAULT NULL, image_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, INDEX IDX_6982202E4584665A (product_id), UNIQUE INDEX UNIQ_6982202E3DA5256D (image_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
@@ -29,8 +29,8 @@ final class Version20221204165430 extends AbstractMigration
         $this->addSql('ALTER TABLE productcategory_product ADD CONSTRAINT FK_5BC2A6A24584665A FOREIGN KEY (product_id) REFERENCES product_cascade (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE entity_with_relations ADD CONSTRAINT FK_A9C9EC96FF92FDCA FOREIGN KEY (manyToOneWithNotExistingFactory_id) REFERENCES brand_cascade (id)');
         $this->addSql('ALTER TABLE product_cascade ADD CONSTRAINT FK_D7FE16D844F5D008 FOREIGN KEY (brand_id) REFERENCES brand_cascade (id)');
-        $this->addSql('ALTER TABLE product_producttag ADD CONSTRAINT FK_B32B4BC24584665A FOREIGN KEY (product_id) REFERENCES product_cascade (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE product_producttag ADD CONSTRAINT FK_B32B4BC291B6F4D1 FOREIGN KEY (producttag_id) REFERENCES tag_cascade (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE product_tag ADD CONSTRAINT FK_E3A6E39C4584665A FOREIGN KEY (product_id) REFERENCES product_cascade (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE product_tag ADD CONSTRAINT FK_E3A6E39CBAD26311 FOREIGN KEY (tag_id) REFERENCES tag_cascade (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE review_cascade ADD CONSTRAINT FK_9DC9B99F4584665A FOREIGN KEY (product_id) REFERENCES product_cascade (id)');
         $this->addSql('ALTER TABLE variant_cascade ADD CONSTRAINT FK_6982202E4584665A FOREIGN KEY (product_id) REFERENCES product_cascade (id)');
         $this->addSql('ALTER TABLE variant_cascade ADD CONSTRAINT FK_6982202E3DA5256D FOREIGN KEY (image_id) REFERENCES image_cascade (id)');

--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMComment;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
-use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Tag as AnotherTagClass;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Comment;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
@@ -312,13 +312,18 @@ final class MakeFactoryTest extends MakerTestCase
     {
         $tester = $this->makeFactoryCommandTester();
 
-        $tester->setInputs(['All']);
+        $inputs = ['All']; // which factory to generate?
+        if (\getenv('USE_ORM')) {
+            $inputs[] = 'OtherTagFactory'; // name collision handling (only for ORM, the collision is caused my an ORM class
+        }
+
+        $tester->setInputs($inputs);
         $tester->execute([]);
 
         $expectedFactories = [];
 
         if (\getenv('USE_ORM')) {
-            $expectedFactories = ['BrandFactory', 'CategoryFactory', 'CommentFactory', 'ContactFactory', 'EntityForRelationsFactory', 'UserFactory'];
+            $expectedFactories = ['BrandFactory', 'CategoryFactory', 'CommentFactory', 'ContactFactory', 'EntityForRelationsFactory', 'UserFactory', 'TagFactory', 'OtherTagFactory'];
         }
 
         if (\getenv('USE_ODM')) {
@@ -474,6 +479,33 @@ final class MakeFactoryTest extends MakerTestCase
 
         $factoryClass = Str::getShortClassName(Address::class);
         $this->assertFileFromMakerSameAsExpectedFile(self::tempFile("src/Factory/{$factoryClass}Factory.php"));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_name_collision(): void
+    {
+        if (!\getenv('USE_ORM')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+
+        $tester = $this->makeFactoryCommandTester();
+        $tester->execute(['class' => Tag::class]);
+
+        $tester->setInputs([
+            'TagFactory', // first attempt to change the factory's name, will still break
+            'OtherTagFactory', // second attempt, is OK
+        ]);
+        $tester->execute(['class' => AnotherTagClass::class]);
+
+        $this->assertFileExists(self::tempFile("src/Factory/TagFactory.php"));
+        $this->assertFileExists(self::tempFile("src/Factory/OtherTagFactory.php"));
+
+        $output = $tester->getDisplay();
+
+        $this->assertStringContainsString('Class "TagFactory" already exists', $output);
+        $this->assertStringContainsString('[ERROR] Class "App\Factory\TagFactory" also already exists!', $output);
     }
 
     protected static function createKernel(array $options = []): KernelInterface

--- a/tests/Functional/FactoryDoctrineCascadeTest.php
+++ b/tests/Functional/FactoryDoctrineCascadeTest.php
@@ -19,7 +19,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Brand;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Image;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Product;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\ProductCategory;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\ProductTag;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Tag;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Review;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Variant;
 
@@ -83,7 +83,7 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
     {
         $product = factory(Product::class, [
             'name' => 'foo',
-            'tags' => [factory(ProductTag::class, ['name' => 'bar'])],
+            'tags' => [factory(Tag::class, ['name' => 'bar'])],
         ])->instantiateWith(function(array $attibutes, string $class): object {
             $this->assertNull($attibutes['tags'][0]->getId());
 


### PR DESCRIPTION
If two factories will have the same name. ie: we use `All` and multiple entities have the same "short name", but in different namespace, it currently results as an error

Now, we ask for a replacement "short name" (because full namespace are cumbersome to write)