### PR TITLE
fix return type syntax

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1843,7 +1843,7 @@ Later, you can access the story's state when creating other fixtures:
         use Zenstruck\Foundry\Story;
 
         /**
-         * @method php(): Category
+         * @method php() Category
          */
         final class CategoryStory extends Story
         {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1843,7 +1843,7 @@ Later, you can access the story's state when creating other fixtures:
         use Zenstruck\Foundry\Story;
 
         /**
-         * @method php() Category
+         * @method Category php()
          */
         final class CategoryStory extends Story
         {


### PR DESCRIPTION
prevents `PHPDoc tag @method has invalid value (rolf(): User): Unexpected token "\n ", expected type at offset  27` (from the closed issue https://github.com/zenstruck/foundry/issues/414)

the errors occurs from the colon `:`
https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/method.html

Maybe also hint in the docs that you need to install `phpstan/phpdoc-parser`