### PR TITLE
minor: allow Symfony 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "doctrine/persistence": "^1.3.3|^2.0|^3.0",
         "fakerphp/faker": "^1.10",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/property-access": "^5.4|^6.0",
-        "symfony/string": "^5.4|^6.0",
+        "symfony/property-access": "^5.4|^6.0|^7.0",
+        "symfony/string": "^5.4|^6.0|^7.0",
         "zenstruck/assert": "^1.0",
         "zenstruck/callback": "^1.1"
     },
@@ -30,9 +30,9 @@
         "doctrine/mongodb-odm-bundle": "^4.4.0",
         "doctrine/orm": "^2.9",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/maker-bundle": "^1.49",
-        "symfony/phpunit-bridge": "^5.4|^6.0",
+        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
         "symfony/translation-contracts": "^2.5|^3.0"
     },
     "config": {


### PR DESCRIPTION
This just allows foundry to be installed on Symfony 7.0. We still need to wait for some upstream dev library's to support 7.0 before we can add to the test matrix.