### PR TITLE
refactor: change phpstan FactoryCollection return type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,6 +26,11 @@ parameters:
 			path: src/Factory.php
 
 		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\FactoryCollection\\:\\:create\\(\\) should return array\\<int, TObject of object\\> but returns array\\<int, \\(TObject of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TObject of object\\>\\>\\.$#"
+			count: 1
+			path: src/FactoryCollection.php
+
+		-
 			message: "#^Parameter \\#1 \\$min of function random_int expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/FactoryCollection.php
@@ -41,6 +46,16 @@ parameters:
 			path: src/FactoryCollection.php
 
 		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\Persistence\\\\PersistentObjectFactory\\:\\:__callStatic\\(\\) should return array\\<int, TModel of object\\> but returns array\\<int, \\(TModel of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\>\\.$#"
+			count: 1
+			path: src/Persistence/PersistentObjectFactory.php
+
+		-
+			message: "#^Method Zenstruck\\\\Foundry\\\\Persistence\\\\PersistentObjectFactory\\:\\:createSequence\\(\\) should return array\\<int, TModel of object\\> but returns array\\<int, \\(TModel of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\>\\.$#"
+			count: 1
+			path: src/Persistence/PersistentObjectFactory.php
+
+		-
 			message: "#^Should not use function \"debug_backtrace\", please change the code\\.$#"
 			count: 1
 			path: src/Persistence/PersistentObjectFactory.php
@@ -49,16 +64,6 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Persistence/PersistentObjectFactory.php
-
-		-
-			message: "#^Method Zenstruck\\\\Foundry\\\\Persistence\\\\PersistentProxyObjectFactory\\:\\:__callStatic\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\> but returns array\\<int, \\(TModel of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\>\\.$#"
-			count: 1
-			path: src/Persistence/PersistentProxyObjectFactory.php
-
-		-
-			message: "#^Method Zenstruck\\\\Foundry\\\\Persistence\\\\PersistentProxyObjectFactory\\:\\:createSequence\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\> but returns array\\<int, \\(TModel of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TModel of object\\>\\>\\.$#"
-			count: 1
-			path: src/Persistence/PersistentProxyObjectFactory.php
 
 		-
 			message: "#^Should not use function \"debug_backtrace\", please change the code\\.$#"
@@ -114,13 +119,3 @@ parameters:
 			message: "#^Parameter \\#1 \\$configuration of static method Zenstruck\\\\Foundry\\\\Factory\\<object\\>\\:\\:boot\\(\\) expects Zenstruck\\\\Foundry\\\\Configuration, object\\|null given\\.$#"
 			count: 1
 			path: src/ZenstruckFoundryBundle.php
-
-		-
-			message: "#^Function Zenstruck\\\\Foundry\\\\create_many\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TObject of object\\>\\> but returns array\\<int, \\(TObject of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TObject of object\\>\\>\\.$#"
-			count: 1
-			path: src/functions.php
-
-		-
-			message: "#^Function Zenstruck\\\\Foundry\\\\instantiate_many\\(\\) should return array\\<int, Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TObject of object\\>\\> but returns array\\<int, \\(TObject of object\\)\\|Zenstruck\\\\Foundry\\\\Persistence\\\\Proxy\\<TObject of object\\>\\>\\.$#"
-			count: 1
-			path: src/functions.php

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -187,7 +187,7 @@ class Factory
     /**
      * @param int|null $max If set, when created, the collection will be a random size between $min and $max
      *
-     * @return FactoryCollection<TObject>
+     * @return ($this is PersistentProxyObjectFactory ? FactoryCollection<Proxy<TObject>> : FactoryCollection<TObject>)
      */
     final public function many(int $min, ?int $max = null): FactoryCollection
     {
@@ -201,7 +201,7 @@ class Factory
     /**
      * @param iterable<array<string, mixed>>|callable(): iterable<array<string, mixed>> $sequence
      *
-     * @return FactoryCollection<TObject>
+     * @return ($this is PersistentProxyObjectFactory ? FactoryCollection<Proxy<TObject>> : FactoryCollection<TObject>)
      */
     final public function sequence(iterable|callable $sequence): FactoryCollection
     {

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -67,9 +67,7 @@ final class FactoryCollection implements \IteratorAggregate
     }
 
     /**
-     * @return list<TObject&Proxy<TObject>>|list<TObject>
-     *
-     * @phpstan-return ($noProxy is true ? list<TObject>: list<Proxy<TObject>>|list<TObject>)
+     * @return list<TObject>
      */
     public function create(
         array|callable $attributes = [],


### PR DESCRIPTION
I think this is a better type system around `FactoryCollection` 

the only problem of this solution is that in userland, for factory collections created from `PersistentProxyObjectFactory`, phpstan requires that you type it this way: `FactoryCollection<Proxy<SomeObject>>` 

but without this update, all objects created with `PersistentProxyObjectFactory::createMany()` (or `createSequence()`) is considered as NOT a proxy. 
ie: I had plenty of errors like this: 
> Call to an undefined method App\Domain\Programming|Zenstruck\Foundry\Persistence\Proxy<App\Domain\Programming>::object()


The PHPStan errors I added to the baseline are still internal to Foundry, and can be added safely