### PR TITLE
feat(bundle): allow registering custom Faker Providers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -506,6 +506,17 @@ random data for your factories:
 
 .. note::
 
+    You can register your own *Faker Provider* by tagging any service with ``foundry.faker_provider``.
+    All public methods on this service will be available on Foundry's Faker instance:
+
+    .. code-block:: php
+
+        use function Zenstruck\Foundry\faker;
+
+        faker()->customMethodOnMyService();
+
+.. note::
+
     For full control, you can register your own ``Faker\Generator`` service:
 
     .. code-block:: yaml

--- a/src/Bundle/DependencyInjection/RegisterFakerProvidersPass.php
+++ b/src/Bundle/DependencyInjection/RegisterFakerProvidersPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zenstruck\Foundry\Bundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class RegisterFakerProvidersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('foundry.faker_provider') as $id => $tags) {
+            $container
+                ->getDefinition('.zenstruck_foundry.faker')
+                ->addMethodCall('addProvider', array(new Reference($id)))
+            ;
+        }
+    }
+}

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ChainManagerRegistryPass;
 use Zenstruck\Foundry\Bundle\DependencyInjection\GlobalStatePass;
+use Zenstruck\Foundry\Bundle\DependencyInjection\RegisterFakerProvidersPass;
 use Zenstruck\Foundry\Bundle\DependencyInjection\ZenstruckFoundryExtension;
 
 /**
@@ -38,6 +39,7 @@ final class ZenstruckFoundryBundle extends Bundle
 
         $container->addCompilerPass(new ChainManagerRegistryPass());
         $container->addCompilerPass(new GlobalStatePass());
+        $container->addCompilerPass(new RegisterFakerProvidersPass());
     }
 
     protected function createContainerExtension(): ?ExtensionInterface

--- a/tests/Fixtures/CustomFakerProvider.php
+++ b/tests/Fixtures/CustomFakerProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CustomFakerProvider
+{
+    public function customValue(): string
+    {
+        return 'custom-value';
+    }
+}

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -93,6 +93,7 @@ class Kernel extends BaseKernel
             ->setAutoconfigured(true)
             ->setAutowired(true)
         ;
+        $c->register(CustomFakerProvider::class)->addTag('foundry.faker_provider');
 
         foreach ($this->factoriesRegistered as $factory) {
             $c->register($factory)

--- a/tests/Functional/FakerTest.php
+++ b/tests/Functional/FakerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class FakerTest extends KernelTestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    public function can_use_custom_provider(): void
+    {
+        $this->assertSame('custom-value', Factory::faker()->customValue());
+    }
+}


### PR DESCRIPTION
Tagging a service with `faker.provider` adds it as a _faker provider_.