### PR TITLE
Drop testing on unsupported symfony versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.0, 8.1, 8.2]
-        symfony: [5.4.*, 6.0.*, 6.1.*, 6.2.*]
+        symfony: [5.4.*, 6.2.*]
         deps: [highest]
         use-orm: [1]
         use-odm: [1]
@@ -23,7 +23,6 @@ jobs:
           - {use-orm: 0, use-odm: 0} # tested directly in a test case
           - {use-orm: 0, use-dama: 1} # cannot happen
           # conflicts
-          - {php: 8.0, symfony: 6.1.*}
           - {php: 8.0, symfony: 6.2.*}
         include:
           - {php: 8.0, symfony: 5.4.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: lowest}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
   fixcs:
     name: Run php-cs-fixer
     needs: sync-with-template
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
     runs-on: ubuntu-latest
     steps:
       - uses: zenstruck/.github@php-cs-fixer
@@ -241,7 +241,7 @@ jobs:
 
   sync-with-template:
     name: Sync meta files
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
     runs-on: ubuntu-latest
     steps:
       - uses: zenstruck/.github@sync-with-template


### PR DESCRIPTION
Also fixes #405... I think, we'll need to test once this is merged.