### PR TITLE
feat: create PhpStan type resolvers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
 
       - name: 'Test'
         run: |
+          # we need phpstan to be installed in order to run tests on phpstan extension
+          composer bin phpstan install
+
           if [ "${{ matrix.use-dama }}" == "1" ]; then
             CONFIGURATION="--configuration phpunit-dama-doctrine.xml.dist"
           fi
@@ -128,7 +131,11 @@ jobs:
           dependency-versions: "highest"
 
       - name: 'Coverage'
-        run: vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist --coverage-text --coverage-clover=foundry.clover
+        run: |
+          # we need phpstan to be installed in order to run tests on phpstan extension
+          composer bin phpstan install
+
+          vendor/bin/simple-phpunit -v --configuration phpunit-dama-doctrine.xml.dist --coverage-text --coverage-clover=foundry.clover
         env:
           USE_ORM: 1
           USE_ODM: 1

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 validate: sca psalm test database-validate-mapping ### Run sca, full test suite and validate migrations
 
 .PHONY: test
-test: vendor ### Run PHPUnit tests suite
+test: vendor $(PHPSTAN_BIN) ### Run PHPUnit tests suite
 	@$(MAKE) --no-print-directory docker-start-if-not-running
 	@${DC_EXEC} -e USE_ORM=${USE_ORM} -e USE_ODM=${USE_ODM} ${PHP} vendor/bin/simple-phpunit --configuration ${PHPUNIT_CONFIG_FILE} $(ARGS)
 

--- a/bin/tools/phpstan/composer.lock
+++ b/bin/tools/phpstan/composer.lock
@@ -117,16 +117,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.2",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d6fdf01c53978b6429f1393ba4afeca39cc68afa",
-                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -155,8 +155,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.2"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -172,26 +175,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-10T09:56:11+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.2.16",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "d6ea16206b1b645ded5b43736d8ef5ae1168eb55"
+                "reference": "7e78605a699d183f5a6936cf91904f4c16ca79b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/d6ea16206b1b645ded5b43736d8ef5ae1168eb55",
-                "reference": "d6ea16206b1b645ded5b43736d8ef5ae1168eb55",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/7e78605a699d183f5a6936cf91904f4c16ca79b2",
+                "reference": "7e78605a699d183f5a6936cf91904f4c16ca79b2",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.1"
+                "phpstan/phpstan": "^1.9.18"
             },
             "conflict": {
                 "symfony/framework-bundle": "<3.0"
@@ -201,7 +204,7 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^8.5.29 || ^9.5",
                 "psr/container": "1.0 || 1.1.1",
                 "symfony/config": "^5.4 || ^6.1",
                 "symfony/console": "^5.4 || ^6.1",
@@ -241,9 +244,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.16"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.3.1"
             },
-            "time": "2022-11-04T13:16:15+00:00"
+            "time": "2023-04-14T16:59:18+00:00"
         }
     ],
     "packages-dev": [],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,21 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\AnonymousFactory\\:\\:create\\(\\) should return Zenstruck\\\\Foundry\\\\Proxy\\<TModel of object\\> but returns \\(TModel of object\\)\\|Zenstruck\\\\Foundry\\\\Proxy\\<TModel of object\\>\\.$#"
+			count: 1
+			path: src/AnonymousFactory.php
+
+		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\AnonymousFactory\\:\\:many\\(\\) should return Zenstruck\\\\Foundry\\\\FactoryCollection\\<TModel of object\\> but returns Zenstruck\\\\Foundry\\\\FactoryCollection\\<object\\>\\.$#"
+			count: 1
+			path: src/AnonymousFactory.php
+
+		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\AnonymousFactory\\:\\:sequence\\(\\) should return Zenstruck\\\\Foundry\\\\FactoryCollection\\<TModel of object\\> but returns Zenstruck\\\\Foundry\\\\FactoryCollection\\<object\\>\\.$#"
+			count: 1
+			path: src/AnonymousFactory.php
+
+		-
 			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string\\|null given\\.$#"
 			count: 1
 			path: src/Bundle/DependencyInjection/GlobalStatePass.php
@@ -76,11 +91,21 @@ parameters:
 			path: src/ZenstruckFoundryBundle.php
 
 		-
-			message: "#^Function Zenstruck\\\\Foundry\\\\create_many\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\>\\> but returns array\\<int, T of object\\>\\.$#"
+			message: "#^Function Zenstruck\\\\Foundry\\\\create\\(\\) should return \\(T of object\\)\\|Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\> but returns object\\.$#"
 			count: 1
 			path: src/functions.php
 
 		-
-			message: "#^Function Zenstruck\\\\Foundry\\\\instantiate_many\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\>\\> but returns array\\<int, T of object\\>\\.$#"
+			message: "#^Function Zenstruck\\\\Foundry\\\\create_many\\(\\) should return array\\<int, \\(T of object\\)\\|Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\>\\> but returns array\\<int, object\\>\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Function Zenstruck\\\\Foundry\\\\instantiate\\(\\) should return \\(T of object\\)\\|Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\> but returns object\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Function Zenstruck\\\\Foundry\\\\instantiate_many\\(\\) should return array\\<int, \\(T of object\\)\\|Zenstruck\\\\Foundry\\\\Proxy\\<T of object\\>\\> but returns array\\<int, object\\>\\.$#"
 			count: 1
 			path: src/functions.php

--- a/phpstan-foundry.neon
+++ b/phpstan-foundry.neon
@@ -1,0 +1,21 @@
+services:
+    -
+        class: Zenstruck\Foundry\PhpStan\FactoryMethodsTypeResolver
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: Zenstruck\Foundry\PhpStan\FactoryStaticMethodsTypeResolver
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+    -
+        class: Zenstruck\Foundry\PhpStan\FactoryRepositoryMethodTypeResolver
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+    -
+        class: Zenstruck\Foundry\PhpStan\AnonymousFactoryTypeResolver
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: Zenstruck\Foundry\PhpStan\AnonymousHelpersTypeResolver
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- phpstan-baseline.neon
+	- phpstan-foundry.neon
 
 parameters:
     inferPrivatePropertyTypeFromConstructor: true
@@ -33,3 +34,4 @@ parameters:
                     - var_dump
     excludePaths:
         - ./src/Bundle/Resources
+        - ./src/PhpStan

--- a/src/Bundle/Maker/Factory/FactoryClassMap.php
+++ b/src/Bundle/Maker/Factory/FactoryClassMap.php
@@ -27,7 +27,6 @@ final class FactoryClassMap
     /** @param \Traversable<ObjectFactory> $factories */
     public function __construct(\Traversable $factories)
     {
-        /** @phpstan-ignore-next-line */
         $this->classesWithFactories = \array_unique(
             \array_reduce(
                 \iterator_to_array($factories, preserve_keys: true),

--- a/src/PhpStan/AnonymousFactoryTypeResolver.php
+++ b/src/PhpStan/AnonymousFactoryTypeResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ORM\Mapping\Entity;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use Zenstruck\Foundry\BaseFactory;
+use Zenstruck\Foundry\Object\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+final class AnonymousFactoryTypeResolver implements DynamicFunctionReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseFactory::class;
+    }
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'Zenstruck\Foundry\anonymous';
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?\PHPStan\Type\Type
+    {
+        $targetClass = $functionCall->getArgs()[0]->value;
+
+        if (!$targetClass instanceof ClassConstFetch) {
+            return null;
+        }
+
+        if (!$targetClass->class instanceof FullyQualified) {
+            return null;
+        }
+
+        $reflectionClass = new \ReflectionClass($targetClass->class->toString());
+        if ($reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class)) {
+            $factoryClass = PersistentObjectFactory::class;
+        } else {
+            $factoryClass = ObjectFactory::class;
+        }
+
+        return new GenericObjectType($factoryClass, [new ObjectType($targetClass->class->toString())]);
+    }
+}

--- a/src/PhpStan/AnonymousHelpersTypeResolver.php
+++ b/src/PhpStan/AnonymousHelpersTypeResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ORM\Mapping\Entity;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use Zenstruck\Foundry\BaseFactory;
+use Zenstruck\Foundry\Object\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+final class AnonymousHelpersTypeResolver implements DynamicFunctionReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseFactory::class;
+    }
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return \in_array(
+            $functionReflection->getName(),
+            [
+                'Zenstruck\Foundry\create',
+                'Zenstruck\Foundry\create_many',
+            ],
+            true
+        );
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?\PHPStan\Type\Type
+    {
+        $targetClass = $this->extractTargetClass($functionCall);
+
+        if (!$targetClass) {
+            return null;
+        }
+
+        $reflectionClass = new \ReflectionClass($targetClass);
+        if ($reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class)) {
+            $factoryClass = PersistentObjectFactory::class;
+        } else {
+            $factoryClass = ObjectFactory::class;
+        }
+
+        $factoryMetadata = new FactoryMetadata($factoryClass, $targetClass);
+
+        return match ($functionCall->name->toString()) {
+            'Zenstruck\Foundry\create' => $factoryMetadata->getSingleResultType(),
+            'Zenstruck\Foundry\create_many' => $factoryMetadata->getFactoryCollectionResultType(),
+            default => null
+        };
+    }
+
+    private function extractTargetClass(FuncCall $functionCall): ?string
+    {
+        $argPosition = match ($functionCall->name->toString()) {
+            'Zenstruck\Foundry\create' => 0,
+            'Zenstruck\Foundry\create_many' => 1,
+            default => null
+        };
+
+        if ($argPosition === null) {
+            return null;
+        }
+
+        $targetClass = $functionCall->getArgs()[$argPosition]->value;
+
+        if (!$targetClass instanceof ClassConstFetch) {
+            return null;
+        }
+
+        if (!$targetClass->class instanceof FullyQualified) {
+            return null;
+        }
+
+        return $targetClass->class->toString();
+    }
+}

--- a/src/PhpStan/FactoryMetadata.php
+++ b/src/PhpStan/FactoryMetadata.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use Zenstruck\Foundry\BaseFactory;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class FactoryMetadata
+{
+    public function __construct(
+        /** @var class-string<BaseFactory> */
+        private string $factoryClass,
+        /** @var class-string */
+        private string $targetClass,
+    )
+    {
+    }
+
+    public static function getFactoryMetadata(CallLike $methodCall, Scope $scope): ?FactoryMetadata
+    {
+        $type = match (true) {
+            $methodCall instanceof MethodCall => $scope->getType($methodCall->var),
+            $methodCall instanceof StaticCall => new ObjectType($methodCall->class->toString()),
+            default => null
+        };
+
+        if (!$type instanceof ObjectType) {
+            return null;
+        }
+
+        if ($type instanceof GenericObjectType) {
+            if (\count($type->getTypes()) !== 1 || !$type->getTypes()[0] instanceof ObjectType) {
+                return null;
+            }
+
+            return new FactoryMetadata($type->getClassName(), $type->getTypes()[0]->getClassName());
+        }
+
+        try {
+            $factoryReflection = new \ReflectionClass($type->getClassName());
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        if ($factoryReflection->isAbstract()) {
+            return null;
+        }
+
+        return new FactoryMetadata($type->getClassName(), $type->getClassName()::class());
+    }
+
+    public function getSingleResultType(): ObjectType
+    {
+        return $this->hasPersistence()
+            ? $this->getProxySingleResult()
+            : new ObjectType($this->targetClass);
+    }
+
+    public function getListResultType(): ArrayType
+    {
+        return new ArrayType(
+            new IntegerType(),
+            $this->getSingleResultType()
+        );
+    }
+
+    public function getFactoryCollectionResultType(): GenericObjectType
+    {
+        return new GenericObjectType(
+            FactoryCollection::class,
+            [
+                $this->getSingleResultType()
+            ]
+        );
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getTargetClass(): string
+    {
+        return $this->targetClass;
+    }
+
+    private function getProxySingleResult(): GenericObjectType
+    {
+        return new GenericObjectType(Proxy::class, [new ObjectType($this->targetClass)]);
+    }
+
+    private function hasPersistence(): bool
+    {
+        return is_a($this->factoryClass, PersistentObjectFactory::class, true);
+    }
+}

--- a/src/PhpStan/FactoryMethodsTypeResolver.php
+++ b/src/PhpStan/FactoryMethodsTypeResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Zenstruck\Foundry\BaseFactory;
+
+final class FactoryMethodsTypeResolver implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseFactory::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array(
+            $methodReflection->getName(),
+            [
+                'create',
+                'many',
+                'sequence',
+            ],
+            true
+        );
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $scope);
+
+        if (!$factoryMetadata) {
+            return null;
+        }
+
+        return match ($methodReflection->getName()) {
+            'create' => $factoryMetadata->getSingleResultType(),
+            'many', 'sequence' => $factoryMetadata->getFactoryCollectionResultType(),
+            default => null
+        };
+    }
+}

--- a/src/PhpStan/FactoryRepositoryMethodTypeResolver.php
+++ b/src/PhpStan/FactoryRepositoryMethodTypeResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document as ODMDocumentAttribute;
+use Doctrine\ORM\Mapping\Entity as ORMEntityAttribute;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Zenstruck\Foundry\BaseFactory;
+use Zenstruck\Foundry\RepositoryProxy;
+
+final class FactoryRepositoryMethodTypeResolver implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseFactory::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'repository';
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+    {
+        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $scope);
+
+        if (!$factoryMetadata) {
+            return null;
+        }
+
+        if (!$this->hasPersistence($factoryMetadata->getTargetClass())) {
+            return null;
+        }
+
+        return new GenericObjectType(RepositoryProxy::class, [new ObjectType($factoryMetadata->getTargetClass())]);
+    }
+
+    /**
+     * @param class-string $templateTypeReferences
+     */
+    private function hasPersistence(string $templateTypeReferences): bool
+    {
+        // extract the repository class name from the attributes of the model class
+        $attributes = (new \ReflectionClass($templateTypeReferences))->getAttributes(ORMEntityAttribute::class);
+        if (!$attributes) {
+            $attributes = (new \ReflectionClass($templateTypeReferences))->getAttributes(ODMDocumentAttribute::class);
+        }
+
+        return (bool) $attributes;
+    }
+}

--- a/src/PhpStan/FactoryStaticMethodsTypeResolver.php
+++ b/src/PhpStan/FactoryStaticMethodsTypeResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use Zenstruck\Foundry\BaseFactory;
+
+final class FactoryStaticMethodsTypeResolver implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseFactory::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array(
+            $methodReflection->getName(),
+            [
+                'createOne',
+                'find',
+                'findOrCreate',
+                'first',
+                'last',
+                'random',
+                'randomOrCreate',
+                'all',
+                'createMany',
+                'createSequence',
+                'findBy',
+                'randomRange',
+                'randomSet',
+            ],
+            true
+        );
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+    {
+        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $scope);
+
+        if (!$factoryMetadata) {
+            return null;
+        }
+
+        return match ($methodReflection->getName()) {
+            'createOne', 'find', 'findOrCreate', 'first', 'last', 'random', 'randomOrCreate' => $factoryMetadata->getSingleResultType(),
+            'all', 'createMany', 'createSequence', 'findBy', 'randomRange', 'randomSet' => $factoryMetadata->getListResultType(),
+            default => null
+        };
+    }
+}

--- a/tests/Fixtures/Entity/User.php
+++ b/tests/Fixtures/Entity/User.php
@@ -18,6 +18,9 @@ class User
     #[ORM\Column(type: "string")]
     private ?string $name = null;
 
+    #[ORM\Column(type: "json")]
+    private array $data = [];
+
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: "user", orphanRemoval: true)]
     private Collection $comments;
 
@@ -65,5 +68,15 @@ class User
                 $comment->setUser(null);
             }
         }
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function setData(array $data): void
+    {
+        $this->data = $data;
     }
 }

--- a/tests/Fixtures/Migrations/Version20221204165429.php
+++ b/tests/Fixtures/Migrations/Version20221204165429.php
@@ -27,7 +27,7 @@ final class Version20221204165429 extends AbstractMigration
         $this->addSql('CREATE TABLE post_tag_secondary (post_id INT NOT NULL, tag_id INT NOT NULL, INDEX IDX_1515F0214B89032C (post_id), INDEX IDX_1515F021BAD26311 (tag_id), PRIMARY KEY(post_id, tag_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE post_post (post_source INT NOT NULL, post_target INT NOT NULL, INDEX IDX_93DF0B866FA89B16 (post_source), INDEX IDX_93DF0B86764DCB99 (post_target), PRIMARY KEY(post_source, post_target)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE tags (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE users (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE users (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, data JSON NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE comments ADD CONSTRAINT FK_5F9E962AA76ED395 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE comments ADD CONSTRAINT FK_5F9E962A4B89032C FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE entity_for_relations ADD CONSTRAINT FK_C63B81552E3A088A FOREIGN KEY (manyToOne_id) REFERENCES entity_with_relations (id)');

--- a/tests/Fixtures/PhpStan/test-types.php
+++ b/tests/Fixtures/PhpStan/test-types.php
@@ -1,0 +1,36 @@
+<?php
+
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObjectFactory;
+use function PHPStan\Testing\assertType;
+use function Zenstruck\Foundry\anonymous;
+use function Zenstruck\Foundry\create;
+use function Zenstruck\Foundry\create_many;
+
+assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::new()->create());
+assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::createOne());
+assertType('Zenstruck\Foundry\RepositoryProxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::repository());
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::new()->many(2));
+assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::new()->many(2)->create());
+assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::createMany(2));
+
+assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', SomeObjectFactory::new()->create());
+assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', SomeObjectFactory::createOne());
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', SomeObjectFactory::new()->many(2));
+assertType('array<int, Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', SomeObjectFactory::new()->many(2)->create());
+assertType('array<int, Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', SomeObjectFactory::createMany(2));
+
+assertType('Zenstruck\Foundry\Persistence\PersistentObjectFactory<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', anonymous(Post::class));
+assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', anonymous(Post::class)->create());
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', anonymous(Post::class)->many(2));
+assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', anonymous(Post::class)->many(2)->create());
+assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', create(Post::class));
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', create_many(2, Post::class));
+
+assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', anonymous(SomeObject::class)->create());
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', anonymous(SomeObject::class)->many(2));
+assertType('array<int, Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', anonymous(SomeObject::class)->many(2)->create());
+assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', create(SomeObject::class));
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', create_many(2, SomeObject::class));

--- a/tests/PhpStan/DynamicTypesResolverTest.php
+++ b/tests/PhpStan/DynamicTypesResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\PhpStan;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class DynamicTypesResolverTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public function typesProvider(): iterable
+    {
+        yield from $this->gatherAssertTypes(__DIR__.'/../Fixtures/PhpStan/test-types.php');
+    }
+
+    /**
+     * @test
+     * @dataProvider typesProvider
+     */
+    public function itCanResolveTests(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__.'/../../phpstan-foundry.neon'];
+    }
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -26,6 +26,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 
+use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 use function Zenstruck\Foundry\anonymous;
 use function Zenstruck\Foundry\lazy;
 
@@ -321,12 +322,8 @@ final class FactoryTest extends TestCase
      */
     public function can_use_arrays_for_attribute_values(): void
     {
-        $object = new class() {
-            public $value;
-        };
+        $user = UserFactory::createOne(['data' => ['foo' => 'bar']]);
 
-        $factory = anonymous($object::class)->create(['value' => ['foo' => 'bar']]);
-
-        $this->assertSame(['foo' => 'bar'], $factory->value);
+        $this->assertSame(['foo' => 'bar'], $user->getData());
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,5 +12,6 @@
 use Symfony\Component\Filesystem\Filesystem;
 
 require \dirname(__DIR__).'/vendor/autoload.php';
+require \dirname(__DIR__).'/bin/tools/phpstan/vendor/autoload.php';
 
 (new Filesystem())->remove(__DIR__.'/../var/cache');


### PR DESCRIPTION
Here is a draft suggestion to add PHPStan type resolvers for factories' methods.

This would override the `@phpstan-method` stuff in the factories, and it has the big advantage to give us back the control over the type system, we could then update these as long as we're updating the code.

It has the drawback that we may need to support two versions of this: one for PHPStan, and another one for Psalm (and I'll have to learn how to make this for Psalm :sweat_smile:) For now we can only drop the `@phpstan-method` generation with maker, and keep the `@psalm-method` annotation.

Some stuff still needs to be done:
- [ ] ~I would like to merge https://github.com/zenstruck/foundry/pull/452 before~ _we will merge it in the branch `feat/split-factories`_
- [ ] We will be able to fix all type problems in https://github.com/zenstruck/foundry/pull/452 (see [here](https://github.com/zenstruck/foundry/pull/452#discussion_r1168659984) and [here](https://github.com/zenstruck/foundry/pull/452#discussion_r1168687668))
- [x] add tests
- [x] provide a `foundry-phpstan.neon` file
- [ ] update doc: remove references to `@phpstan-method` and show how it should be configured
- [ ] update `make:factory`
- [ ] create a `CHANGELOG.md` to explain existing `@phpstan-method` can be dropped in userland

we can even imagine that once we've made the subtree split, we'd create a `zenstruck/foundry-phpstan` package which will be a phpstan extension and be auto installed with `phpstan/extension-installer`

WDYT of this?