### PR TITLE
minor: set Factory::isPersisting() protected

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -416,7 +416,7 @@ class Factory
         }
     }
 
-    private function isPersisting(): bool
+    protected function isPersisting(): bool
     {
         if (!$this->persist || !self::configuration()->hasManagerRegistry()) {
             return false;

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -28,7 +28,7 @@ final class ZenstruckFoundryBundle extends Bundle
 {
     public function boot(): void
     {
-        if (!Factory::isBooted()) {
+        if (!Factory::isBooted() && $this->container) {
             Factory::boot($this->container->get('.zenstruck_foundry.configuration'));
         }
     }


### PR DESCRIPTION
Hi!

a factory can't tell if it is persisting, which in some case could be helpful!

EDIT: @kbond do you have any idea why we have this erro in CI?
it's coming from https://github.com/doctrine/orm/pull/10785 and occurs only without dama, when global test state is flushed

something strange:
it does not occur when I call `make test -- --stop-on-failure --filter FactoryDoctrineCascadeTest`
but it occurs with the full test suite, whereas I suspect it occurs for the first test which uses doctrine
:thinking: 