### PR TITLE
fix(split-factories): some fixes

### DIFF
--- a/bin/tools/phpstan/composer.lock
+++ b/bin/tools/phpstan/composer.lock
@@ -117,16 +117,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.14",
+            "version": "1.10.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
                 "shasum": ""
             },
             "require": {
@@ -175,20 +175,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-19T13:47:27+00:00"
+            "time": "2023-08-24T21:54:50+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "7e78605a699d183f5a6936cf91904f4c16ca79b2"
+                "reference": "7332b90dfc291ac5b4b83fbca2081936faa1e3f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/7e78605a699d183f5a6936cf91904f4c16ca79b2",
-                "reference": "7e78605a699d183f5a6936cf91904f4c16ca79b2",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/7332b90dfc291ac5b4b83fbca2081936faa1e3f9",
+                "reference": "7332b90dfc291ac5b4b83fbca2081936faa1e3f9",
                 "shasum": ""
             },
             "require": {
@@ -244,9 +244,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.3.1"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.3.2"
             },
-            "time": "2023-04-14T16:59:18+00:00"
+            "time": "2023-05-16T12:46:15+00:00"
         }
     ],
     "packages-dev": [],

--- a/phpstan-foundry.neon
+++ b/phpstan-foundry.neon
@@ -4,6 +4,10 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
     -
+        class: Zenstruck\Foundry\PhpStan\FactoryCollectionMethodsTypeResolver
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
         class: Zenstruck\Foundry\PhpStan\FactoryStaticMethodsTypeResolver
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,11 @@ parameters:
     paths:
         - ./src
 
-        # let's analyse factories generated with maker
+        # let's analyse a factory generated with maker
         - ./tests/Fixtures/Maker/expected/can_create_factory.php
+
+        # and a factory used in tests
+        - ./tests/Fixtures/Factories/PostFactory.php
     level: 8
     bootstrapFiles:
         - ./vendor/autoload.php

--- a/phpunit-dama-doctrine.xml.dist
+++ b/phpunit-dama-doctrine.xml.dist
@@ -11,7 +11,11 @@
         <ini name="error_reporting" value="-1"/>
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel"/>
         <env name="USE_DAMA_DOCTRINE_TEST_BUNDLE" value="1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
+        <!--
+            max[self]=1 represents "The Zenstruck\Foundry\BaseFactory::new() method is considered final" deprecation.
+            It could be removed in 2.0
+        -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=1&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
         <env name="SHELL_VERBOSITY" value="0"/>
     </php>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,11 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
+        <!--
+            max[self]=1 represents "The Zenstruck\Foundry\BaseFactory::new() method is considered final" deprecation.
+            It could be removed in 2.0
+        -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=1&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
         <env name="SHELL_VERBOSITY" value="0"/>
     </php>
 

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -51,8 +51,9 @@ abstract class BaseFactory
 
     /**
      * @param Attributes|string $attributes
+     * @final
      */
-    final public static function new(array|callable|string $attributes = [], string ...$states): static
+    public static function new(array|callable|string $attributes = [], string ...$states): static
     {
         if (\is_string($attributes) || $states) {
             trigger_deprecation('zenstruck/foundry', '1.36', 'Passing states as strings is deprecated and this behavior will be removed in 2.0.', self::class, self::class);
@@ -242,10 +243,6 @@ abstract class BaseFactory
      */
     protected function normalizeAttribute(mixed $value, string $name): mixed
     {
-        if (\is_callable($value)) {
-            $value = $value();
-        }
-
         if ($value instanceof FactoryCollection) {
             $value = $value->all();
         }
@@ -265,9 +262,10 @@ abstract class BaseFactory
     }
 
     /**
+     * @internal
      * @param Attributes $attributes
      */
-    final protected function mergedAttributes(array|callable $attributes): array
+    protected function mergedAttributes(array|callable $attributes): array
     {
         return \array_merge(
             ...[

--- a/src/Bundle/Resources/skeleton/Factory.tpl.php
+++ b/src/Bundle/Resources/skeleton/Factory.tpl.php
@@ -48,7 +48,7 @@ foreach ($makeFactoryData->getDefaultProperties() as $propertyName => $value) {
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(<?= $makeFactoryData->getObjectShortName() ?> $<?= lcfirst($makeFactoryData->getObjectShortName()) ?>): void {})

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry;
 
+use Zenstruck\Foundry\Object\ObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
@@ -28,7 +29,7 @@ abstract class Factory extends PersistentObjectFactory
      */
     public function __construct(string $class, array|callable $defaultAttributes = [])
     {
-        trigger_deprecation('zenstruck/foundry', '1.36', '"%s" is deprecated and this class will be removed in 2.0, please use "%s" instead.', self::class, PersistentObjectFactory::class);
+        trigger_deprecation('zenstruck/foundry', '1.36', '"%s" is deprecated and this class will be removed in 2.0, please use "%s" or "%s" instead.', self::class, PersistentObjectFactory::class, ObjectFactory::class);
 
         /** @phpstan-ignore-next-line */
         if (self::class === static::class) {

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -45,18 +45,37 @@ final class FactoryCollection implements \IteratorAggregate
         $this->max = $max ?? $min;
     }
 
+    /**
+     * @template U
+     *
+     * @param BaseFactory<U> $factory
+     *
+     * @return static<U>
+     */
     public static function set(BaseFactory $factory, int $count): self
     {
         return new self($factory, $count, null, null, true);
     }
 
+    /**
+     * @template U
+     *
+     * @param BaseFactory<U> $factory
+     *
+     * @return static<U>
+     */
     public static function range(BaseFactory $factory, int $min, int $max): self
     {
         return new self($factory, $min, $max, null, true);
     }
 
     /**
+     * @template U
+     *
+     * @param BaseFactory<U> $factory
      * @param Parameters $sequence
+     *
+     * @return static<U>
      */
     public static function sequence(BaseFactory $factory, iterable $sequence): self
     {

--- a/src/ModelFactory.php
+++ b/src/ModelFactory.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry;
 
+use Zenstruck\Foundry\Object\ObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
@@ -28,7 +29,7 @@ abstract class ModelFactory extends Factory
 {
     public function __construct()
     {
-        trigger_deprecation('zenstruck/foundry', '1.36', '"%s" is deprecated and this class will be removed in 2.0, please use "%s" instead.', self::class, PersistentObjectFactory::class);
+        trigger_deprecation('zenstruck/foundry', '1.36', '"%s" is deprecated and this class will be removed in 2.0, please use "%s" or "%s" instead.', self::class, PersistentObjectFactory::class, ObjectFactory::class);
 
         parent::__construct(static::getClass());
     }

--- a/src/Object/ObjectFactory.php
+++ b/src/Object/ObjectFactory.php
@@ -112,14 +112,6 @@ abstract class ObjectFactory extends BaseFactory
         // execute "lazy" values
         $parameters = LazyValue::normalizeArray($parameters);
 
-        foreach ($this->beforeInstantiate as $hook) {
-            $parameters = $hook($parameters, static::class());
-
-            if (!\is_array($parameters)) {
-                throw new \LogicException('Before Instantiate event callback must return an array.');
-            }
-        }
-
         $object = ($this->instantiator ?? self::factoryManager()->defaultObjectInstantiator())($parameters, static::class());
 
         foreach ($this->afterInstantiate as $hook) {
@@ -127,5 +119,25 @@ abstract class ObjectFactory extends BaseFactory
         }
 
         return [$object, $parameters];
+    }
+
+    /**
+     * @param Attributes $attributes
+     *
+     * @internal
+     */
+    final protected function mergedAttributes(array|callable $attributes): array
+    {
+        $attributes = parent::mergedAttributes($attributes);
+
+        foreach ($this->beforeInstantiate as $hook) {
+            $attributes = $hook($attributes, static::class());
+
+            if (!\is_array($attributes)) {
+                throw new \LogicException('Before Instantiate event callback must return an array.');
+            }
+        }
+
+        return $attributes;
     }
 }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -43,6 +43,15 @@ abstract class PersistentObjectFactory extends ObjectFactory
     private bool $persist = true;
     private bool $cascadePersist = false;
 
+    final public static function new(array|callable|string $attributes = [], string ...$states): static
+    {
+        if (!PersistenceManager::classCanBePersisted(static::class())) {
+            trigger_deprecation('zenstruck/foundry', '1.36', 'Class "%s" cannot be persisted. Using "%s" with non-persistable class is deprecated and will throw an exception in 2.0. Please use "%s".', static::class(), PersistentObjectFactory::class, ObjectFactory::class);
+        }
+
+        return parent::new($attributes, ...$states);
+    }
+
     /**
      * @internal
      */
@@ -299,10 +308,6 @@ abstract class PersistentObjectFactory extends ObjectFactory
     {
         if ($value instanceof Proxy) {
             return $value->isPersisted() ? $value->refresh()->object() : $value->object();
-        }
-
-        if (\is_callable($value)) {
-            $value = $value();
         }
 
         if ($value instanceof FactoryCollection) {

--- a/src/PhpStan/AnonymousFactoryTypeResolver.php
+++ b/src/PhpStan/AnonymousFactoryTypeResolver.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\PhpStan;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ORM\Mapping\Entity;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
@@ -25,8 +23,12 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use Zenstruck\Foundry\BaseFactory;
 use Zenstruck\Foundry\Object\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
+/**
+ * @internal
+ */
 final class AnonymousFactoryTypeResolver implements DynamicFunctionReturnTypeExtension
 {
     public function getClass(): string
@@ -51,8 +53,7 @@ final class AnonymousFactoryTypeResolver implements DynamicFunctionReturnTypeExt
             return null;
         }
 
-        $reflectionClass = new \ReflectionClass($targetClass->class->toString());
-        if ($reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class)) {
+        if (PersistenceManager::classCanBePersisted($targetClass->class->toString())) {
             $factoryClass = PersistentObjectFactory::class;
         } else {
             $factoryClass = ObjectFactory::class;

--- a/src/PhpStan/AnonymousHelpersTypeResolver.php
+++ b/src/PhpStan/AnonymousHelpersTypeResolver.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\PhpStan;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ORM\Mapping\Entity;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
@@ -23,8 +21,12 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use Zenstruck\Foundry\BaseFactory;
 use Zenstruck\Foundry\Object\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
+/**
+ * @internal
+ */
 final class AnonymousHelpersTypeResolver implements DynamicFunctionReturnTypeExtension
 {
     public function getClass(): string
@@ -52,8 +54,7 @@ final class AnonymousHelpersTypeResolver implements DynamicFunctionReturnTypeExt
             return null;
         }
 
-        $reflectionClass = new \ReflectionClass($targetClass);
-        if ($reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class)) {
+        if (PersistenceManager::classCanBePersisted($targetClass)) {
             $factoryClass = PersistentObjectFactory::class;
         } else {
             $factoryClass = ObjectFactory::class;

--- a/src/PhpStan/FactoryCollectionMethodsTypeResolver.php
+++ b/src/PhpStan/FactoryCollectionMethodsTypeResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\PhpStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
+use Zenstruck\Foundry\Proxy;
+
+/**
+ * @internal
+ */
+final class FactoryCollectionMethodsTypeResolver implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return FactoryCollection::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'create';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $factoryCollectionType = $scope->getType($methodCall->var);
+
+        if (
+            !$factoryCollectionType instanceof GenericObjectType
+            || !($targetType = $factoryCollectionType->getTypes()[0] ?? null) instanceof TypeWithClassName
+        ) {
+            return null;
+        }
+
+        $targetClass = $targetType->getClassName();
+
+        if ($targetClass === Proxy::class) {
+            $typeReturnedByCollection = $targetType;
+        } else {
+            $typeReturnedByCollection = PersistenceManager::classCanBePersisted($targetClass)
+                ? new GenericObjectType(Proxy::class, [new ObjectType($targetClass)])
+                : new ObjectType($targetClass);
+        }
+
+        return AccessoryArrayListType::intersectWith(
+            new ArrayType(new IntegerType(), $typeReturnedByCollection)
+        );
+    }
+}

--- a/src/PhpStan/FactoryMethodsTypeResolver.php
+++ b/src/PhpStan/FactoryMethodsTypeResolver.php
@@ -20,6 +20,9 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use Zenstruck\Foundry\BaseFactory;
 
+/**
+ * @internal
+ */
 final class FactoryMethodsTypeResolver implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
@@ -42,7 +45,7 @@ final class FactoryMethodsTypeResolver implements DynamicMethodReturnTypeExtensi
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
     {
-        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $scope);
+        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $methodReflection, $scope);
 
         if (!$factoryMetadata) {
             return null;

--- a/src/PhpStan/FactoryStaticMethodsTypeResolver.php
+++ b/src/PhpStan/FactoryStaticMethodsTypeResolver.php
@@ -20,6 +20,9 @@ use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use Zenstruck\Foundry\BaseFactory;
 
+/**
+ * @internal
+ */
 final class FactoryStaticMethodsTypeResolver implements DynamicStaticMethodReturnTypeExtension
 {
     public function getClass(): string
@@ -52,7 +55,7 @@ final class FactoryStaticMethodsTypeResolver implements DynamicStaticMethodRetur
 
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
     {
-        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $scope);
+        $factoryMetadata = FactoryMetadata::getFactoryMetadata($methodCall, $methodReflection, $scope);
 
         if (!$factoryMetadata) {
             return null;

--- a/src/Psalm/FixAnonymousFunctions.php
+++ b/src/Psalm/FixAnonymousFunctions.php
@@ -22,6 +22,9 @@ use Zenstruck\Foundry\Object\ObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Proxy;
 
+/**
+ * @internal
+ */
 final class FixAnonymousFunctions implements FunctionReturnTypeProviderInterface, MethodReturnTypeProviderInterface
 {
     public static function getFunctionIds(): array

--- a/src/Psalm/FoundryPlugin.php
+++ b/src/Psalm/FoundryPlugin.php
@@ -16,6 +16,9 @@ namespace Zenstruck\Foundry\Psalm;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 
+/**
+ * @internal
+ */
 final class FoundryPlugin implements PluginEntryPointInterface
 {
     public function __invoke(RegistrationInterface $psalm, ?\SimpleXMLElement $config = null): void

--- a/src/Psalm/PsalmTypeHelper.php
+++ b/src/Psalm/PsalmTypeHelper.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\Psalm;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ORM\Mapping\Entity;
 use PhpParser\Node\Expr\ClassConstFetch;
 use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Proxy;
 
+/**
+ * @internal
+ */
 final class PsalmTypeHelper
 {
     public static function classType(string $targetClass): \Psalm\Type\Union
@@ -66,8 +68,19 @@ final class PsalmTypeHelper
             return null;
         }
 
-        $reflectionClass = new \ReflectionClass($factoryTargetClass);
+        return PersistenceManager::classCanBePersisted($factoryTargetClass);
+    }
 
-        return $reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class);
+    /**
+     * @param class-string $class
+     * @param class-string $potentialParent
+     */
+    public static function isSubClassOf(string $class, string $potentialParent): bool
+    {
+        try {
+            return \is_subclass_of($class, $potentialParent);
+        } catch (\Throwable) {
+            return false;
+        }
     }
 }

--- a/src/Psalm/RemoveFactoryPhpDocMethods.php
+++ b/src/Psalm/RemoveFactoryPhpDocMethods.php
@@ -19,6 +19,7 @@ use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
  * Let's make Psalm forget about `@method` in factories PHPDoc.
+ * @internal
  */
 final class RemoveFactoryPhpDocMethods implements AfterClassLikeVisitInterface
 {
@@ -27,7 +28,7 @@ final class RemoveFactoryPhpDocMethods implements AfterClassLikeVisitInterface
         $classLikeStorage = $event->getStorage();
 
         if (PersistentObjectFactory::class === $classLikeStorage->parent_class
-            || \is_subclass_of($classLikeStorage->name, PersistentObjectFactory::class)) {
+            || PsalmTypeHelper::isSubClassOf($classLikeStorage->name, PersistentObjectFactory::class)) {
             foreach (\array_keys($classLikeStorage->pseudo_methods) as $name) {
                 if (\method_exists(PersistentObjectFactory::class, $name)) {
                     unset($classLikeStorage->pseudo_methods[$name]);

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,10 +11,9 @@
 
 namespace Zenstruck\Foundry;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ORM\Mapping\Entity;
 use Faker;
 use Zenstruck\Foundry\Object\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
@@ -50,8 +49,7 @@ function anonymous(string $class, array|callable $defaultAttributes = []): Objec
     if (!\class_exists($anonymousClassName)) { // @phpstan-ignore-line
         $factoryClass = ObjectFactory::class;
 
-        $reflectionClass = new \ReflectionClass($class);
-        if ($reflectionClass->getAttributes(Entity::class) || $reflectionClass->getAttributes(Document::class)) {
+        if (PersistenceManager::classCanBePersisted($class)) {
             $factoryClass = PersistentObjectFactory::class;
         }
 

--- a/tests/Fixtures/Factories/AddressFactory.php
+++ b/tests/Fixtures/Factories/AddressFactory.php
@@ -2,13 +2,13 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
 
-use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Object\ObjectFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class AddressFactory extends PersistentObjectFactory
+final class AddressFactory extends ObjectFactory
 {
     public static function class(): string
     {

--- a/tests/Fixtures/Factories/ODM/CommentFactory.php
+++ b/tests/Fixtures/Factories/ODM/CommentFactory.php
@@ -2,11 +2,11 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
 
-use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Object\ObjectFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMComment;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
 
-class CommentFactory extends PersistentObjectFactory
+class CommentFactory extends ObjectFactory
 {
     public static function class(): string
     {

--- a/tests/Fixtures/Factories/ODM/UserFactory.php
+++ b/tests/Fixtures/Factories/ODM/UserFactory.php
@@ -5,6 +5,10 @@ namespace Zenstruck\Foundry\Tests\Fixtures\Factories\ODM;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
 
+/**
+ * This factory should extend ObjectFactory because ODMUser class is not "persistable" but let's keep it this way
+ * in order to test legacy behavior with EmbeddedDocument.
+ */
 final class UserFactory extends PersistentObjectFactory
 {
     public static function class(): string

--- a/tests/Fixtures/Factories/PostFactory.php
+++ b/tests/Fixtures/Factories/PostFactory.php
@@ -2,13 +2,33 @@
 
 namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
 
+use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\Instantiator;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Repository\PostRepository;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  * @extends PersistentObjectFactory<Post>
+ *
+ * @method static Post|Proxy                     createOne(array $attributes = [])
+ * @method static Post[]|Proxy[]                 createMany(int $number, array|callable $attributes = [])
+ * @method static Post[]&Proxy[]                 createSequence(array|callable $sequence)
+ * @method static Post|Proxy                     find(object|array|mixed $criteria)
+ * @method static Post|Proxy                     findOrCreate(array $attributes)
+ * @method static Post|Proxy                     first(string $sortedField = 'id')
+ * @method static Post|Proxy                     last(string $sortedField = 'id')
+ * @method static Post|Proxy                     random(array $attributes = [])
+ * @method static Post|Proxy                     randomOrCreate(array $attributes = []))
+ * @method static Post[]|Proxy[]                 all()
+ * @method static Post[]|Proxy[]                 findBy(array $attributes)
+ * @method static Post[]|Proxy[]                 randomSet(int $number, array $attributes = []))
+ * @method static Post[]|Proxy[]                 randomRange(int $min, int $max, array $attributes = []))
+ * @method static PostRepository|RepositoryProxy repository()
+ * @method        Post|Proxy                     create(array|callable $attributes = [])
  */
 class PostFactory extends PersistentObjectFactory
 {
@@ -20,6 +40,24 @@ class PostFactory extends PersistentObjectFactory
     public static function class(): string
     {
         return Post::class;
+    }
+
+    /**
+     * @return Proxy<Post>
+     * This method is here to test an edge case with the phpstan extension
+     */
+    public static function staticMethodCallWithSelf(): Proxy
+    {
+        return self::findOrCreate([]);
+    }
+
+    /**
+     * @return FactoryCollection<Proxy<Post>>
+     * This method is here to test an edge case with the phpstan extension
+     */
+    public function methodUsingThis(): FactoryCollection
+    {
+        return $this->sequence([]);
     }
 
     protected function getDefaults(): array

--- a/tests/Fixtures/Factories/PostFactoryWithValidInitialize.php
+++ b/tests/Fixtures/Factories/PostFactoryWithValidInitialize.php
@@ -7,7 +7,7 @@ namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
  */
 final class PostFactoryWithValidInitialize extends PostFactory
 {
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this->published();
     }

--- a/tests/Fixtures/Maker/expected/can_create_factory.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory.php
@@ -68,7 +68,7 @@ final class CategoryFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Category $category): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class.php
@@ -66,7 +66,7 @@ final class SomeObjectFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(SomeObject $someObject): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_not_persisted_class_interactively.php
@@ -64,7 +64,7 @@ final class SomeObjectFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(SomeObject $someObject): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_document.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_document.php
@@ -71,7 +71,7 @@ final class ODMPostFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(ODMPost $oDMPost): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_embedded_document.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_odm_with_data_set_embedded_document.php
@@ -57,7 +57,7 @@ final class ODMCommentFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(ODMComment $oDMComment): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_for_orm_embedded_class.php
@@ -55,7 +55,7 @@ final class AddressFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Address $address): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir.php
@@ -68,7 +68,7 @@ final class CategoryFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Category $category): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_in_test_dir_interactively.php
@@ -68,7 +68,7 @@ final class TagFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Tag $tag): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_interactively.php
@@ -72,7 +72,7 @@ final class CommentFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Comment $comment): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
@@ -56,7 +56,7 @@ final class CategoryFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Category $category): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_odm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_odm.php
@@ -69,7 +69,7 @@ final class DocumentWithEnumFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(DocumentWithEnum $documentWithEnum): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_orm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_orm.php
@@ -69,7 +69,7 @@ final class EntityWithEnumFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(EntityWithEnum $entityWithEnum): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_without_persistence.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_default_enum_with_data_set_without_persistence.php
@@ -56,7 +56,7 @@ final class EntityWithEnumFactory extends ObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(EntityWithEnum $entityWithEnum): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_odm.php
@@ -74,7 +74,7 @@ final class ODMPostFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(ODMPost $oDMPost): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_embeddable_with_data_set_orm.php
@@ -69,7 +69,7 @@ final class ContactFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(Contact $contact): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_defaults.php
@@ -72,7 +72,7 @@ final class EntityWithRelationsFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(EntityWithRelations $entityWithRelations): void {})

--- a/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
+++ b/tests/Fixtures/Maker/expected/can_create_factory_with_relation_for_all_fields.php
@@ -72,7 +72,7 @@ final class EntityWithRelationsFactory extends PersistentObjectFactory
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-    protected function initialize(): self
+    protected function initialize(): static
     {
         return $this
             // ->afterInstantiate(function(EntityWithRelations $entityWithRelations): void {})

--- a/tests/Fixtures/Object/SomeOtherObjectFactory.php
+++ b/tests/Fixtures/Object/SomeOtherObjectFactory.php
@@ -6,6 +6,9 @@ use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
  * @extends PersistentObjectFactory<SomeOtherObject>
+ *
+ *  This factory should extend ObjectFactory because SomeOtherObject class is not "persistable" but let's keep it this way
+ *  in order to test legacy behavior.
  */
 final class SomeOtherObjectFactory extends PersistentObjectFactory
 {

--- a/tests/Fixtures/PhpStan/test-types.php
+++ b/tests/Fixtures/PhpStan/test-types.php
@@ -13,11 +13,13 @@ assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post
 assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::new()->create(['title' => 'foo']));
 assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::new()->create(fn() => ['title' => 'foo']));
 assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::createOne());
+assertType('Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::findOrCreate([]));
 assertType('Zenstruck\Foundry\RepositoryProxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', PostFactory::repository());
 assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::new()->many(2));
 assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::new()->sequence([[]]));
 assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::new()->many(2)->create());
 assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::createMany(2));
+assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', PostFactory::all([]));
 
 assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', SomeObjectFactory::new()->create());
 assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', SomeObjectFactory::new()->create(['title' => 'foo']));
@@ -42,3 +44,7 @@ assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures
 assertType('array<int, Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', anonymous(SomeObject::class)->many(2)->create());
 assertType('Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject', create(SomeObject::class));
 assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', create_many(2, SomeObject::class));
+
+assertType('Zenstruck\Foundry\FactoryCollection<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>', \Zenstruck\Foundry\FactoryCollection::set(PostFactory::new(), 2));
+assertType('array<int, Zenstruck\Foundry\Proxy<Zenstruck\Foundry\Tests\Fixtures\Entity\Post>>', \Zenstruck\Foundry\FactoryCollection::set(PostFactory::new(), 2)->create());
+assertType('array<int, Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject>', \Zenstruck\Foundry\FactoryCollection::set(SomeObjectFactory::new(), 2)->create());

--- a/tests/Functional/FactoryTest.php
+++ b/tests/Functional/FactoryTest.php
@@ -208,6 +208,9 @@ final class FactoryTest extends KernelTestCase
 
     /**
      * @test
+     *
+     * legacy tag could be removed once SomeOtherObjectFactory extends ObjectFactory
+     * @group legacy
      */
     public function can_create_an_object_not_persisted_with_nested_factory(): void
     {
@@ -218,7 +221,7 @@ final class FactoryTest extends KernelTestCase
 
     /**
      * @test
-     * @legacy
+     * @group legacy
      */
     public function can_use_legacy_factory(): void
     {

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -38,14 +38,23 @@ final class ODMModelFactoryTest extends ModelFactoryTest
      */
     public function can_use_factory_for_embedded_object(): void
     {
-        $proxyObject = CommentFactory::createOne(['user' => new ODMUser('some user'), 'body' => 'some body']);
-        self::assertInstanceOf(Proxy::class, $proxyObject);
-        self::assertFalse($proxyObject->isPersisted());
-
-        $comment = $proxyObject->object();
+        $comment = CommentFactory::createOne(['user' => new ODMUser('some user'), 'body' => 'some body']);
         self::assertInstanceOf(ODMComment::class, $comment);
         self::assertEquals(new ODMUser('some user'), $comment->getUser());
         self::assertSame('some body', $comment->getBody());
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function can_use_factory_for_embedded_object_legacy(): void
+    {
+        $proxy = UserFactory::createOne(['name' => 'foo']);
+        self::assertInstanceOf(Proxy::class, $proxy);
+        self::assertSame('foo', $proxy->getName());
+        self::assertInstanceOf(ODMUser::class, $proxy->object());
+        self::assertSame('foo', $proxy->object()->getName());
     }
 
     /**
@@ -95,6 +104,9 @@ final class ODMModelFactoryTest extends ModelFactoryTest
 
     /**
      * @test
+     *
+     * legacy tag could be removed once UserFactory extends ObjectFactory
+     * @group legacy
      */
     public function can_find_or_create_from_object(): void
     {
@@ -112,6 +124,9 @@ final class ODMModelFactoryTest extends ModelFactoryTest
 
     /**
      * @test
+     *
+     *  legacy tag could be removed once UserFactory extends ObjectFactory
+     * @group legacy
      */
     public function can_find_or_create_from_proxy_of_object(): void
     {

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -680,6 +680,9 @@ final class ORMModelFactoryTest extends ModelFactoryTest
 
     /**
      * @test
+     *
+     *  legacy tag could be removed once SomeOtherObjectFactory extends ObjectFactory
+     * @group legacy
      */
     public function it_can_create_entity_with_property_name_different_from_constructor_name(): void
     {

--- a/tests/Functional/WithDoctrineDisabledKernelTest.php
+++ b/tests/Functional/WithDoctrineDisabledKernelTest.php
@@ -17,8 +17,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Assert;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
-use Zenstruck\Foundry\Tests\Fixtures\Factories\AddressFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Kernel;
 
 final class WithDoctrineDisabledKernelTest extends KernelTestCase
@@ -37,17 +37,17 @@ final class WithDoctrineDisabledKernelTest extends KernelTestCase
      */
     public function create_object(): void
     {
-        $address = AddressFactory::new()->withoutPersisting()->create(['value' => 'test'])->object();
-        Assert::that($address)->isInstanceOf(Address::class);
-        Assert::that($address->getValue())->is('test');
+        $address = PostFactory::new()->withoutPersisting()->create(['title' => 'test'])->object();
+        Assert::that($address)->isInstanceOf(Post::class);
+        Assert::that($address->getTitle())->is('test');
 
-        $address = AddressFactory::createOne(['value' => 'test'])->object();
-        Assert::that($address)->isInstanceOf(Address::class);
-        Assert::that($address->getValue())->is('test');
+        $address = PostFactory::createOne(['title' => 'test'])->object();
+        Assert::that($address)->isInstanceOf(Post::class);
+        Assert::that($address->getTitle())->is('test');
     }
 
     protected static function createKernel(array $options = []): KernelInterface
     {
-        return Kernel::create(false);
+        return Kernel::create(enableDoctrine: false);
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -24,6 +24,7 @@ use Zenstruck\Foundry\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\UserFactory;
 
@@ -162,11 +163,17 @@ final class FactoryTest extends TestCase
 
                 return $attributes;
             })
+            ->beforeInstantiate(static function(array $attributes): array {
+                $attributes['category'] = CategoryFactory::new(['name' => 'foo']);
+
+                return $attributes;
+            })
             ->create($attributeArray)
         ;
 
         $this->assertSame('title', $object->getTitle());
         $this->assertSame('body', $object->getBody());
+        $this->assertSame('foo', $object->getCategory()->getName());
     }
 
     /**

--- a/tests/Unit/PersistenceManagerTest.php
+++ b/tests/Unit/PersistenceManagerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use Doctrine\ORM\Mapping\Entity;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Persistence\PersistenceManager;
+use Zenstruck\Foundry\Tests\Fixtures\Document\ODMPost;
+use Zenstruck\Foundry\Tests\Fixtures\Document\ODMUser;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Address;
+use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
+
+class PersistenceManagerTest extends TestCase
+{
+    /**
+     * @dataProvider providePersistableClasses
+     * @test
+     */
+    public function it_can_tell_if_class_can_be_persisted(string $className, bool $canBePersisted): void
+    {
+        self::assertSame($canBePersisted, PersistenceManager::classCanBePersisted($className));
+    }
+
+    public static function providePersistableClasses(): iterable
+    {
+        yield 'ORM entity can be persisted' => [Post::class, true];
+        yield 'ORM entity with annotation can be persisted' => [EntityWithAnnotation::class, true];
+        yield 'ODM document can be persisted' => [ODMPost::class, true];
+        yield 'ORM embeddable cannot be persisted' => [Address::class, false];
+        yield 'ODM embedded cannot be persisted' => [ODMUser::class, false];
+        yield 'Basic DTO cannot be persisted' => [SomeObject::class, false];
+    }
+}
+
+/**
+ * @Entity
+ */
+class EntityWithAnnotation
+{
+
+}


### PR DESCRIPTION
PHPStan fixes:
- using `$this` inside factory was problematic with phpstan
- using `self::findOrCreate()` or any static method was also problematic
- phpstan did not understood factoryCollection->create() would return a list<>
- auto-detect for a `FactoryCollection` whether if the target class has persistence or not 

bug fixes:
- factory parameters are not invokable
- we must apply "before instantiate" callbacks before normalizing step
- `@ORM\Entity` and `@ODM\Document` annotations should be checked along with attributes to check if a class is persistable  