### PR TITLE
fix: regression from embedded object in findOrCreate function

### DIFF
--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -326,6 +326,8 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
             if ($attributeValue instanceof Factory) {
                 $attributeValue = $attributeValue->withoutPersisting()->create()->object();
+            } else if ($attributeValue instanceof Proxy) {
+                $attributeValue = $attributeValue->object();
             }
 
             try {
@@ -340,8 +342,11 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
                 default => throw new \LogicException(\sprintf('Metadata class %s is not supported.', $metadataForAttribute::class))
             };
 
+            // it's a regular entity
             if (!$isEmbedded) {
-                throw new \InvalidArgumentException('Only embeddable objects can be passed as attributes for "findOrCreate()" method.');
+                $normalizedCriteria[$attributeName] = $attributeValue;
+
+                continue;
             }
 
             foreach ($metadataForAttribute->getFieldNames() as $field) {

--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -333,7 +333,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             try {
                 $metadataForAttribute = $this->getObjectManager()->getClassMetadata($attributeValue::class);
             } catch (MappingException $e) {
-                throw new \InvalidArgumentException('Only embeddable objects can be passed as attributes for "findOrCreate()" method.', previous: $e);
+                throw new \InvalidArgumentException('Only managed objects can be passed as attributes for "findOrCreate()" method.', previous: $e);
             }
 
             $isEmbedded = match ($metadataForAttribute::class) {

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -19,6 +19,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\UserFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -87,6 +88,40 @@ final class ODMModelFactoryTest extends ModelFactoryTest
         PostFactory::assert()->count(1);
 
         $post2 = PostFactory::findOrCreate(['title' => 'foo', 'user' => new ODMUser('some user')]);
+        PostFactory::assert()->count(1);
+
+        self::assertSame($post->object(), $post2->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_object(): void
+    {
+        $user = UserFactory::createOne(['name' => 'some user']);
+        $post = PostFactory::findOrCreate($attributes = ['user' => $user->object()]);
+
+        self::assertSame($user->object(), $post->getUser());
+        PostFactory::assert()->count(1);
+
+        $post2 = PostFactory::findOrCreate($attributes);
+        PostFactory::assert()->count(1);
+
+        self::assertSame($post->object(), $post2->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_proxy_of_object(): void
+    {
+        $user = UserFactory::createOne(['name' => 'some user']);
+        $post = PostFactory::findOrCreate($attributes = ['user' => $user]);
+
+        self::assertSame($user->object(), $post->getUser());
+        PostFactory::assert()->count(1);
+
+        $post2 = PostFactory::findOrCreate($attributes);
         PostFactory::assert()->count(1);
 
         self::assertSame($post->object(), $post2->object());

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Functional;
 use Doctrine\ORM\EntityManagerInterface;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\User;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
@@ -569,6 +570,40 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         ContactFactory::assert()->count(1);
 
         self::assertSame($contact->object(), $contact2->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_object(): void
+    {
+        $user = UserFactory::createOne();
+        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user->object()]);
+
+        self::assertSame($user->object(), $comment->getUser());
+        CommentFactory::assert()->count(1);
+
+        $comment2 = CommentFactory::findOrCreate($attributes);
+        CommentFactory::assert()->count(1);
+
+        self::assertSame($comment->object(), $comment2->object());
+    }
+
+    /**
+     * @test
+     */
+    public function can_find_or_create_from_proxy_of_object(): void
+    {
+        $user = UserFactory::createOne();
+        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user]);
+
+        self::assertSame($user->object(), $comment->getUser());
+        CommentFactory::assert()->count(1);
+
+        $comment2 = CommentFactory::findOrCreate($attributes);
+        CommentFactory::assert()->count(1);
+
+        self::assertSame($comment->object(), $comment2->object());
     }
 
     protected function categoryClass(): string


### PR DESCRIPTION
Fix the issue https://github.com/zenstruck/foundry/issues/437.

I added:

- in `src/RepositoryProxy.php` when `isEmbedded` is false, that means this is a regular entity
- in `src/RepositoryProxy.php` I added a test to allow `$attributeValue` to be a `Proxy` object (maybe it's an hidden feat, WDYT ?)
- add minimal tests to prevent futur regressions