### PR TITLE
fix(RepositoryProxy::find()): allow not entity object in

### DIFF
--- a/src/RepositoryProxy.php
+++ b/src/RepositoryProxy.php
@@ -16,6 +16,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
@@ -332,7 +333,7 @@ final class RepositoryProxy implements ObjectRepository, \IteratorAggregate, \Co
 
             try {
                 $metadataForAttribute = $this->getObjectManager()->getClassMetadata($attributeValue::class);
-            } catch (MappingException) {
+            } catch (MappingException|ORMMappingException) {
                 $normalizedCriteria[$attributeName] = $attributeValue;
 
                 continue;

--- a/tests/Fixtures/Factories/EntityWithEnumFactory.php
+++ b/tests/Fixtures/Factories/EntityWithEnumFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\Tests\Fixtures\PHP81\EntityWithEnum;
+use Zenstruck\Foundry\Tests\Fixtures\PHP81\SomeEnum;
+
+final class EntityWithEnumFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'enum' => self::faker()->randomElement(SomeEnum::cases()),
+        ];
+    }
+
+    protected static function getClass(): string
+    {
+        return EntityWithEnum::class;
+    }
+}

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -18,6 +18,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CommentFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\ContactFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\EntityWithEnumFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithInvalidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithNullInitialize;
@@ -25,6 +26,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactoryWithValidInitialize;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\SpecificPostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\TagFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
+use Zenstruck\Foundry\Tests\Fixtures\PHP81\SomeEnum;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -603,6 +605,21 @@ final class ORMModelFactoryTest extends ModelFactoryTest
         CommentFactory::assert()->count(1);
 
         self::assertSame($comment->object(), $comment2->object());
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function can_find_or_create_entity_with_enum(): void
+    {
+        $entityWithEnum = EntityWithEnumFactory::findOrCreate($attributes = ['enum' => SomeEnum::VALUE]);
+        EntityWithEnumFactory::assert()->count(1);
+
+        $entityWithEnum2 = EntityWithEnumFactory::findOrCreate($attributes);
+        EntityWithEnumFactory::assert()->count(1);
+
+        self::assertSame($entityWithEnum->object(), $entityWithEnum2->object());
     }
 
     protected function categoryClass(): string


### PR DESCRIPTION
want a good joke? `Doctrine\ORM\Mapping\MappingException` does not extend `Doctrine\Persistence\Mapping\MappingException`! (but `\Doctrine\ODM\MongoDB\Mapping\MappingException` does) :facepalm: :clown_face: 