### PR TITLE
refactor: deprecate config auto_refresh_proxies

### DIFF
--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Zenstruck\Foundry\Bundle\Command\StubMakeFactory;
 use Zenstruck\Foundry\Bundle\Command\StubMakeStory;
 use Zenstruck\Foundry\Instantiator;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Story;
 use Zenstruck\Foundry\Test\ORMDatabaseResetter;
@@ -55,6 +56,17 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
         if (true === $mergedConfig['auto_refresh_proxies']) {
             $container->getDefinition('.zenstruck_foundry.configuration')->addMethodCall('enableDefaultProxyAutoRefresh');
         } elseif (false === $mergedConfig['auto_refresh_proxies']) {
+            trigger_deprecation(
+                'zenstruck\foundry',
+                '1.37.0',
+                <<<MESSAGE
+                Configuring the default proxy auto-refresh to false is deprecated. You should set it to "true", which will be the default value in 2.0.
+                If you still want to disable auto refresh, make your factory implement "%s" instead of "%s".
+                MESSAGE,
+                PersistentObjectFactory::class,
+                PersistentProxyObjectFactory::class,
+            );
+
             $container->getDefinition('.zenstruck_foundry.configuration')->addMethodCall('disableDefaultProxyAutoRefresh');
         }
     }

--- a/tests/Fixtures/Entity/Cascade/Product.php
+++ b/tests/Fixtures/Entity/Cascade/Product.php
@@ -82,6 +82,7 @@ class Product
     public function setReview(Review $review): void
     {
         $this->review = $review;
+        $review->setProduct($this);
     }
 
     public function getVariants(): Collection
@@ -113,6 +114,7 @@ class Product
     {
         if (!$this->categories->contains($category)) {
             $this->categories[] = $category;
+            $category->addProduct($this);
         }
     }
 

--- a/tests/Fixtures/Entity/Cascade/ProductCategory.php
+++ b/tests/Fixtures/Entity/Cascade/ProductCategory.php
@@ -54,4 +54,12 @@ class ProductCategory
     {
         return $this->products;
     }
+
+    public function addProduct(Product $product): void
+    {
+        if (!$this->products->contains($product)) {
+            $this->products[] = $product;
+            $product->addCategory($this);
+        }
+    }
 }

--- a/tests/Fixtures/Entity/Category.php
+++ b/tests/Fixtures/Entity/Category.php
@@ -95,7 +95,7 @@ class Category
     {
         if (!$this->secondaryPosts->contains($secondaryPost)) {
             $this->secondaryPosts[] = $secondaryPost;
-            $secondaryPost->setCategory($this);
+            $secondaryPost->setSecondaryCategory($this);
         }
     }
 
@@ -105,7 +105,7 @@ class Category
             $this->secondaryPosts->removeElement($secondaryPost);
             // set the owning side to null (unless already changed)
             if ($secondaryPost->getCategory() === $this) {
-                $secondaryPost->setCategory(null);
+                $secondaryPost->setSecondaryCategory(null);
             }
         }
     }

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -162,7 +162,7 @@ class Kernel extends BaseKernel
         }
 
         if (\getenv('USE_FOUNDRY_BUNDLE')) {
-            $foundryConfig = ['auto_refresh_proxies' => false];
+            $foundryConfig = ['auto_refresh_proxies' => true];
             if ($this->defaultMakeFactoryNamespace) {
                 $foundryConfig['make_factory'] = ['default_namespace' => $this->defaultMakeFactoryNamespace];
             }

--- a/tests/Functional/FactoryDoctrineCascadeTest.php
+++ b/tests/Functional/FactoryDoctrineCascadeTest.php
@@ -11,7 +11,9 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Instantiator;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -22,6 +24,7 @@ use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\ProductCategory;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Review;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Tag;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Cascade\Variant;
+use Zenstruck\Foundry\Tests\Fixtures\Kernel;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
 

--- a/tests/Functional/ODMModelFactoryTest.php
+++ b/tests/Functional/ODMModelFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
+use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMCategory;
 use Zenstruck\Foundry\Tests\Fixtures\Document\ODMComment;
@@ -97,6 +98,9 @@ final class ODMModelFactoryTest extends ModelFactoryTest
      */
     public function can_find_or_create_from_object(): void
     {
+        // must disable auto refresh proxy: otherwise doctrine would update post from db and recreate the user object.
+        Factory::configuration()->disableDefaultProxyAutoRefresh();
+
         $user = UserFactory::createOne(['name' => 'some user']);
         $post = PostFactory::findOrCreate($attributes = ['user' => $user->_real()]);
 
@@ -114,6 +118,9 @@ final class ODMModelFactoryTest extends ModelFactoryTest
      */
     public function can_find_or_create_from_proxy_of_object(): void
     {
+        // must disable auto refresh proxy: otherwise doctrine would update post from db and recreate the user object.
+        Factory::configuration()->disableDefaultProxyAutoRefresh();
+
         $user = UserFactory::createOne(['name' => 'some user']);
         $post = PostFactory::findOrCreate($attributes = ['user' => $user]);
 

--- a/tests/Functional/ProxyTest.php
+++ b/tests/Functional/ProxyTest.php
@@ -136,6 +136,7 @@ abstract class ProxyTest extends KernelTestCase
     public function can_force_set_multiple_fields(): void
     {
         $post = $this->postFactoryClass()::createOne(['title' => 'old title', 'body' => 'old body']);
+        $post->_disableAutoRefresh();
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -248,6 +249,7 @@ abstract class ProxyTest extends KernelTestCase
     public function without_auto_refresh_does_not_enable_auto_refresh_if_it_was_disabled_originally(): void
     {
         $post = $this->postFactoryClass()::createOne(['title' => 'old title', 'body' => 'old body']);
+        $post->_disableAutoRefresh();
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());
@@ -274,6 +276,7 @@ abstract class ProxyTest extends KernelTestCase
     public function without_auto_refresh_keeps_disabled_if_originally_disabled(): void
     {
         $post = $this->postFactoryClass()::createOne(['title' => 'old title', 'body' => 'old body']);
+        $post->_disableAutoRefresh();
 
         $this->assertSame('old title', $post->getTitle());
         $this->assertSame('old body', $post->getBody());

--- a/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
+++ b/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
@@ -220,6 +220,7 @@ final class ZenstruckFoundryExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_enable_auto_refresh_proxies(): void
     {
@@ -232,6 +233,7 @@ final class ZenstruckFoundryExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @test
+     * @group legacy
      */
     public function can_disable_auto_refresh_proxies(): void
     {


### PR DESCRIPTION
ok, this gave me serious headaches! 😅 :exploding_head:  but the PR is finally green :green_circle: 

we had some small incoherence in the model at different places, which made the test fail if the entities are refreshed from the db 

at first, I wanted to deprecate the option `auto_refresh_proxies` and default to true, but this could lead to :
- people who still don't define the option may have some trouble
- as well as people who specified it to `false` in the config: they would remove the option because of the deprecation, and the behavior will change implicitly.

What I propose is to make this explicit: let's force the user through deprecation to set this option to `true`, so they won't be surprised that some of their test fail. And let's deprecate the option in 2.0, where we won't use it anymore.
WDYT?
