### PR TITLE
fix: running `array_values()` on array attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
             "symfony/flex": true
         }
     },
+    "conflict": {
+        "doctrine/mongodb-odm": "2.5.0"
+    },
     "autoload": {
         "psr-4": { "Zenstruck\\Foundry\\": "src/" },
         "files": ["src/functions.php"]

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -116,7 +116,7 @@ class Factory
                     ...\array_values(\array_filter($normalizedAttribute, static fn(mixed $attribute): bool => $attribute instanceof PostPersistCallback)),
                 ];
 
-                $normalizedAttribute = \array_values(\array_filter($normalizedAttribute, static fn(mixed $attribute): bool => !$attribute instanceof PostPersistCallback));
+                $normalizedAttribute = \array_filter($normalizedAttribute, static fn(mixed $attribute): bool => !$attribute instanceof PostPersistCallback);
             }
 
             if ($normalizedAttribute instanceof PostPersistCallback) {

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -394,4 +394,18 @@ final class FactoryTest extends TestCase
 
         (new AnonymousFactory(Post::class))->create(['title' => 'title', 'body' => 'body'])->save();
     }
+
+    /**
+     * @test
+     */
+    public function can_use_arrays_for_attribute_values(): void
+    {
+        $object = new class {
+            public $value;
+        };
+
+        $factory = AnonymousFactory::new($object::class)->create(['value' => ['foo' => 'bar']]);
+
+        $this->assertSame(['foo' => 'bar'], $factory->value);
+    }
 }


### PR DESCRIPTION
#423 lost the keys for attributes that were arrays.