### PR TITLE
feat(lazy): Add memoized LazyValue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,11 @@ $(PSALM_BIN): vendor bin/tools/psalm/composer.json bin/tools/psalm/composer.lock
 	@${DOCKER_PHP_WITHOUT_XDEBUG} /usr/bin/composer bin psalm install
 	@touch -c $@ bin/tools/psalm/composer.json bin/tools/psalm/composer.lock
 
+.PHONY: docs
+docs: vendor ### Generate documentation to docs/output
+	@$(MAKE) --no-print-directory docker-start-if-not-running
+	@${DOCKER_PHP} ./bin/build-docs
+
 .PHONY: database-generate-migration
 database-generate-migration: database-drop-schema ### Generate new migration based on mapping in Zenstruck\Foundry\Tests\Fixtures\Entity
 	@${DOCKER_PHP} vendor/bin/doctrine-migrations migrations:migrate --no-interaction --allow-no-migration # first, let's load into db existing migrations

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ make help
 validate                       Run sca, full test suite and validate migrations
 test                           Run PHPUnit tests suite
 sca                            Run static analysis
+docs                           Generate documentation to docs/output
 database-generate-migration    Generate new migration based on mapping in Zenstruck\Foundry\Tests\Fixtures\Entity
 database-validate-mapping      Validate mapping in Zenstruck\Foundry\Tests\Fixtures\Entity
 database-drop-schema           Drop database schema

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -845,7 +845,7 @@ Lazy values
 ~~~~~~~~~~~
 
 The ``getDefaults()`` method is called everytime a factory is instantiated (even if you don't end up
-creating it). Sometimes, you might not want your value calculated every time. For example, ff you have a value for one
+creating it). Sometimes, you might not want your value calculated every time. For example, if you have a value for one
 of your attributes that:
 
  - has side effects (i.e. creating a file or fetching a random existing entity from another factory)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -286,7 +286,10 @@ should have. `Faker`_ is available to easily get random data:
         protected function getDefaults(): array
         {
             return [
+                // Call CategoryFactory::random() everytime this factory is instantiated
                 'category' => new LazyValue(fn() => CategoryFactory::random()),
+                // Memoize the result of the callback, so the same Category wil be used everytime
+                'category' => LazyValue::memoize(fn() => CategoryFactory::random()),
 
                 'file' => lazy(fn() => create_temp_file()), // or use the lazy() helper function
             ];

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -40,7 +40,7 @@ final class LazyValue
 
     public static function new(callable $factory): self
     {
-        return new self($factory, false);
+        return new self($factory, true);
     }
 
     public static function memoize(callable $factory): self

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -40,12 +40,12 @@ final class LazyValue
 
     public static function new(callable $factory): self
     {
-        return new self($factory, true);
+        return new self($factory, false, true);
     }
 
     public static function memoize(callable $factory): self
     {
-        return new self($factory, true);
+        return new self($factory, true, true);
     }
 
     /**

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -19,19 +19,28 @@ final class LazyValue
     /** @var callable():mixed */
     private $factory;
 
-    /** @var bool */
-    private $memoize;
+    private bool $memoize;
 
-    /** @var mixed */
-    private $memoizedValue = null;
+    private mixed $memoizedValue = null;
 
     /**
      * @param callable():mixed $factory
+     *
+     * @deprecated directly using LazyValue's constructor is deprecated. It will be private in v2. Use named constructors instead.
      */
-    public function __construct(callable $factory, bool $memoize = false)
+    public function __construct(callable $factory, bool $memoize = false, bool $calledInternally = false)
     {
         $this->factory = $factory;
         $this->memoize = $memoize;
+
+        if (!$calledInternally) {
+            trigger_deprecation('zenstruck/foundry', '1.34.0', "directly using LazyValue's constructor is deprecated. It will be private in v2. Use named constructors instead.");
+        }
+    }
+
+    public static function new(callable $factory): self
+    {
+        return new self($factory, false);
     }
 
     public static function memoize(callable $factory): self

--- a/src/functions.php
+++ b/src/functions.php
@@ -130,7 +130,7 @@ function faker(): Faker\Generator
  */
 function lazy(callable $factory): LazyValue
 {
-    return new LazyValue($factory);
+    return LazyValue::new($factory);
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -132,3 +132,13 @@ function lazy(callable $factory): LazyValue
 {
     return new LazyValue($factory);
 }
+
+/**
+ * @see LazyValue::memoize
+ *
+ * @param callable():mixed $factory
+ */
+function memoize(callable $factory): LazyValue
+{
+    return LazyValue::memoize($factory);
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -59,7 +59,7 @@ final class FactoryTest extends TestCase
     public function lazy_values_are_only_calculated_if_needed(): void
     {
         $count = 0;
-        $lazyValue = new LazyValue(function() use (&$count) {
+        $lazyValue = LazyValue::new(function() use (&$count) {
             ++$count;
 
             return 'title';
@@ -82,6 +82,31 @@ final class FactoryTest extends TestCase
         ;
 
         $this->assertSame('title', $post->getTitle());
+        $this->assertSame(1, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function lazy_memoized_values_are_only_calculated_once(): void
+    {
+        $count = 0;
+        $lazyValue = LazyValue::memoize(function() use (&$count) {
+            ++$count;
+
+            return 'title';
+        });
+        $factory = anonymous(Post::class, ['title' => $lazyValue, 'body' => 'body']);
+
+        $posts = $factory
+            ->many(3)
+            ->create()
+        ;
+
+        foreach ($posts as $post) {
+            $this->assertSame('title', $post->getTitle());
+        }
+
         $this->assertSame(1, $count);
     }
 

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -52,19 +52,18 @@ final class FunctionsTest extends TestCase
      */
     public function lazy(): void
     {
-        $callback = new LazyValue(fn () => new \stdClass());
-        $value = lazy($callback);
+        $value = lazy(fn () => new \stdClass());
 
         $this->assertInstanceOf(LazyValue::class, $value);
         $this->assertNotSame($value(), $value());
     }
+
     /**
      * @test
      */
     public function memoize(): void
     {
-        $callback = new LazyValue(fn () => new \stdClass());
-        $value = memoize($callback);
+        $value = memoize(fn () => new \stdClass());
 
         $this->assertInstanceOf(LazyValue::class, $value);
         $this->assertSame($value(), $value());

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -16,6 +16,7 @@ use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\LazyValue;
 use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\Test\Factories;
@@ -27,6 +28,8 @@ use function Zenstruck\Foundry\create_many;
 use function Zenstruck\Foundry\faker;
 use function Zenstruck\Foundry\instantiate;
 use function Zenstruck\Foundry\instantiate_many;
+use function Zenstruck\Foundry\memoize;
+use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\repository;
 
 /**
@@ -42,6 +45,29 @@ final class FunctionsTest extends TestCase
     public function faker(): void
     {
         $this->assertIsString(faker()->name());
+    }
+
+    /**
+     * @test
+     */
+    public function lazy(): void
+    {
+        $callback = new LazyValue(fn () => new \stdClass());
+        $value = lazy($callback);
+
+        $this->assertInstanceOf(LazyValue::class, $value);
+        $this->assertNotSame($value(), $value());
+    }
+    /**
+     * @test
+     */
+    public function memoize(): void
+    {
+        $callback = new LazyValue(fn () => new \stdClass());
+        $value = memoize($callback);
+
+        $this->assertInstanceOf(LazyValue::class, $value);
+        $this->assertSame($value(), $value());
     }
 
     /**

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -59,4 +59,24 @@ final class LazyValueTest extends TestCase
 
         $this->assertSame([5, 'foo', 6, 'foo' => ['bar' => 7, 'baz' => 'foo'], [8, 'foo']], $value());
     }
+
+    /**
+     * @test
+     */
+    public function does_not_memoize_value_by_default(): void
+    {
+        $value = new LazyValue(fn () => new \stdClass());
+
+        $this->assertNotSame($value(), $value());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_memoized_value(): void
+    {
+        $value = LazyValue::memoize(fn () => new \stdClass());
+
+        $this->assertSame($value(), $value());
+    }
 }

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -24,7 +24,7 @@ final class LazyValueTest extends TestCase
      */
     public function executes_factory(): void
     {
-        $value = new LazyValue(fn() => 'foo');
+        $value = LazyValue::new(fn() => 'foo');
 
         $this->assertSame('foo', $value());
     }
@@ -34,7 +34,7 @@ final class LazyValueTest extends TestCase
      */
     public function can_handle_nested_lazy_values(): void
     {
-        $value = new LazyValue(new LazyValue(new LazyValue(fn() => new LazyValue(fn() => 'foo'))));
+        $value = LazyValue::new(LazyValue::new(LazyValue::new(fn() => LazyValue::new(fn() => 'foo'))));
 
         $this->assertSame('foo', $value());
     }
@@ -44,16 +44,16 @@ final class LazyValueTest extends TestCase
      */
     public function can_handle_array_with_lazy_values(): void
     {
-        $value = new LazyValue(function() {
+        $value = LazyValue::new(function() {
             return [
                 5,
-                new LazyValue(fn() => 'foo'),
+                LazyValue::new(fn() => 'foo'),
                 6,
                 'foo' => [
                     'bar' => 7,
-                    'baz' => new LazyValue(fn() => 'foo'),
+                    'baz' => LazyValue::new(fn() => 'foo'),
                 ],
-                [8, new LazyValue(fn() => 'foo')],
+                [8, LazyValue::new(fn() => 'foo')],
             ];
         });
 
@@ -62,10 +62,21 @@ final class LazyValueTest extends TestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function does_not_memoize_value_by_default(): void
     {
         $value = new LazyValue(fn () => new \stdClass());
+
+        $this->assertNotSame($value(), $value());
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_memoize_value(): void
+    {
+        $value = LazyValue::new(fn () => new \stdClass());
 
         $this->assertNotSame($value(), $value());
     }


### PR DESCRIPTION
As discussed, this PR introduces the ability to memoize a LazyValue, which enables the following use-case:

```php
class TaskFactory extends ModelFactory
{
    protected function getDefaults(): array
    {
        $owner = LazyValue::memoize(fn () => UserFactory::new());

        return [
            // Same User instance will be both added to the Project and set as the Task owner
            'project' => ProjectFactory::new(['users' => [$owner]]),
            'owner'   => $owner,
        ];
    }
    
    protected static function getClass(): string
    {
        return Task::class;
    }
}
```

I'm not entirely happy with the docs change, but I don't know how to explain it better without breaking LazyValue out into it's own section.

Closes: #473