### PR TITLE
fix: allow any object passed as find() criteria

### DIFF
--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -332,8 +332,10 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
             try {
                 $metadataForAttribute = $this->getObjectManager()->getClassMetadata($attributeValue::class);
-            } catch (MappingException $e) {
-                throw new \InvalidArgumentException('Only managed objects can be passed as attributes for "findOrCreate()" method.', previous: $e);
+            } catch (MappingException) {
+                $normalizedCriteria[$attributeName] = $attributeValue;
+
+                continue;
             }
 
             $isEmbedded = match ($metadataForAttribute::class) {
@@ -352,7 +354,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
             foreach ($metadataForAttribute->getFieldNames() as $field) {
                 $embeddableFieldValue = $propertyAccessor->getValue($attributeValue, $field);
                 if (\is_object($embeddableFieldValue)) {
-                    throw new \InvalidArgumentException('Nested embeddable objects are still not supported in "findOrCreate()" method.');
+                    throw new \InvalidArgumentException('Nested embeddable objects are still not supported in "find()" method.');
                 }
 
                 $normalizedCriteria["{$attributeName}.{$field}"] = $embeddableFieldValue;

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -577,7 +577,7 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     public function can_find_or_create_from_object(): void
     {
         $user = UserFactory::createOne();
-        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user->object()]);
+        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user->object(), 'createdAt' => new \DateTimeImmutable('2023-01-01')]);
 
         self::assertSame($user->object(), $comment->getUser());
         CommentFactory::assert()->count(1);


### PR DESCRIPTION
fixes #439

/cc @sad270