### PR TITLE
minor: add $persistentManagerName param

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -175,7 +175,7 @@ final class Configuration
      * @phpstan-param Proxy<TObject>|TObject|class-string<TObject> $objectOrClass
      * @phpstan-return RepositoryProxy<TObject>
      */
-    public function repositoryFor(object|string $objectOrClass): RepositoryProxy
+    public function repositoryFor(object|string $objectOrClass, string|null $persistentManagerName = null): RepositoryProxy
     {
         if ($objectOrClass instanceof Proxy) {
             $objectOrClass = $objectOrClass->object();
@@ -186,7 +186,7 @@ final class Configuration
         }
 
         /** @var EntityRepository<TObject>|null $repository */
-        $repository = $this->managerRegistry()?->getRepository($objectOrClass);
+        $repository = $this->managerRegistry()?->getRepository($objectOrClass, $persistentManagerName);
 
         if (!$repository) {
             throw new \RuntimeException(\sprintf('No repository registered for "%s".', $objectOrClass));

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -260,9 +260,9 @@ abstract class ModelFactory extends Factory
     /**
      * @phpstan-return RepositoryProxy<TModel>
      */
-    final public static function repository(): RepositoryProxy
+    final public static function repository(string|null $persistentManagerName = null): RepositoryProxy
     {
-        return static::configuration()->repositoryFor(static::getClass());
+        return static::configuration()->repositoryFor(static::getClass(), $persistentManagerName);
     }
 
     /**

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -207,9 +207,9 @@ final class Proxy implements \Stringable
         return Instantiator::forceGet($this->object(), $property);
     }
 
-    public function repository(): RepositoryProxy
+    public function repository(string|null $persistentManagerName = null): RepositoryProxy
     {
-        return Factory::configuration()->repositoryFor($this->class);
+        return Factory::configuration()->repositoryFor($this->class, $persistentManagerName);
     }
 
     public function enableAutoRefresh(): self

--- a/src/functions.php
+++ b/src/functions.php
@@ -110,9 +110,9 @@ function instantiate_many(int $number, string $class, array|callable $attributes
  *
  * @return RepositoryProxy<TObject>
  */
-function repository(object|string $objectOrClass): RepositoryProxy
+function repository(object|string $objectOrClass, string|null $persistentManagerName = null): RepositoryProxy
 {
-    return Factory::configuration()->repositoryFor($objectOrClass);
+    return Factory::configuration()->repositoryFor($objectOrClass, $persistentManagerName);
 }
 
 /**


### PR DESCRIPTION
fixes #447 

I've not provided tests, because the code is trivial, but this would need to add a new document manager in the test :shrug: 

/cc @kerstvo

EDIT: I just realized that adding a param to `ModelFactory::repository()` will create an error in psalm in userland, because of the `@phpstan-method` annotation :disappointed: 

https://github.com/zenstruck/foundry/actions/runs/4707671150/jobs/8349671474?pr=450#step:8:18