### PR TITLE
fix: maker with cs fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:5.7.42
         env:
           MYSQL_ROOT_PASSWORD: 1234
         ports:
@@ -62,7 +62,7 @@ jobs:
           - 27017:27017
 
     env:
-      MYSQL_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7
+      MYSQL_URL: mysql://root:1234@127.0.0.1:3306/zenstruck_foundry?serverVersion=5.7.42
       PGSQL_URL: postgresql://postgres:1234@127.0.0.1:5432/zenstruck_foundry_${{ matrix.use-dama }}_${{ matrix.orm-db }}?charset=utf8&serverVersion=15
       MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/orm": "^2.9",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/maker-bundle": "^1.30",
+        "symfony/maker-bundle": "^1.49",
         "symfony/phpunit-bridge": "^5.4|^6.0",
         "symfony/translation-contracts": "^2.5|^3.0"
     },

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION
 
-FROM php:${PHP_VERSION}-cli
+FROM php:${PHP_VERSION}-cli-bullseye
 
 COPY --from=composer:2.4 /usr/bin/composer /usr/bin/composer
 
@@ -49,7 +49,7 @@ ARG UID=1001
 ARG XDEBUG_HOST="172.17.0.1"
 
 RUN addgroup --system --gid ${UID} ${USER} ; \
-    adduser --system --disabled-password --uid ${UID} --ingroup ${USER} ${USER} ; \
+    adduser --system --home /home/${USER} --disabled-password --uid ${UID} --ingroup ${USER} ${USER} ; \
     mkdir -p /app/var ; \
     chown -R ${USER}:${USER} /app ; \
     sed -i "s/%xdebug_host%/${XDEBUG_HOST}/g" /usr/local/etc/php/conf.d/xdebug.ini

--- a/tests/Fixtures/Maker/expected/can_create_factory.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 /**
  * @extends ModelFactory<Category>
  *
- * @method        Category|Proxy create(array|callable $attributes = [])
- * @method static Category|Proxy createOne(array $attributes = [])
- * @method static Category|Proxy find(object|array|mixed $criteria)
- * @method static Category|Proxy findOrCreate(array $attributes)
- * @method static Category|Proxy first(string $sortedField = 'id')
- * @method static Category|Proxy last(string $sortedField = 'id')
- * @method static Category|Proxy random(array $attributes = [])
- * @method static Category|Proxy randomOrCreate(array $attributes = [])
+ * @method        Category|Proxy                   create(array|callable $attributes = [])
+ * @method static Category|Proxy                   createOne(array $attributes = [])
+ * @method static Category|Proxy                   find(object|array|mixed $criteria)
+ * @method static Category|Proxy                   findOrCreate(array $attributes)
+ * @method static Category|Proxy                   first(string $sortedField = 'id')
+ * @method static Category|Proxy                   last(string $sortedField = 'id')
+ * @method static Category|Proxy                   random(array $attributes = [])
+ * @method static Category|Proxy                   randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Category[]|Proxy[] all()
- * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Category[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Category[]|Proxy[] findBy(array $attributes)
- * @method static Category[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Category[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Category[]|Proxy[]               all()
+ * @method static Category[]|Proxy[]               createMany(int $number, array|callable $attributes = [])
+ * @method static Category[]|Proxy[]               createSequence(iterable|callable $sequence)
+ * @method static Category[]|Proxy[]               findBy(array $attributes)
+ * @method static Category[]|Proxy[]               randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]               randomSet(int $number, array $attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository_with_data_set_phpstan.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository_with_data_set_phpstan.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Repository\PostRepository;
 /**
  * @extends ModelFactory<Post>
  *
- * @method        Post|Proxy create(array|callable $attributes = [])
- * @method static Post|Proxy createOne(array $attributes = [])
- * @method static Post|Proxy find(object|array|mixed $criteria)
- * @method static Post|Proxy findOrCreate(array $attributes)
- * @method static Post|Proxy first(string $sortedField = 'id')
- * @method static Post|Proxy last(string $sortedField = 'id')
- * @method static Post|Proxy random(array $attributes = [])
- * @method static Post|Proxy randomOrCreate(array $attributes = [])
+ * @method        Post|Proxy                     create(array|callable $attributes = [])
+ * @method static Post|Proxy                     createOne(array $attributes = [])
+ * @method static Post|Proxy                     find(object|array|mixed $criteria)
+ * @method static Post|Proxy                     findOrCreate(array $attributes)
+ * @method static Post|Proxy                     first(string $sortedField = 'id')
+ * @method static Post|Proxy                     last(string $sortedField = 'id')
+ * @method static Post|Proxy                     random(array $attributes = [])
+ * @method static Post|Proxy                     randomOrCreate(array $attributes = [])
  * @method static PostRepository|RepositoryProxy repository()
- * @method static Post[]|Proxy[] all()
- * @method static Post[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Post[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Post[]|Proxy[] findBy(array $attributes)
- * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Post[]|Proxy[]                 all()
+ * @method static Post[]|Proxy[]                 createMany(int $number, array|callable $attributes = [])
+ * @method static Post[]|Proxy[]                 createSequence(iterable|callable $sequence)
+ * @method static Post[]|Proxy[]                 findBy(array $attributes)
+ * @method static Post[]|Proxy[]                 randomRange(int $min, int $max, array $attributes = [])
+ * @method static Post[]|Proxy[]                 randomSet(int $number, array $attributes = [])
  *
  * @phpstan-method        Proxy<Post> create(array|callable $attributes = [])
  * @phpstan-method static Proxy<Post> createOne(array $attributes = [])

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository_with_data_set_psalm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_entity_with_repository_with_data_set_psalm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Repository\PostRepository;
 /**
  * @extends ModelFactory<Post>
  *
- * @method        Post|Proxy create(array|callable $attributes = [])
- * @method static Post|Proxy createOne(array $attributes = [])
- * @method static Post|Proxy find(object|array|mixed $criteria)
- * @method static Post|Proxy findOrCreate(array $attributes)
- * @method static Post|Proxy first(string $sortedField = 'id')
- * @method static Post|Proxy last(string $sortedField = 'id')
- * @method static Post|Proxy random(array $attributes = [])
- * @method static Post|Proxy randomOrCreate(array $attributes = [])
+ * @method        Post|Proxy                     create(array|callable $attributes = [])
+ * @method static Post|Proxy                     createOne(array $attributes = [])
+ * @method static Post|Proxy                     find(object|array|mixed $criteria)
+ * @method static Post|Proxy                     findOrCreate(array $attributes)
+ * @method static Post|Proxy                     first(string $sortedField = 'id')
+ * @method static Post|Proxy                     last(string $sortedField = 'id')
+ * @method static Post|Proxy                     random(array $attributes = [])
+ * @method static Post|Proxy                     randomOrCreate(array $attributes = [])
  * @method static PostRepository|RepositoryProxy repository()
- * @method static Post[]|Proxy[] all()
- * @method static Post[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Post[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Post[]|Proxy[] findBy(array $attributes)
- * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Post[]|Proxy[]                 all()
+ * @method static Post[]|Proxy[]                 createMany(int $number, array|callable $attributes = [])
+ * @method static Post[]|Proxy[]                 createSequence(iterable|callable $sequence)
+ * @method static Post[]|Proxy[]                 findBy(array $attributes)
+ * @method static Post[]|Proxy[]                 randomRange(int $min, int $max, array $attributes = [])
+ * @method static Post[]|Proxy[]                 randomSet(int $number, array $attributes = [])
  *
  * @psalm-method        Proxy<Post> create(array|callable $attributes = [])
  * @psalm-method static Proxy<Post> createOne(array $attributes = [])

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -9,8 +18,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
 /**
  * @extends ModelFactory<SomeObject>
  *
- * @method        SomeObject|Proxy create(array|callable $attributes = [])
- * @method static SomeObject|Proxy createOne(array $attributes = [])
+ * @method        SomeObject|Proxy     create(array|callable $attributes = [])
+ * @method static SomeObject|Proxy     createOne(array $attributes = [])
  * @method static SomeObject[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static SomeObject[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class_interactively.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -9,8 +18,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
 /**
  * @extends ModelFactory<SomeObject>
  *
- * @method        SomeObject|Proxy create(array|callable $attributes = [])
- * @method static SomeObject|Proxy createOne(array $attributes = [])
+ * @method        SomeObject|Proxy     create(array|callable $attributes = [])
+ * @method static SomeObject|Proxy     createOne(array $attributes = [])
  * @method static SomeObject[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static SomeObject[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_document.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_document.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
 /**
  * @extends ModelFactory<ODMPost>
  *
- * @method        ODMPost|Proxy create(array|callable $attributes = [])
- * @method static ODMPost|Proxy createOne(array $attributes = [])
- * @method static ODMPost|Proxy find(object|array|mixed $criteria)
- * @method static ODMPost|Proxy findOrCreate(array $attributes)
- * @method static ODMPost|Proxy first(string $sortedField = 'id')
- * @method static ODMPost|Proxy last(string $sortedField = 'id')
- * @method static ODMPost|Proxy random(array $attributes = [])
- * @method static ODMPost|Proxy randomOrCreate(array $attributes = [])
+ * @method        ODMPost|Proxy                      create(array|callable $attributes = [])
+ * @method static ODMPost|Proxy                      createOne(array $attributes = [])
+ * @method static ODMPost|Proxy                      find(object|array|mixed $criteria)
+ * @method static ODMPost|Proxy                      findOrCreate(array $attributes)
+ * @method static ODMPost|Proxy                      first(string $sortedField = 'id')
+ * @method static ODMPost|Proxy                      last(string $sortedField = 'id')
+ * @method static ODMPost|Proxy                      random(array $attributes = [])
+ * @method static ODMPost|Proxy                      randomOrCreate(array $attributes = [])
  * @method static DocumentRepository|RepositoryProxy repository()
- * @method static ODMPost[]|Proxy[] all()
- * @method static ODMPost[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static ODMPost[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static ODMPost[]|Proxy[] findBy(array $attributes)
- * @method static ODMPost[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static ODMPost[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  all()
+ * @method static ODMPost[]|Proxy[]                  createMany(int $number, array|callable $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  createSequence(iterable|callable $sequence)
+ * @method static ODMPost[]|Proxy[]                  findBy(array $attributes)
+ * @method static ODMPost[]|Proxy[]                  randomRange(int $min, int $max, array $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  randomSet(int $number, array $attributes = [])
  */
 final class ODMPostFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_embedded_document.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_embedded_document.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -10,8 +19,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\ODM\UserFactory;
 /**
  * @extends ModelFactory<ODMComment>
  *
- * @method        ODMComment|Proxy create(array|callable $attributes = [])
- * @method static ODMComment|Proxy createOne(array $attributes = [])
+ * @method        ODMComment|Proxy     create(array|callable $attributes = [])
+ * @method static ODMComment|Proxy     createOne(array $attributes = [])
  * @method static ODMComment[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static ODMComment[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -9,8 +18,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
 /**
  * @extends ModelFactory<Address>
  *
- * @method        Address|Proxy create(array|callable $attributes = [])
- * @method static Address|Proxy createOne(array $attributes = [])
+ * @method        Address|Proxy     create(array|callable $attributes = [])
+ * @method static Address|Proxy     createOne(array $attributes = [])
  * @method static Address[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static Address[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Tests\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 /**
  * @extends ModelFactory<Category>
  *
- * @method        Category|Proxy create(array|callable $attributes = [])
- * @method static Category|Proxy createOne(array $attributes = [])
- * @method static Category|Proxy find(object|array|mixed $criteria)
- * @method static Category|Proxy findOrCreate(array $attributes)
- * @method static Category|Proxy first(string $sortedField = 'id')
- * @method static Category|Proxy last(string $sortedField = 'id')
- * @method static Category|Proxy random(array $attributes = [])
- * @method static Category|Proxy randomOrCreate(array $attributes = [])
+ * @method        Category|Proxy                   create(array|callable $attributes = [])
+ * @method static Category|Proxy                   createOne(array $attributes = [])
+ * @method static Category|Proxy                   find(object|array|mixed $criteria)
+ * @method static Category|Proxy                   findOrCreate(array $attributes)
+ * @method static Category|Proxy                   first(string $sortedField = 'id')
+ * @method static Category|Proxy                   last(string $sortedField = 'id')
+ * @method static Category|Proxy                   random(array $attributes = [])
+ * @method static Category|Proxy                   randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Category[]|Proxy[] all()
- * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Category[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Category[]|Proxy[] findBy(array $attributes)
- * @method static Category[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Category[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Category[]|Proxy[]               all()
+ * @method static Category[]|Proxy[]               createMany(int $number, array|callable $attributes = [])
+ * @method static Category[]|Proxy[]               createSequence(iterable|callable $sequence)
+ * @method static Category[]|Proxy[]               findBy(array $attributes)
+ * @method static Category[]|Proxy[]               randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]               randomSet(int $number, array $attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir_interactively.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Tests\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Tag;
 /**
  * @extends ModelFactory<Tag>
  *
- * @method        Tag|Proxy create(array|callable $attributes = [])
- * @method static Tag|Proxy createOne(array $attributes = [])
- * @method static Tag|Proxy find(object|array|mixed $criteria)
- * @method static Tag|Proxy findOrCreate(array $attributes)
- * @method static Tag|Proxy first(string $sortedField = 'id')
- * @method static Tag|Proxy last(string $sortedField = 'id')
- * @method static Tag|Proxy random(array $attributes = [])
- * @method static Tag|Proxy randomOrCreate(array $attributes = [])
+ * @method        Tag|Proxy                        create(array|callable $attributes = [])
+ * @method static Tag|Proxy                        createOne(array $attributes = [])
+ * @method static Tag|Proxy                        find(object|array|mixed $criteria)
+ * @method static Tag|Proxy                        findOrCreate(array $attributes)
+ * @method static Tag|Proxy                        first(string $sortedField = 'id')
+ * @method static Tag|Proxy                        last(string $sortedField = 'id')
+ * @method static Tag|Proxy                        random(array $attributes = [])
+ * @method static Tag|Proxy                        randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Tag[]|Proxy[] all()
- * @method static Tag[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Tag[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Tag[]|Proxy[] findBy(array $attributes)
- * @method static Tag[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Tag[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Tag[]|Proxy[]                    all()
+ * @method static Tag[]|Proxy[]                    createMany(int $number, array|callable $attributes = [])
+ * @method static Tag[]|Proxy[]                    createSequence(iterable|callable $sequence)
+ * @method static Tag[]|Proxy[]                    findBy(array $attributes)
+ * @method static Tag[]|Proxy[]                    randomRange(int $min, int $max, array $attributes = [])
+ * @method static Tag[]|Proxy[]                    randomSet(int $number, array $attributes = [])
  */
 final class TagFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Comment;
 /**
  * @extends ModelFactory<Comment>
  *
- * @method        Comment|Proxy create(array|callable $attributes = [])
- * @method static Comment|Proxy createOne(array $attributes = [])
- * @method static Comment|Proxy find(object|array|mixed $criteria)
- * @method static Comment|Proxy findOrCreate(array $attributes)
- * @method static Comment|Proxy first(string $sortedField = 'id')
- * @method static Comment|Proxy last(string $sortedField = 'id')
- * @method static Comment|Proxy random(array $attributes = [])
- * @method static Comment|Proxy randomOrCreate(array $attributes = [])
+ * @method        Comment|Proxy                    create(array|callable $attributes = [])
+ * @method static Comment|Proxy                    createOne(array $attributes = [])
+ * @method static Comment|Proxy                    find(object|array|mixed $criteria)
+ * @method static Comment|Proxy                    findOrCreate(array $attributes)
+ * @method static Comment|Proxy                    first(string $sortedField = 'id')
+ * @method static Comment|Proxy                    last(string $sortedField = 'id')
+ * @method static Comment|Proxy                    random(array $attributes = [])
+ * @method static Comment|Proxy                    randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Comment[]|Proxy[] all()
- * @method static Comment[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Comment[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Comment[]|Proxy[] findBy(array $attributes)
- * @method static Comment[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Comment[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Comment[]|Proxy[]                all()
+ * @method static Comment[]|Proxy[]                createMany(int $number, array|callable $attributes = [])
+ * @method static Comment[]|Proxy[]                createSequence(iterable|callable $sequence)
+ * @method static Comment[]|Proxy[]                findBy(array $attributes)
+ * @method static Comment[]|Proxy[]                randomRange(int $min, int $max, array $attributes = [])
+ * @method static Comment[]|Proxy[]                randomSet(int $number, array $attributes = [])
  */
 final class CommentFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -9,8 +18,8 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 /**
  * @extends ModelFactory<Category>
  *
- * @method        Category|Proxy create(array|callable $attributes = [])
- * @method static Category|Proxy createOne(array $attributes = [])
+ * @method        Category|Proxy     create(array|callable $attributes = [])
+ * @method static Category|Proxy     createOne(array $attributes = [])
  * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static Category[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_odm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_odm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -12,21 +21,21 @@ use Zenstruck\Foundry\Tests\Fixtures\PHP81\SomeEnum;
 /**
  * @extends ModelFactory<DocumentWithEnum>
  *
- * @method        DocumentWithEnum|Proxy create(array|callable $attributes = [])
- * @method static DocumentWithEnum|Proxy createOne(array $attributes = [])
- * @method static DocumentWithEnum|Proxy find(object|array|mixed $criteria)
- * @method static DocumentWithEnum|Proxy findOrCreate(array $attributes)
- * @method static DocumentWithEnum|Proxy first(string $sortedField = 'id')
- * @method static DocumentWithEnum|Proxy last(string $sortedField = 'id')
- * @method static DocumentWithEnum|Proxy random(array $attributes = [])
- * @method static DocumentWithEnum|Proxy randomOrCreate(array $attributes = [])
+ * @method        DocumentWithEnum|Proxy             create(array|callable $attributes = [])
+ * @method static DocumentWithEnum|Proxy             createOne(array $attributes = [])
+ * @method static DocumentWithEnum|Proxy             find(object|array|mixed $criteria)
+ * @method static DocumentWithEnum|Proxy             findOrCreate(array $attributes)
+ * @method static DocumentWithEnum|Proxy             first(string $sortedField = 'id')
+ * @method static DocumentWithEnum|Proxy             last(string $sortedField = 'id')
+ * @method static DocumentWithEnum|Proxy             random(array $attributes = [])
+ * @method static DocumentWithEnum|Proxy             randomOrCreate(array $attributes = [])
  * @method static DocumentRepository|RepositoryProxy repository()
- * @method static DocumentWithEnum[]|Proxy[] all()
- * @method static DocumentWithEnum[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static DocumentWithEnum[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static DocumentWithEnum[]|Proxy[] findBy(array $attributes)
- * @method static DocumentWithEnum[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static DocumentWithEnum[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static DocumentWithEnum[]|Proxy[]         all()
+ * @method static DocumentWithEnum[]|Proxy[]         createMany(int $number, array|callable $attributes = [])
+ * @method static DocumentWithEnum[]|Proxy[]         createSequence(iterable|callable $sequence)
+ * @method static DocumentWithEnum[]|Proxy[]         findBy(array $attributes)
+ * @method static DocumentWithEnum[]|Proxy[]         randomRange(int $min, int $max, array $attributes = [])
+ * @method static DocumentWithEnum[]|Proxy[]         randomSet(int $number, array $attributes = [])
  */
 final class DocumentWithEnumFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_orm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_orm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -12,21 +21,21 @@ use Zenstruck\Foundry\Tests\Fixtures\PHP81\SomeEnum;
 /**
  * @extends ModelFactory<EntityWithEnum>
  *
- * @method        EntityWithEnum|Proxy create(array|callable $attributes = [])
- * @method static EntityWithEnum|Proxy createOne(array $attributes = [])
- * @method static EntityWithEnum|Proxy find(object|array|mixed $criteria)
- * @method static EntityWithEnum|Proxy findOrCreate(array $attributes)
- * @method static EntityWithEnum|Proxy first(string $sortedField = 'id')
- * @method static EntityWithEnum|Proxy last(string $sortedField = 'id')
- * @method static EntityWithEnum|Proxy random(array $attributes = [])
- * @method static EntityWithEnum|Proxy randomOrCreate(array $attributes = [])
+ * @method        EntityWithEnum|Proxy             create(array|callable $attributes = [])
+ * @method static EntityWithEnum|Proxy             createOne(array $attributes = [])
+ * @method static EntityWithEnum|Proxy             find(object|array|mixed $criteria)
+ * @method static EntityWithEnum|Proxy             findOrCreate(array $attributes)
+ * @method static EntityWithEnum|Proxy             first(string $sortedField = 'id')
+ * @method static EntityWithEnum|Proxy             last(string $sortedField = 'id')
+ * @method static EntityWithEnum|Proxy             random(array $attributes = [])
+ * @method static EntityWithEnum|Proxy             randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static EntityWithEnum[]|Proxy[] all()
- * @method static EntityWithEnum[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static EntityWithEnum[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static EntityWithEnum[]|Proxy[] findBy(array $attributes)
- * @method static EntityWithEnum[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static EntityWithEnum[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static EntityWithEnum[]|Proxy[]         all()
+ * @method static EntityWithEnum[]|Proxy[]         createMany(int $number, array|callable $attributes = [])
+ * @method static EntityWithEnum[]|Proxy[]         createSequence(iterable|callable $sequence)
+ * @method static EntityWithEnum[]|Proxy[]         findBy(array $attributes)
+ * @method static EntityWithEnum[]|Proxy[]         randomRange(int $min, int $max, array $attributes = [])
+ * @method static EntityWithEnum[]|Proxy[]         randomSet(int $number, array $attributes = [])
  */
 final class EntityWithEnumFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_without_persistence.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_without_persistence.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Zenstruck\Foundry\ModelFactory;
@@ -10,8 +19,8 @@ use Zenstruck\Foundry\Tests\Fixtures\PHP81\SomeEnum;
 /**
  * @extends ModelFactory<EntityWithEnum>
  *
- * @method        EntityWithEnum|Proxy create(array|callable $attributes = [])
- * @method static EntityWithEnum|Proxy createOne(array $attributes = [])
+ * @method        EntityWithEnum|Proxy     create(array|callable $attributes = [])
+ * @method static EntityWithEnum|Proxy     createOne(array $attributes = [])
  * @method static EntityWithEnum[]|Proxy[] createMany(int $number, array|callable $attributes = [])
  * @method static EntityWithEnum[]|Proxy[] createSequence(iterable|callable $sequence)
  */

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
 /**
  * @extends ModelFactory<ODMPost>
  *
- * @method        ODMPost|Proxy create(array|callable $attributes = [])
- * @method static ODMPost|Proxy createOne(array $attributes = [])
- * @method static ODMPost|Proxy find(object|array|mixed $criteria)
- * @method static ODMPost|Proxy findOrCreate(array $attributes)
- * @method static ODMPost|Proxy first(string $sortedField = 'id')
- * @method static ODMPost|Proxy last(string $sortedField = 'id')
- * @method static ODMPost|Proxy random(array $attributes = [])
- * @method static ODMPost|Proxy randomOrCreate(array $attributes = [])
+ * @method        ODMPost|Proxy                      create(array|callable $attributes = [])
+ * @method static ODMPost|Proxy                      createOne(array $attributes = [])
+ * @method static ODMPost|Proxy                      find(object|array|mixed $criteria)
+ * @method static ODMPost|Proxy                      findOrCreate(array $attributes)
+ * @method static ODMPost|Proxy                      first(string $sortedField = 'id')
+ * @method static ODMPost|Proxy                      last(string $sortedField = 'id')
+ * @method static ODMPost|Proxy                      random(array $attributes = [])
+ * @method static ODMPost|Proxy                      randomOrCreate(array $attributes = [])
  * @method static DocumentRepository|RepositoryProxy repository()
- * @method static ODMPost[]|Proxy[] all()
- * @method static ODMPost[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static ODMPost[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static ODMPost[]|Proxy[] findBy(array $attributes)
- * @method static ODMPost[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static ODMPost[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  all()
+ * @method static ODMPost[]|Proxy[]                  createMany(int $number, array|callable $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  createSequence(iterable|callable $sequence)
+ * @method static ODMPost[]|Proxy[]                  findBy(array $attributes)
+ * @method static ODMPost[]|Proxy[]                  randomRange(int $min, int $max, array $attributes = [])
+ * @method static ODMPost[]|Proxy[]                  randomSet(int $number, array $attributes = [])
  */
 final class ODMPostFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Contact;
 /**
  * @extends ModelFactory<Contact>
  *
- * @method        Contact|Proxy create(array|callable $attributes = [])
- * @method static Contact|Proxy createOne(array $attributes = [])
- * @method static Contact|Proxy find(object|array|mixed $criteria)
- * @method static Contact|Proxy findOrCreate(array $attributes)
- * @method static Contact|Proxy first(string $sortedField = 'id')
- * @method static Contact|Proxy last(string $sortedField = 'id')
- * @method static Contact|Proxy random(array $attributes = [])
- * @method static Contact|Proxy randomOrCreate(array $attributes = [])
+ * @method        Contact|Proxy                    create(array|callable $attributes = [])
+ * @method static Contact|Proxy                    createOne(array $attributes = [])
+ * @method static Contact|Proxy                    find(object|array|mixed $criteria)
+ * @method static Contact|Proxy                    findOrCreate(array $attributes)
+ * @method static Contact|Proxy                    first(string $sortedField = 'id')
+ * @method static Contact|Proxy                    last(string $sortedField = 'id')
+ * @method static Contact|Proxy                    random(array $attributes = [])
+ * @method static Contact|Proxy                    randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Contact[]|Proxy[] all()
- * @method static Contact[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Contact[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Contact[]|Proxy[] findBy(array $attributes)
- * @method static Contact[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Contact[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Contact[]|Proxy[]                all()
+ * @method static Contact[]|Proxy[]                createMany(int $number, array|callable $attributes = [])
+ * @method static Contact[]|Proxy[]                createSequence(iterable|callable $sequence)
+ * @method static Contact[]|Proxy[]                findBy(array $attributes)
+ * @method static Contact[]|Proxy[]                randomRange(int $min, int $max, array $attributes = [])
+ * @method static Contact[]|Proxy[]                randomSet(int $number, array $attributes = [])
  */
 final class ContactFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use App\Factory\Cascade\BrandFactory;
@@ -13,21 +22,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 /**
  * @extends ModelFactory<EntityWithRelations>
  *
- * @method        EntityWithRelations|Proxy create(array|callable $attributes = [])
- * @method static EntityWithRelations|Proxy createOne(array $attributes = [])
- * @method static EntityWithRelations|Proxy find(object|array|mixed $criteria)
- * @method static EntityWithRelations|Proxy findOrCreate(array $attributes)
- * @method static EntityWithRelations|Proxy first(string $sortedField = 'id')
- * @method static EntityWithRelations|Proxy last(string $sortedField = 'id')
- * @method static EntityWithRelations|Proxy random(array $attributes = [])
- * @method static EntityWithRelations|Proxy randomOrCreate(array $attributes = [])
+ * @method        EntityWithRelations|Proxy        create(array|callable $attributes = [])
+ * @method static EntityWithRelations|Proxy        createOne(array $attributes = [])
+ * @method static EntityWithRelations|Proxy        find(object|array|mixed $criteria)
+ * @method static EntityWithRelations|Proxy        findOrCreate(array $attributes)
+ * @method static EntityWithRelations|Proxy        first(string $sortedField = 'id')
+ * @method static EntityWithRelations|Proxy        last(string $sortedField = 'id')
+ * @method static EntityWithRelations|Proxy        random(array $attributes = [])
+ * @method static EntityWithRelations|Proxy        randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static EntityWithRelations[]|Proxy[] all()
- * @method static EntityWithRelations[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static EntityWithRelations[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static EntityWithRelations[]|Proxy[] findBy(array $attributes)
- * @method static EntityWithRelations[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static EntityWithRelations[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    all()
+ * @method static EntityWithRelations[]|Proxy[]    createMany(int $number, array|callable $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    createSequence(iterable|callable $sequence)
+ * @method static EntityWithRelations[]|Proxy[]    findBy(array $attributes)
+ * @method static EntityWithRelations[]|Proxy[]    randomRange(int $min, int $max, array $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    randomSet(int $number, array $attributes = [])
  */
 final class EntityWithRelationsFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use App\Factory\Cascade\BrandFactory;
@@ -13,21 +22,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 /**
  * @extends ModelFactory<EntityWithRelations>
  *
- * @method        EntityWithRelations|Proxy create(array|callable $attributes = [])
- * @method static EntityWithRelations|Proxy createOne(array $attributes = [])
- * @method static EntityWithRelations|Proxy find(object|array|mixed $criteria)
- * @method static EntityWithRelations|Proxy findOrCreate(array $attributes)
- * @method static EntityWithRelations|Proxy first(string $sortedField = 'id')
- * @method static EntityWithRelations|Proxy last(string $sortedField = 'id')
- * @method static EntityWithRelations|Proxy random(array $attributes = [])
- * @method static EntityWithRelations|Proxy randomOrCreate(array $attributes = [])
+ * @method        EntityWithRelations|Proxy        create(array|callable $attributes = [])
+ * @method static EntityWithRelations|Proxy        createOne(array $attributes = [])
+ * @method static EntityWithRelations|Proxy        find(object|array|mixed $criteria)
+ * @method static EntityWithRelations|Proxy        findOrCreate(array $attributes)
+ * @method static EntityWithRelations|Proxy        first(string $sortedField = 'id')
+ * @method static EntityWithRelations|Proxy        last(string $sortedField = 'id')
+ * @method static EntityWithRelations|Proxy        random(array $attributes = [])
+ * @method static EntityWithRelations|Proxy        randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static EntityWithRelations[]|Proxy[] all()
- * @method static EntityWithRelations[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static EntityWithRelations[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static EntityWithRelations[]|Proxy[] findBy(array $attributes)
- * @method static EntityWithRelations[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static EntityWithRelations[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    all()
+ * @method static EntityWithRelations[]|Proxy[]    createMany(int $number, array|callable $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    createSequence(iterable|callable $sequence)
+ * @method static EntityWithRelations[]|Proxy[]    findBy(array $attributes)
+ * @method static EntityWithRelations[]|Proxy[]    randomRange(int $min, int $max, array $attributes = [])
+ * @method static EntityWithRelations[]|Proxy[]    randomSet(int $number, array $attributes = [])
  */
 final class EntityWithRelationsFactory extends ModelFactory
 {

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_phpstan.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_phpstan.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 /**
  * @extends ModelFactory<Category>
  *
- * @method        Category|Proxy create(array|callable $attributes = [])
- * @method static Category|Proxy createOne(array $attributes = [])
- * @method static Category|Proxy find(object|array|mixed $criteria)
- * @method static Category|Proxy findOrCreate(array $attributes)
- * @method static Category|Proxy first(string $sortedField = 'id')
- * @method static Category|Proxy last(string $sortedField = 'id')
- * @method static Category|Proxy random(array $attributes = [])
- * @method static Category|Proxy randomOrCreate(array $attributes = [])
+ * @method        Category|Proxy                   create(array|callable $attributes = [])
+ * @method static Category|Proxy                   createOne(array $attributes = [])
+ * @method static Category|Proxy                   find(object|array|mixed $criteria)
+ * @method static Category|Proxy                   findOrCreate(array $attributes)
+ * @method static Category|Proxy                   first(string $sortedField = 'id')
+ * @method static Category|Proxy                   last(string $sortedField = 'id')
+ * @method static Category|Proxy                   random(array $attributes = [])
+ * @method static Category|Proxy                   randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Category[]|Proxy[] all()
- * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Category[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Category[]|Proxy[] findBy(array $attributes)
- * @method static Category[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Category[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Category[]|Proxy[]               all()
+ * @method static Category[]|Proxy[]               createMany(int $number, array|callable $attributes = [])
+ * @method static Category[]|Proxy[]               createSequence(iterable|callable $sequence)
+ * @method static Category[]|Proxy[]               findBy(array $attributes)
+ * @method static Category[]|Proxy[]               randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]               randomSet(int $number, array $attributes = [])
  *
  * @phpstan-method        Proxy<Category> create(array|callable $attributes = [])
  * @phpstan-method static Proxy<Category> createOne(array $attributes = [])

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_psalm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_psalm.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Factory;
 
 use Doctrine\ORM\EntityRepository;
@@ -11,21 +20,21 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 /**
  * @extends ModelFactory<Category>
  *
- * @method        Category|Proxy create(array|callable $attributes = [])
- * @method static Category|Proxy createOne(array $attributes = [])
- * @method static Category|Proxy find(object|array|mixed $criteria)
- * @method static Category|Proxy findOrCreate(array $attributes)
- * @method static Category|Proxy first(string $sortedField = 'id')
- * @method static Category|Proxy last(string $sortedField = 'id')
- * @method static Category|Proxy random(array $attributes = [])
- * @method static Category|Proxy randomOrCreate(array $attributes = [])
+ * @method        Category|Proxy                   create(array|callable $attributes = [])
+ * @method static Category|Proxy                   createOne(array $attributes = [])
+ * @method static Category|Proxy                   find(object|array|mixed $criteria)
+ * @method static Category|Proxy                   findOrCreate(array $attributes)
+ * @method static Category|Proxy                   first(string $sortedField = 'id')
+ * @method static Category|Proxy                   last(string $sortedField = 'id')
+ * @method static Category|Proxy                   random(array $attributes = [])
+ * @method static Category|Proxy                   randomOrCreate(array $attributes = [])
  * @method static EntityRepository|RepositoryProxy repository()
- * @method static Category[]|Proxy[] all()
- * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Category[]|Proxy[] createSequence(iterable|callable $sequence)
- * @method static Category[]|Proxy[] findBy(array $attributes)
- * @method static Category[]|Proxy[] randomRange(int $min, int $max, array $attributes = [])
- * @method static Category[]|Proxy[] randomSet(int $number, array $attributes = [])
+ * @method static Category[]|Proxy[]               all()
+ * @method static Category[]|Proxy[]               createMany(int $number, array|callable $attributes = [])
+ * @method static Category[]|Proxy[]               createSequence(iterable|callable $sequence)
+ * @method static Category[]|Proxy[]               findBy(array $attributes)
+ * @method static Category[]|Proxy[]               randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]               randomSet(int $number, array $attributes = [])
  *
  * @psalm-method        Proxy<Category> create(array|callable $attributes = [])
  * @psalm-method static Proxy<Category> createOne(array $attributes = [])

--- a/tests/Functional/Bundle/Maker/MakeStoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeStoryTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the zenstruck/foundry package.
- *
- * (c) Kevin Bond <kevinbond@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Zenstruck\Foundry\Tests\Functional\Bundle\Maker;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -34,6 +25,15 @@ final class MakeStoryTest extends MakerTestCase
         $this->assertFileExists(self::tempFile('src/Story/FooBarStory.php'));
         $this->assertSame(<<<EOF
             <?php
+
+            /*
+             * This file is part of the zenstruck/foundry package.
+             *
+             * (c) Kevin Bond <kevinbond@gmail.com>
+             *
+             * For the full copyright and license information, please view the LICENSE
+             * file that was distributed with this source code.
+             */
 
             namespace App\\Story;
 
@@ -72,6 +72,15 @@ final class MakeStoryTest extends MakerTestCase
         $this->assertSame(<<<EOF
             <?php
 
+            /*
+             * This file is part of the zenstruck/foundry package.
+             *
+             * (c) Kevin Bond <kevinbond@gmail.com>
+             *
+             * For the full copyright and license information, please view the LICENSE
+             * file that was distributed with this source code.
+             */
+
             namespace App\\Story;
 
             use Zenstruck\\Foundry\\Story;
@@ -104,6 +113,15 @@ final class MakeStoryTest extends MakerTestCase
         $this->assertFileExists(self::tempFile('tests/Story/FooBarStory.php'));
         $this->assertSame(<<<EOF
             <?php
+
+            /*
+             * This file is part of the zenstruck/foundry package.
+             *
+             * (c) Kevin Bond <kevinbond@gmail.com>
+             *
+             * For the full copyright and license information, please view the LICENSE
+             * file that was distributed with this source code.
+             */
 
             namespace App\\Tests\\Story;
 
@@ -141,6 +159,15 @@ final class MakeStoryTest extends MakerTestCase
         $this->assertStringNotContainsString('Note: pass --test if you want to generate stories in your tests/ directory', $output);
         $this->assertSame(<<<EOF
             <?php
+
+            /*
+             * This file is part of the zenstruck/foundry package.
+             *
+             * (c) Kevin Bond <kevinbond@gmail.com>
+             *
+             * For the full copyright and license information, please view the LICENSE
+             * file that was distributed with this source code.
+             */
 
             namespace App\\Tests\\Story;
 


### PR DESCRIPTION
since some times, maker bundle is shipped with cs fixer, so it fixes the cs of created files. This feature cannot be deactivated, so I updated the expected file to match the code style

this feature appeared in maker 1.49.0 so I decided to bump this version (dev req) in order to have the same behavior even with `--prefer-lowest` option