### PR TITLE
Have `delayFlush()` return the callback's return

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -155,17 +155,19 @@ final class Configuration
         return $this->databaseResetEnabled;
     }
 
-    public function delayFlush(callable $callback): void
+    public function delayFlush(callable $callback): mixed
     {
         $this->flushEnabled = false;
 
-        $callback();
+        $result = $callback();
 
         foreach ($this->managerRegistry()?->getManagers() ?? [] as $manager) {
             $manager->flush();
         }
 
         $this->flushEnabled = true;
+
+        return $result;
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -320,9 +320,9 @@ class Factory
         }
     }
 
-    final public static function delayFlush(callable $callback): void
+    final public static function delayFlush(callable $callback): mixed
     {
-        self::configuration()->delayFlush($callback);
+        return self::configuration()->delayFlush($callback);
     }
 
     /**

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
@@ -151,15 +152,20 @@ final class FactoryTest extends KernelTestCase
         repository(Post::class)->assert()->empty();
         repository(Category::class)->assert()->empty();
 
-        Factory::delayFlush(static function(): void {
-            anonymous(Post::class)->create([
+        $post = null;
+        $return = Factory::delayFlush(static function() use (&$post): Proxy {
+            $post = anonymous(Post::class)->create([
                 'title' => 'title',
                 'body' => 'body',
                 'category' => anonymous(Category::class, ['name' => 'name']),
             ]);
             repository(Post::class)->assert()->empty();
             repository(Category::class)->assert()->empty();
+
+            return $post;
         });
+
+        $this->assertSame($post, $return);
 
         repository(Post::class)->assert()->count(1);
         repository(Category::class)->assert()->count(1);
@@ -173,7 +179,8 @@ final class FactoryTest extends KernelTestCase
         repository(Post::class)->assert()->empty();
         repository(Category::class)->assert()->empty();
 
-        Factory::delayFlush(static function(): void {
+        $post = null;
+        $return = Factory::delayFlush(static function() use (&$post): Proxy {
             $post = anonymous(Post::class)->create([
                 'title' => 'title',
                 'body' => 'body',
@@ -183,7 +190,11 @@ final class FactoryTest extends KernelTestCase
             $post->setBody('new body');
             repository(Post::class)->assert()->empty();
             repository(Category::class)->assert()->empty();
+
+            return $post;
         });
+
+        $this->assertSame($post, $return);
 
         repository(Post::class)->assert()->count(1);
         repository(Category::class)->assert()->count(1);


### PR DESCRIPTION
A minor DX improvement, instead of having to do eg:

```php
$tags = [];
Factory::delayFlush(function() use (&$tags) {
    // ...
    $tags = TagFactory::createMany(200);
});
```

the needed fixtures can now be returned instead:

```php
$tags = Factory::delayFlush(function() {
    // ...
    return TagFactory::createMany(200);
});
```

or multiple:

```php
[$categories, $tags] = Factory::delayFlush(function() {
    return [
        CategoryFactory::createMany(100),
        TagFactory::createMany(200),
    ];
});
```