### PR TITLE
feat: findOrCreate() can use embeddable

### DIFF
--- a/tests/Fixtures/Entity/Address.php
+++ b/tests/Fixtures/Entity/Address.php
@@ -7,18 +7,19 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 final class Address
 {
-    /**
-     * @var mixed|null
-     */
-    #[ORM\Column(type: "string", nullable: true)]
-    private $value;
+    public function __construct(
+        #[ORM\Column(type: "string", nullable: true)]
+        private string $value
+    )
+    {
+    }
 
     public function getValue()
     {
         return $this->value;
     }
 
-    public function setValue($value): void
+    public function setValue(string $value): void
     {
         $this->value = $value;
     }

--- a/tests/Fixtures/Entity/Contact.php
+++ b/tests/Fixtures/Entity/Contact.php
@@ -22,7 +22,7 @@ class Contact
     public function __construct($name)
     {
         $this->name = $name;
-        $this->address = new Address();
+        $this->address = new Address('some address');
     }
 
     public function getName()

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
@@ -34,6 +34,7 @@ final class AddressFactory extends ModelFactory
     protected function getDefaults(): array
     {
         return [
+            'value' => self::faker()->sentence(),
         ];
     }
 

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -140,11 +140,9 @@ final class FactoryTest extends KernelTestCase
      */
     public function can_create_embeddable(): void
     {
-        $object1 = (new AnonymousFactory(Address::class))->create();
-        $object2 = (new AnonymousFactory(Address::class))->create(['value' => 'an address']);
+        $object = (new AnonymousFactory(Address::class))->create(['value' => 'an address']);
 
-        $this->assertNull($object1->getValue());
-        $this->assertSame('an address', $object2->getValue());
+        $this->assertSame('an address', $object->getValue());
     }
 
     public function can_delay_flush(): void

--- a/tests/Functional/ODMAnonymousFactoryTest.php
+++ b/tests/Functional/ODMAnonymousFactoryTest.php
@@ -11,13 +11,30 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Zenstruck\Foundry\AnonymousFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMCategory;
+use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
+use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class ODMAnonymousFactoryTest extends AnonymousFactoryTest
 {
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_embedded_object()
+    {
+        $factory = AnonymousFactory::new(ODMPost::class);
+
+        $factory->assert()->count(0);
+        $factory->findOrCreate($attributes = ['title' => 'foo', 'body' => 'bar', 'user' => new ODMUser('some user')]);
+        $factory->assert()->count(1);
+        $factory->findOrCreate($attributes);
+        $factory->assert()->count(1);
+    }
+
     protected function setUp(): void
     {
         if (!\getenv('USE_ODM')) {

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -77,6 +77,21 @@ final class ODMModelFactoryTest extends ModelFactoryTest
         self::assertCount(1, $posts);
     }
 
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_embedded_object(): void
+    {
+        $post = PostFactory::findOrCreate(['title' => 'foo', 'user' => new ODMUser('some user')]);
+        self::assertSame('some user', $post->getUser()->getName());
+        PostFactory::assert()->count(1);
+
+        $post2 = PostFactory::findOrCreate(['title' => 'foo', 'user' => new ODMUser('some user')]);
+        PostFactory::assert()->count(1);
+
+        self::assertSame($post->object(), $post2->object());
+    }
+
     protected function categoryClass(): string
     {
         return ODMCategory::class;

--- a/tests/Functional/ORMAnonymousFactoryTest.php
+++ b/tests/Functional/ORMAnonymousFactoryTest.php
@@ -11,13 +11,30 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Zenstruck\Foundry\AnonymousFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class ORMAnonymousFactoryTest extends AnonymousFactoryTest
 {
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_embedded_object()
+    {
+        $factory = AnonymousFactory::new(Contact::class);
+
+        $factory->assert()->count(0);
+        $factory->findOrCreate($attributes = ['name' => 'foo', 'address' => new Address('some address')]);
+        $factory->assert()->count(1);
+        $factory->findOrCreate($attributes);
+        $factory->assert()->count(1);
+    }
+
     protected function setUp(): void
     {
         if (!\getenv('USE_ORM')) {

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
@@ -538,6 +539,36 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         PostFactory::assert()->count(4);
         PostFactory::assert()->count(2, ['category' => $category]);
         self::assertSame(2, PostFactory::count(['category' => $category]));
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_embedded_object(): void
+    {
+        $contact = ContactFactory::findOrCreate($attributes = ['name' => 'foo', 'address' => new Address('some address')]);
+        self::assertSame('some address', $contact->getAddress()->getValue());
+        ContactFactory::assert()->count(1);
+
+        $contact2 = ContactFactory::findOrCreate($attributes);
+        ContactFactory::assert()->count(1);
+
+        self::assertSame($contact->object(), $contact2->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_factory_of_embedded_object(): void
+    {
+        $contact = ContactFactory::findOrCreate($attributes = ['name' => 'foo', 'address' => AddressFactory::new(['value' => 'address'])]);
+        self::assertSame('address', $contact->getAddress()->getValue());
+        ContactFactory::assert()->count(1);
+
+        $contact2 = ContactFactory::findOrCreate($attributes);
+        ContactFactory::assert()->count(1);
+
+        self::assertSame($contact->object(), $contact2->object());
     }
 
     protected function categoryClass(): string

--- a/tests/Functional/ORMProxyTest.php
+++ b/tests/Functional/ORMProxyTest.php
@@ -56,7 +56,7 @@ final class ORMProxyTest extends ProxyTest
         // object is included in the changeset when using UOW::recomputeSingleEntityChangeSet().
         // Changing to UOW::computeChangeSet() fixes this.
         $this->assertSame('john', $contact->getName());
-        $this->assertNull($contact->getAddress()->getValue());
+        $this->assertSame('some address', $contact->getAddress()->getValue());
 
         $contact->getAddress()->setValue('address');
         $contact->save();


### PR DESCRIPTION
related to #428

This PR has some limitations:
- still not possible to use factories as suggested in https://github.com/zenstruck/foundry/issues/428#issuecomment-1466957360 but I'm wondering if wan can do this, because we need to extract the attributes from the factory. Thus `Factory::normalizeAttributes()` should be opened, and I'm not sure it is a good idea (maybe we can make it internal?)
- not possible to deal with nested embeddable: this is not impossible, but would need some recursive method that would complicate the code

not really sure where we should document this?

/cc @KDederichs

