### PR TITLE
feat: allow ModelFactory::findOrCreate() in unit tests

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -16,6 +16,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Faker;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Exception\FoundryBootException;
 
 /**
  * @internal
@@ -241,10 +242,13 @@ final class Configuration
         return $this->odmObjectManagersToReset;
     }
 
+    /**
+     * @throws FoundryBootException
+     */
     private function managerRegistry(): ?ManagerRegistry
     {
         if (!$this->hasManagerRegistry()) {
-            throw new \RuntimeException('Foundry was booted without doctrine. Ensure your TestCase extends '.KernelTestCase::class);
+            throw FoundryBootException::notBootedWithDoctrine();
         }
 
         return $this->managerRegistry;

--- a/src/Exception/FoundryBootException.php
+++ b/src/Exception/FoundryBootException.php
@@ -11,15 +11,29 @@
 
 namespace Zenstruck\Foundry\Exception;
 
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
 /**
  * @internal
  */
-final class FoundryNotBootedException extends \RuntimeException
+final class FoundryBootException extends \RuntimeException
 {
-    public function __construct()
+    private function __construct(string $message)
     {
-        parent::__construct(
+        parent::__construct($message);
+    }
+
+    public static function notBootedYet(): self
+    {
+        return new self(
             'Foundry is not yet booted. Using in a test: is your Test case using the Factories trait? Using in a fixture: is ZenstruckFoundryBundle enabled for this environment?'
+        );
+    }
+
+    public static function notBootedWithDoctrine(): self
+    {
+        return new self(
+            'Foundry was booted without doctrine. Ensure your TestCase extends '.KernelTestCase::class
         );
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,7 +15,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Faker;
-use Zenstruck\Foundry\Exception\FoundryNotBootedException;
+use Zenstruck\Foundry\Exception\FoundryBootException;
 use Zenstruck\Foundry\Persistence\InversedRelationshipCascadePersistCallback;
 use Zenstruck\Foundry\Persistence\PostPersistCallback;
 
@@ -291,13 +291,13 @@ class Factory
     }
 
     /**
+     * @throws FoundryBootException
      * @internal
-     * @throws FoundryNotBootedException
      */
     final public static function configuration(): Configuration
     {
         if (!self::isBooted()) {
-            throw new FoundryNotBootedException();
+            throw FoundryBootException::notBootedYet();
         }
 
         return self::$configuration; // @phpstan-ignore-line
@@ -315,7 +315,7 @@ class Factory
     {
         try {
             return self::configuration()->faker();
-        } catch (FoundryNotBootedException $exception) {
+        } catch (FoundryBootException $exception) {
             throw new \RuntimeException("Cannot get Foundry's configuration. If using faker in a data provider, consider passing attributes as a callable.");
         }
     }

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry;
 
+use Zenstruck\Foundry\Exception\FoundryBootException;
+
 /**
  * @template TModel of object
  * @template-extends Factory<TModel>
@@ -106,8 +108,11 @@ abstract class ModelFactory extends Factory
      */
     final public static function findOrCreate(array $attributes): Proxy
     {
-        if ($found = static::repository()->find($attributes)) {
-            return $found;
+        try {
+            if ($found = static::repository()->find($attributes)) {
+                return $found;
+            }
+        } catch (FoundryBootException) {
         }
 
         return static::new()->create($attributes);

--- a/tests/Unit/ModelFactoryTest.php
+++ b/tests/Unit/ModelFactoryTest.php
@@ -116,4 +116,16 @@ final class ModelFactoryTest extends TestCase
         $this->assertNull($post->getId());
         $this->assertCount(3, $post->getTags());
     }
+
+    /**
+     * @test
+     */
+    public function can_call_find_or_create(): void
+    {
+        $post = PostFactory::findOrCreate([
+            'title' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $post->getTitle());
+    }
 }


### PR DESCRIPTION
sometimes, in order to ease creation of multiple nested elements and prevent unique constraint errors, I need to add a bunch of `SomeFactory::findOrCreate()` but it breaks my tests where I'm not using `KernelTestCase`