### PR TITLE
minor(ci): remove mysql/no-dama from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,6 @@ jobs:
           - php: 8.2
             deps: highest
             symfony: '*'
-            database: mysql
-            use-dama: 0
-          - php: 8.2
-            deps: highest
-            symfony: '*'
             database: pgsql
             use-dama: 0
     env:


### PR DESCRIPTION
This job is painfully slow. @nikophil do you think we can get away with removing it? The pgsql w/o dama is still there but it's much faster.