### PR TITLE
minor: use `doctrine:schema:update` in `ResetDatabase`

### DIFF
--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -75,6 +75,7 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
                 'doctrine:schema:update',
                 [
                     '--em' => $manager,
+                    '--force' => true,
                 ]
             );
         }

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -72,7 +72,7 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
         foreach ($this->objectManagersToReset() as $manager) {
             $this->runCommand(
                 $this->application,
-                'doctrine:schema:create',
+                'doctrine:schema:update',
                 [
                     '--em' => $manager,
                 ]

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -76,6 +76,7 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
                 [
                     '--em' => $manager,
                     '--force' => true,
+                    '--complete' => true,
                 ]
             );
         }


### PR DESCRIPTION
Use schema:update in favour of schema:create when using the DatabaseResetter

Using schema:create always tries to create the non-default PostgreSQL schemas, which triggers an Exception when the schema already exists. (PostgreSQL schemas are not removed by schema:drop)

fixes #495