### PR TITLE
1.x bc layer

### DIFF
--- a/phpunit.dama.xml.dist
+++ b/phpunit.dama.xml.dist
@@ -11,7 +11,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixtures\Kernel"/>
         <env name="USE_DAMA_DOCTRINE_TEST_BUNDLE" value="1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="/will be private in Foundry/"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
         <env name="SHELL_VERBOSITY" value="0"/>
     </php>
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -251,11 +251,19 @@ final class Configuration
 
     public function disablePersist(): void
     {
+        if (!self::hasManagerRegistry()) {
+            trigger_deprecation('zenstruck\foundry', '1.37.0', 'Calling function "disable_persisting()" when Foundry is booted without doctrine is deprecated and will throw an exception in 2.0.');
+        }
+
         $this->persistEnabled = false;
     }
 
     public function enablePersist(): void
     {
+        if (!self::hasManagerRegistry()) {
+            trigger_deprecation('zenstruck\foundry', '1.37.0', 'Calling function "enable_persisting()" when Foundry is booted without doctrine is deprecated and will throw an exception in 2.0.');
+        }
+
         $this->persistEnabled = true;
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -192,6 +192,8 @@ class Factory
     final public function sequence(iterable|callable $sequence): FactoryCollection
     {
         if (\is_callable($sequence)) {
+            trigger_deprecation('zenstruck\foundry', '1.37.0', \sprintf('Passing a callable to method "%s()" is deprecated and will be removed in 2.0.', __METHOD__, self::class));
+
             $sequence = $sequence();
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -192,7 +192,7 @@ class Factory
     final public function sequence(iterable|callable $sequence): FactoryCollection
     {
         if (\is_callable($sequence)) {
-            trigger_deprecation('zenstruck\foundry', '1.37.0', \sprintf('Passing a callable to method "%s()" is deprecated and will be removed in 2.0.', __METHOD__, self::class));
+            trigger_deprecation('zenstruck\foundry', '1.37.0', \sprintf('Passing a callable to method "%s()" is deprecated and will be removed in 2.0.', __METHOD__));
 
             $sequence = $sequence();
         }

--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -63,7 +63,11 @@ trait Factories
     public static function _tearDownFactories(): void
     {
         try {
-            Factory::configuration()->enablePersist();
+            $configuration = Factory::configuration();
+
+            if ($configuration->hasManagerRegistry()) {
+                $configuration->enablePersist();
+            }
         } catch (FoundryBootException) {
         }
 

--- a/src/Test/TestState.php
+++ b/src/Test/TestState.php
@@ -37,51 +37,51 @@ final class TestState
     private static array $globalStates = [];
 
     /**
-     * @deprecated Use TestState::configure()
+     * @deprecated Use UnitTestConfig::configure()
      */
     public static function setInstantiator(callable $instantiator): void
     {
-        trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of TestState::setInstantiator() is deprecated. Please use TestState::configure().');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0. Use "%s::configure()" instead.', __METHOD__, UnitTestConfig::class));
 
         self::$instantiator = $instantiator;
     }
 
     /**
-     * @deprecated Use TestState::configure()
+     * @deprecated Use UnitTestConfig::configure()
      */
     public static function setFaker(Faker\Generator $faker): void
     {
-        trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of TestState::setFaker() is deprecated. Please use TestState::configure().');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0. Use "%s::configure()" instead.', __METHOD__, UnitTestConfig::class));
 
         self::$faker = $faker;
     }
 
     /**
-     * @deprecated Use bundle configuration
+     * @deprecated
      */
     public static function enableDefaultProxyAutoRefresh(): void
     {
-        trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of TestState::enableDefaultProxyAutoRefresh() is deprecated. Please use bundle configuration under "auto_refresh_proxies" key.');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0 without replacement.', __METHOD__));
 
         self::$defaultProxyAutoRefresh = true;
     }
 
     /**
-     * @deprecated Use bundle configuration
+     * @deprecated
      */
     public static function disableDefaultProxyAutoRefresh(): void
     {
-        trigger_deprecation('zenstruck\foundry', '1.23', 'Usage of TestState::disableDefaultProxyAutoRefresh() is deprecated. Please use bundle configuration under "auto_refresh_proxies" key.');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0 without replacement.', __METHOD__));
 
         self::$defaultProxyAutoRefresh = false;
     }
 
     /**
-     * @deprecated Use TestState::enableDefaultProxyAutoRefresh()
+     * @deprecated
      */
     public static function alwaysAutoRefreshProxies(): void
     {
-        trigger_deprecation('zenstruck\foundry', '1.9', 'TestState::alwaysAutoRefreshProxies() is deprecated, use TestState::enableDefaultProxyAutoRefresh().');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0 without replacement.', __METHOD__));
 
         self::enableDefaultProxyAutoRefresh();
     }
@@ -146,11 +146,11 @@ final class TestState
     }
 
     /**
-     * @deprecated use TestState::bootFoundry()
+     * @deprecated
      */
     public static function bootFactory(Configuration $configuration): Configuration
     {
-        trigger_deprecation('zenstruck/foundry', '1.4.0', 'TestState::bootFactory() is deprecated, use TestState::bootFoundry().');
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0 without replacement.', __METHOD__));
 
         self::bootFoundry($configuration);
 
@@ -220,7 +220,21 @@ final class TestState
         StoryManager::setGlobalState();
     }
 
+    /**
+     * @deprecated
+     */
     public static function configure(?Instantiator $instantiator = null, ?Faker\Generator $faker = null): void
+    {
+        trigger_deprecation('zenstruck/foundry', '1.37.0', sprintf('Method "%s()" is deprecated and will be removed in Foundry 2.0. Use "%s::configure()" instead.', __METHOD__, UnitTestConfig::class));
+
+        self::$instantiator = $instantiator;
+        self::$faker = $faker;
+    }
+
+    /**
+     * @internal
+     */
+    public static function configureInternal(?Instantiator $instantiator = null, ?Faker\Generator $faker = null): void
     {
         self::$instantiator = $instantiator;
         self::$faker = $faker;

--- a/src/Test/UnitTestConfig.php
+++ b/src/Test/UnitTestConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Test;
+
+use Faker;
+use Zenstruck\Foundry\Instantiator;
+
+final class UnitTestConfig
+{
+    public static function configure(?Instantiator $instantiator = null, ?Faker\Generator $faker = null): void
+    {
+        TestState::configureInternal($instantiator, $faker);
+    }
+}

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -314,9 +314,21 @@ abstract class ModelFactoryTest extends KernelTestCase
 
     /**
      * @test
-     * @dataProvider sequenceProvider
      */
-    public function can_create_sequence(\Closure|string|array $sequence): void
+    public function can_create_sequence(): void
+    {
+        $categoryFactoryClass = $this->categoryFactoryClass();
+        $categoryFactoryClass::createSequence([['name' => 'foo'], ['name' => 'bar']]);
+
+        $categoryFactoryClass::assert()->exists(['name' => 'foo']);
+        $categoryFactoryClass::assert()->exists(['name' => 'bar']);
+    }
+
+    /**
+     * @dataProvider sequenceProvider
+     * @group legacy
+     */
+    public function can_create_sequence_with_callable(callable $sequence): void
     {
         $categoryFactoryClass = $this->categoryFactoryClass();
         $categoryFactoryClass::createSequence($sequence);
@@ -327,10 +339,6 @@ abstract class ModelFactoryTest extends KernelTestCase
 
     public function sequenceProvider(): iterable
     {
-        yield 'with array of attributes' => [
-            [['name' => 'foo'], ['name' => 'bar']],
-        ];
-
         yield 'with a callable which returns an array of attributes' => [
             static fn(): array => [['name' => 'foo'], ['name' => 'bar']],
         ];

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -30,6 +30,8 @@ use function Zenstruck\Foundry\instantiate_many;
 use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\memoize;
 use function Zenstruck\Foundry\object;
+use function Zenstruck\Foundry\Persistence\disable_persisting;
+use function Zenstruck\Foundry\Persistence\enable_persisting;
 use function Zenstruck\Foundry\repository;
 
 /**
@@ -149,5 +151,17 @@ final class FunctionsTest extends TestCase
         Factory::configuration()->setManagerRegistry($registry);
 
         $this->assertInstanceOf(RepositoryDecorator::class, repository(new Category()));
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function enable_or_disable_persisting_can_be_called_without_doctrine(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        enable_persisting();
+        disable_persisting();
     }
 }


### PR DESCRIPTION
- refactor: deprecate passing callable to sequence
- refactor: deprecate usage of disable/enable_persisting without doctrine
- refactor: deprecate TestState for UnitTestConfig
