### PR TITLE
fix: do not flush global state twice when dama is not enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
           - {php: 8.0, symfony: 5.4.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: lowest, orm-db: postgres}
           - {php: 8.0, symfony: 5.4.*, use-orm: 1, use-odm: 1, use-dama: 0, deps: lowest, orm-db: postgres}
           - {php: 8.0, symfony: 5.4.*, use-orm: 0, use-odm: 1, use-dama: 0, deps: lowest, orm-db: postgres}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: highest, orm-db: postgres}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 1, use-odm: 1, use-dama: 0, deps: highest, orm-db: postgres}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 1, use-odm: 0, use-dama: 1, deps: highest, orm-db: postgres}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 0, use-odm: 1, use-dama: 0, deps: highest, orm-db: postgres}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 1, use-odm: 0, use-dama: 1, deps: highest, orm-db: mysql}
-          - {php: 8.2, symfony: 6.2.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: highest, orm-db: mysql}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: highest, orm-db: postgres}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 1, use-odm: 1, use-dama: 0, deps: highest, orm-db: postgres}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 1, use-odm: 0, use-dama: 1, deps: highest, orm-db: postgres}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 0, use-odm: 1, use-dama: 0, deps: highest, orm-db: postgres}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 1, use-odm: 0, use-dama: 1, deps: highest, orm-db: mysql}
+          - {php: 8.2, symfony: 6.3.*, use-orm: 1, use-odm: 0, use-dama: 0, deps: highest, orm-db: mysql}
 
     services:
       mysql:

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -37,7 +37,7 @@ final class DatabaseResetter
         return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
     }
 
-    public static function resetDatabase(KernelInterface $kernel): void
+    public static function resetDatabase(KernelInterface $kernel, bool $damaIsEnabled): void
     {
         if (!$kernel->getContainer()->has('doctrine')) {
             return;
@@ -47,7 +47,7 @@ final class DatabaseResetter
 
         $databaseResetter->resetDatabase();
 
-        self::bootFoundry($kernel);
+        self::bootFoundry($kernel, flushGlobalState: $damaIsEnabled);
 
         self::$hasBeenReset = true;
     }
@@ -82,7 +82,7 @@ final class DatabaseResetter
         return $databaseResetters;
     }
 
-    private static function bootFoundry(KernelInterface $kernel): void
+    private static function bootFoundry(KernelInterface $kernel, bool $flushGlobalState = true): void
     {
         $container = $kernel->getContainer();
 
@@ -90,9 +90,11 @@ final class DatabaseResetter
             TestState::bootFromContainer($container);
         }
 
-        TestState::flushGlobalState(
-            $container->has('.zenstruck_foundry.global_state_registry') ? $container->get('.zenstruck_foundry.global_state_registry') : null
-        );
+        if ($flushGlobalState) {
+            TestState::flushGlobalState(
+                $container->has('.zenstruck_foundry.global_state_registry') ? $container->get('.zenstruck_foundry.global_state_registry') : null
+            );
+        }
     }
 
     private static function createApplication(KernelInterface $kernel): Application

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -50,7 +50,7 @@ trait ResetDatabase
         }
 
         if (self::shouldReset($kernel)) {
-            DatabaseResetter::resetDatabase($kernel);
+            DatabaseResetter::resetDatabase($kernel, $isDAMADoctrineTestBundleEnabled);
         }
 
         if ($isDAMADoctrineTestBundleEnabled) {


### PR DESCRIPTION
fixes #487

not sure why this happened now (maybe because of the new exception in doctrine/orm) but without dama, the first test using `ResetDatabase` was flushing twice the global state, hence the error