### PR TITLE
docs: add static ide hint to stories

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1882,7 +1882,7 @@ Later, you can access the story's state when creating other fixtures:
         use Zenstruck\Foundry\Story;
 
         /**
-         * @method Category php()
+         * @method static Category php()
          */
         final class CategoryStory extends Story
         {
@@ -1893,6 +1893,8 @@ Later, you can access the story's state when creating other fixtures:
         }
 
     Now your IDE will know ``CategoryStory::php()`` returns an object of type ``Category``.
+    
+    Using a magic method also does not require a prior ``::load()`` call on the story, it will initialize itself.
 
 .. note::
 


### PR DESCRIPTION
The story docs mention a way to hint the return value of story state references. It uses static method calls to retrieve them, but does not declare them as static, leading to IDE warnings.

It is also not mentioned that the magic getters, through `\Zenstruck\Foundry\Story::__callStatic` already ensure the story is loaded correctly, so calling `::load` does not add anything to the test.