### PR TITLE
fix(global state): register story as service in StoryManager

### DIFF
--- a/src/Test/GlobalStateRegistry.php
+++ b/src/Test/GlobalStateRegistry.php
@@ -53,7 +53,9 @@ final class GlobalStateRegistry
         return [
             ...\array_map(
                 static fn(Story $story): \Closure => static function() use ($story): void {
-                    $story->build();
+                    // even if we already have access to the instance here,
+                    // let's use ::load() in order to register the service in StoryManager
+                    $story::class::load();
                 },
                 $this->storiesAsService
             ),

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -158,6 +158,7 @@ class Kernel extends BaseKernel
             if ($this->enableDoctrine && \getenv('USE_ODM') && !\getenv('USE_DAMA_DOCTRINE_TEST_BUNDLE')) {
                 $globalState[] = ODMTagStory::class;
                 $globalState[] = ODMTagStoryAsAService::class;
+                $c->register(ODMTagStoryAsAService::class)->addTag('foundry.story');
             }
 
             $foundryConfig['global_state'] = $globalState;

--- a/tests/Functional/ODMGlobalStateTest.php
+++ b/tests/Functional/ODMGlobalStateTest.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Tests\Functional;
 
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\TagFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\ODMTagStory;
+use Zenstruck\Foundry\Tests\Fixtures\Stories\ODMTagStoryAsAService;
 
 final class ODMGlobalStateTest extends GlobalStateTest
 {
@@ -27,6 +28,16 @@ final class ODMGlobalStateTest extends GlobalStateTest
         }
 
         parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function ensure_global_story_as_a_service_is_not_loaded_again(): void
+    {
+        TagFactory::repository()->assert()->count(1, ['name' => 'design']);
+        ODMTagStoryAsAService::load();
+        TagFactory::repository()->assert()->count(1, ['name' => 'design']);
     }
 
     protected function getTagFactoryClass(): string


### PR DESCRIPTION
fixes #433

The problem was we were directly using `$story->build()` from the global state, without registering the "story as service" in the `StoryManager`. Resulting that the pool was not saved, and recreated.

I've tested the fix on one of my projects, and managed to create a failing test case here.

/cc @mvhirsch 

