### PR TITLE
Add introduction to index.rst for symfony.com accessibility

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,17 @@
 Foundry
 =======
 
+Foundry makes creating fixtures data fun again, via an expressive, auto-completable, on-demand fixtures system with
+Symfony and Doctrine:
+
+The factories can be used inside `DoctrineFixturesBundle <https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html>`)
+to load fixtures or inside your tests, `where it has even more features <https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#using-in-your-tests>`.
+
 Foundry supports ``doctrine/orm`` (with `doctrine/doctrine-bundle <https://github.com/doctrine/doctrinebundle>`_),
 ``doctrine/mongodb-odm`` (with `doctrine/mongodb-odm-bundle <https://github.com/doctrine/DoctrineMongoDBBundle>`_)
 or a combination of these.
+
+Want to watch a screencast 🎥 about it? Check out https://symfonycasts.com/foundry
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,8 @@ Foundry
 Foundry makes creating fixtures data fun again, via an expressive, auto-completable, on-demand fixtures system with
 Symfony and Doctrine:
 
-The factories can be used inside `DoctrineFixturesBundle <https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html>`)
-to load fixtures or inside your tests, `where it has even more features <https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#using-in-your-tests>`.
+The factories can be used inside `DoctrineFixturesBundle <https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html>`_
+to load fixtures or inside your tests, `where it has even more features <https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#using-in-your-tests>`_.
 
 Foundry supports ``doctrine/orm`` (with `doctrine/doctrine-bundle <https://github.com/doctrine/doctrinebundle>`_),
 ``doctrine/mongodb-odm`` (with `doctrine/mongodb-odm-bundle <https://github.com/doctrine/DoctrineMongoDBBundle>`_)


### PR DESCRIPTION
I just discovered this package on the symfony.com website. When I arrived on the [doc](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html) page I didn't understand what this package was for. I had to find the GitHub project and look at the readme in order to figure out what it was about.

I hope that adding the introduction text from the readme to the `index.rst` will help newcomers.