### PR TITLE
dependencies: bump faker to 1.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=8.0",
         "doctrine/persistence": "^1.3.3|^2.0|^3.0",
-        "fakerphp/faker": "^1.5",
+        "fakerphp/faker": "^1.10",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/property-access": "^5.4|^6.0",
         "symfony/string": "^5.4|^6.0",


### PR DESCRIPTION
The CI "suddenly" started to fail with the "deps: lowest" permutation.

I don't really understand why, but with the lowest dependency, faker is now required with `v1.5`, although it used to be installed with `v1.10`

see [the last green CI on 1.x](https://github.com/zenstruck/foundry/actions/runs/4884758459/jobs/8717930622#step:6:135) VS [the following ones](https://github.com/zenstruck/foundry/actions/runs/5042649941/jobs/9043502672#step:6:135)

Not sure why this has changed, since we have not made any changes in `composer.json`. But it happens that [even faker 1.7 requires php 7](https://github.com/FakerPHP/Faker/blob/v1.7.0/composer.json#L13) so I think we can bump safely to the last version which accepts php 8.