### PR TITLE
fix: restore Factory::$cascadePersist

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -39,6 +39,8 @@ class Factory
 
     private bool $persist = true;
 
+    private bool $cascadePersist = false;
+
     /** @var array<array|callable> */
     private array $attributeSet = [];
 
@@ -122,7 +124,7 @@ class Factory
 
         $proxy = new Proxy($object);
 
-        if (!$this->isPersisting()) {
+        if (!$this->isPersisting() || $this->cascadePersist) {
             return $proxy;
         }
 
@@ -372,9 +374,7 @@ class Factory
                 }
             }
 
-            if ($cascadePersist) {
-                $value = $value->withoutPersisting();
-            }
+            $value->cascadePersist = $cascadePersist;
         }
 
         return $value->create()->object();
@@ -408,9 +408,7 @@ class Factory
 
         return \array_map(
             function(self $factory): self {
-                if (!$this->isPersisting()) {
-                    $factory = $factory->withoutPersisting();
-                }
+                $factory->cascadePersist = $this->cascadePersist;
 
                 return $factory;
             },

--- a/tests/Fixtures/Entity/Cascade/Variant.php
+++ b/tests/Fixtures/Entity/Cascade/Variant.php
@@ -19,7 +19,7 @@ class Variant
     #[ORM\ManyToOne(targetEntity: Product::class, inversedBy: "variants")]
     private ?Product $product = null;
 
-    #[ORM\OneToOne(targetEntity: Image::class, cascade: ["persist"])]
+    #[ORM\OneToOne(targetEntity: Image::class)]
     private ?Image $image = null;
 
     public function getId(): ?int

--- a/tests/Functional/FactoryDoctrineCascadeTest.php
+++ b/tests/Functional/FactoryDoctrineCascadeTest.php
@@ -47,10 +47,10 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
         $product = factory(Product::class, [
             'name' => 'foo',
             'brand' => factory(Brand::class, ['name' => 'bar']),
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['brand']->getId());
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['brand']->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
         $this->assertNotNull($product->getBrand()->getId());
@@ -64,11 +64,17 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
     {
         $product = factory(Product::class, [
             'name' => 'foo',
-            'variants' => [factory(Variant::class, ['name' => 'bar'])],
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['variants'][0]->getId());
+            'variants' => [
+                factory(Variant::class, [
+                    'name' => 'bar',
+                    // asserts a "sub" relationship without cascade persist is persisted
+                    'image' => factory(Image::class, ['path' => '/some/path']),
+                ]),
+            ],
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['variants'][0]->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
         $this->assertCount(1, $product->getVariants());
@@ -84,10 +90,10 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
         $product = factory(Product::class, [
             'name' => 'foo',
             'tags' => [factory(Tag::class, ['name' => 'bar'])],
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['tags'][0]->getId());
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['tags'][0]->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
         $this->assertCount(1, $product->getTags());
@@ -103,10 +109,10 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
         $product = factory(Product::class, [
             'name' => 'foo',
             'categories' => [factory(ProductCategory::class, ['name' => 'bar'])],
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['categories'][0]->getId());
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['categories'][0]->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
         $this->assertCount(1, $product->getCategories());
@@ -119,17 +125,17 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
      */
     public function one_to_one_relationship(): void
     {
-        $variant = factory(Variant::class, [
+        $product = factory(Product::class, [
             'name' => 'foo',
-            'image' => factory(Image::class, ['path' => '/path/to/file.extension']),
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['image']->getId());
+            'review' => factory(Review::class, ['rank' => 5]),
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['review']->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
-        $this->assertNotNull($variant->getImage()->getId());
-        $this->assertSame('/path/to/file.extension', $variant->getImage()->getPath());
+        $this->assertNotNull($product->getReview()->getId());
+        $this->assertSame(5, $product->getReview()->getRank());
     }
 
     /**
@@ -140,10 +146,10 @@ final class FactoryDoctrineCascadeTest extends KernelTestCase
         $product = factory(Product::class, [
             'name' => 'foo',
             'review' => factory(Review::class, ['rank' => 4]),
-        ])->instantiateWith(function(array $attibutes, string $class): object {
-            $this->assertNull($attibutes['review']->getId());
+        ])->instantiateWith(function(array $attributes, string $class): object {
+            $this->assertNull($attributes['review']->getId());
 
-            return (new Instantiator())($attibutes, $class);
+            return (new Instantiator())($attributes, $class);
         })->create();
 
         $this->assertNotNull($product->getReview()->getId());


### PR DESCRIPTION
sorry for that, I just discovered a case where `Factory::$cascadePersist` is needed. The solution in #422 could not work because of this: https://github.com/zenstruck/foundry/blob/1.x/src/Factory.php#L350

I've provided in the PR a test which ensures this case is covered