### PR TITLE
feat: add `LazyValue` to calculate attribute values only when needed

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -260,6 +260,30 @@ should have. `Faker`_ is available to easily get random data:
     Using ``make:factory --all-fields`` will generate default values for all fields of the entity,
     not only non-nullable fields.
 
+.. note::
+
+    ``getDefaults()`` is called everytime a factory is instantiated (even if you don't end up
+    creating it. If you have a value for one of your attributes that has side effects (ie
+    creating a file or fetching a random existing entity from another factory), you can wrap
+    the value in a ``LazyValue``. This ensures the value is only calculated when/if it's
+    needed.
+
+    .. code-block:: php
+
+        use Zenstruck\Foundry\Attributes\LazyValue;
+        use function Zenstruck\Foundry\lazy;
+
+        // ...
+
+        protected function getDefaults(): array
+        {
+            return [
+                'category' => new LazyValue(fn() => CategoryFactory::random()),
+
+                'file' => lazy(fn() => create_temp_file()), // or use the lazy() helper function
+            ];
+        }
+
 Using your Factory
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Faker;
+use Zenstruck\Foundry\LazyValue;
 use Zenstruck\Foundry\Exception\FoundryNotBootedException;
 
 /**
@@ -92,6 +93,9 @@ class Factory
 
         // normalize each attribute set and collapse
         $attributes = \array_merge(...\array_map(fn(callable|array $attributes): array => $this->normalizeAttributes($attributes), $attributeSet));
+
+        // execute "lazy" values
+        $attributes = LazyValue::normalizeArray($attributes);
 
         foreach ($this->beforeInstantiate as $callback) {
             $attributes = $callback($attributes);

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Zenstruck\Foundry;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LazyValue
+{
+    /** @var callable():mixed */
+    private $factory;
+
+    /**
+     * @param callable():mixed $factory
+     */
+    public function __construct(callable $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * @internal
+     */
+    public function __invoke(): mixed
+    {
+        $value = ($this->factory)();
+
+        if ($value instanceof self) {
+            return ($value)();
+        }
+
+        if (\is_array($value)) {
+            return self::normalizeArray($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @internal
+     */
+    public static function normalizeArray(array $value): array
+    {
+        \array_walk_recursive($value, static function(mixed &$v): void {
+            if ($v instanceof self) {
+                $v = $v();
+            }
+        });
+
+        return $value;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry;
 
 use Faker;
+use Zenstruck\Foundry\LazyValue;
 
 /**
  * @see Factory::__construct()
@@ -103,4 +104,14 @@ function repository(object|string $objectOrClass): RepositoryProxy
 function faker(): Faker\Generator
 {
     return Factory::faker();
+}
+
+/**
+ * @see LazyValue
+ *
+ * @param callable():mixed $factory
+ */
+function lazy(callable $factory): LazyValue
+{
+    return new LazyValue($factory);
 }

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\LazyValue;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LazyValueTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function executes_factory(): void
+    {
+        $value = new LazyValue(fn() => 'foo');
+
+        $this->assertSame('foo', $value());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_nested_lazy_values(): void
+    {
+        $value = new LazyValue(new LazyValue(new LazyValue(fn() => new LazyValue(fn() => 'foo'))));
+
+        $this->assertSame('foo', $value());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_array_with_lazy_values(): void
+    {
+        $value = new LazyValue(function() {
+            return [
+                5,
+                new LazyValue(fn() => 'foo'),
+                6,
+                'foo' => [
+                    'bar' => 7,
+                    'baz' => new LazyValue(fn() => 'foo'),
+                ],
+                [8, new LazyValue(fn() => 'foo')],
+            ];
+        });
+
+        $this->assertSame([5, 'foo', 6, 'foo' => ['bar' => 7, 'baz' => 'foo'], [8, 'foo']], $value());
+    }
+}


### PR DESCRIPTION
Fixes: #244
Fixes: #373 (alternate implementation)

```php
use Zenstruck\Foundry\Attributes\LazyValue;
use function Zenstruck\Foundry\lazy;

// ...

protected function getDefaults(): array
{
    return [
        'category' => new LazyValue(fn() => CategoryFactory::random()),

        'file' => lazy(fn() => create_temp_file()), // or use the lazy() helper function
    ];
}
```