### PR TITLE
refactor: add BC layer for methods in Instantiator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/AnonymousFactoryGenerator.php
 
 		-
-			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string\\|null given\\.$#"
-			count: 1
-			path: src/Bundle/DependencyInjection/GlobalStatePass.php
-
-		-
 			message: "#^Parameter \\#1 \\$class of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getManagerForClass\\(\\) expects class\\-string, string given\\.$#"
 			count: 1
 			path: src/Configuration.php

--- a/src/Bundle/DependencyInjection/GlobalStatePass.php
+++ b/src/Bundle/DependencyInjection/GlobalStatePass.php
@@ -69,7 +69,7 @@ final class GlobalStatePass implements CompilerPassInterface
 
         $globalStateItemDefinition = $container->getDefinition($globalStateItem);
 
-        return (new \ReflectionClass($globalStateItemDefinition->getClass()))->hasMethod('__invoke');
+        return (new \ReflectionClass($globalStateItemDefinition->getClass()))->hasMethod('__invoke'); // @phpstan-ignore-line
     }
 
     private function isStandaloneStory(ContainerBuilder $container, string $globalStateItem): bool

--- a/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
+++ b/src/Bundle/DependencyInjection/ZenstruckFoundryExtension.php
@@ -100,11 +100,11 @@ final class ZenstruckFoundryExtension extends ConfigurableExtension
         $definition->setFactory([Instantiator::class, $withoutConstructor ? 'withoutConstructor' : 'withConstructor']);
 
         if ($config['allow_extra_attributes']) {
-            $definition->addMethodCall('allowExtraAttributes');
+            $definition->addMethodCall('allowExtra');
         }
 
         if ($config['always_force_properties']) {
-            $definition->addMethodCall('alwaysForceProperties');
+            $definition->addMethodCall('alwaysForce');
         }
     }
 

--- a/src/Instantiator.php
+++ b/src/Instantiator.php
@@ -54,7 +54,7 @@ final class Instantiator
 
         foreach ($attributes as $attribute => $value) {
             if (0 === \mb_strpos($attribute, 'optional:')) {
-                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtraAttributes() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtra() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
                 continue;
             }
 
@@ -75,7 +75,7 @@ final class Instantiator
             }
 
             if (0 === \mb_strpos($attribute, 'force:')) {
-                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+                trigger_deprecation('zenstruck\foundry', '1.5.0', 'Using "force:" property prefixes is deprecated, use Instantiator::alwaysForce() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
 
                 self::forceSet($object, \mb_substr($attribute, 6), $value);
 
@@ -135,14 +135,28 @@ final class Instantiator
      * Ignore attributes that can't be set to object.
      *
      * @param string[] $attributes The attributes you'd like the instantiator to ignore (if empty, ignore any extra)
+     *
+     * @deprecated Use self::allowExtra() instead
      */
     public function allowExtraAttributes(array $attributes = []): self
     {
-        if (empty($attributes)) {
+        trigger_deprecation('zenstruck/foundry', '1.37.0', 'Method "Instantiator::allowExtraAttributes()" is deprecated. Please use "Instantiator::allowExtra()" instead.');
+
+        return $this->allowExtra(...$attributes);
+    }
+
+    /**
+     * Ignore attributes that can't be set to object.
+     *
+     * @param string $parameters The attributes you'd like the instantiator to ignore (if empty, ignore any extra)
+     */
+    public function allowExtra(string ...$parameters): self
+    {
+        if (empty($parameters)) {
             $this->allowExtraAttributes = true;
         }
 
-        $this->extraAttributes = $attributes;
+        $this->extraAttributes = $parameters;
 
         return $this;
     }
@@ -151,8 +165,22 @@ final class Instantiator
      * Always force properties, never use setters (still uses constructor unless disabled).
      *
      * @param string[] $properties The properties you'd like the instantiator to "force set" (if empty, force set all)
+     *
+     * @deprecated Use self::alwaysForce() instead
      */
     public function alwaysForceProperties(array $properties = []): self
+    {
+        trigger_deprecation('zenstruck/foundry', '1.37.0', 'Method "Instantiator::alwaysForceProperties()" is deprecated. Please use "Instantiator::alwaysForce()" instead.');
+
+        return $this->alwaysForce(...$properties);
+    }
+
+    /**
+     * Always force properties, never use setters (still uses constructor unless disabled).
+     *
+     * @param string $properties The properties you'd like the instantiator to "force set" (if empty, force set all)
+     */
+    public function alwaysForce(string ...$properties): self
     {
         if (empty($properties)) {
             $this->alwaysForceProperties = true;

--- a/tests/Fixtures/Factories/CategoryFactory.php
+++ b/tests/Fixtures/Factories/CategoryFactory.php
@@ -34,7 +34,7 @@ final class CategoryFactory extends PersistentProxyObjectFactory
     {
         return $this
             ->instantiateWith(
-                Instantiator::withConstructor()->allowExtraAttributes(['extraPostsBeforeInstantiate', 'extraPostsAfterInstantiate'])
+                Instantiator::withConstructor()->allowExtra('extraPostsBeforeInstantiate', 'extraPostsAfterInstantiate')
             )
             ->beforeInstantiate(function(array $attributes): array {
                 if (isset($attributes['extraPostsBeforeInstantiate'])) {

--- a/tests/Fixtures/Factories/PostFactory.php
+++ b/tests/Fixtures/Factories/PostFactory.php
@@ -47,7 +47,7 @@ class PostFactory extends PersistentProxyObjectFactory
     {
         return $this
             ->instantiateWith(
-                Instantiator::withConstructor()->allowExtraAttributes(['extraCategoryBeforeInstantiate', 'extraCategoryAfterInstantiate'])
+                Instantiator::withConstructor()->allowExtra('extraCategoryBeforeInstantiate', 'extraCategoryAfterInstantiate')
             )
             ->beforeInstantiate(function(array $attributes): array {
                 if (isset($attributes['extraCategoryBeforeInstantiate'])) {

--- a/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
+++ b/tests/Unit/Bundle/DependencyInjection/ZenstruckFoundryExtensionTest.php
@@ -132,8 +132,8 @@ final class ZenstruckFoundryExtensionTest extends AbstractExtensionTestCase
             ],
         ]);
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('.zenstruck_foundry.default_instantiator', 'allowExtraAttributes');
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('.zenstruck_foundry.default_instantiator', 'alwaysForceProperties');
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('.zenstruck_foundry.default_instantiator', 'allowExtra');
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('.zenstruck_foundry.default_instantiator', 'alwaysForce');
 
         $instantiator = $this->container->get('.zenstruck_foundry.default_instantiator');
 

--- a/tests/Unit/InstantiatorTest.php
+++ b/tests/Unit/InstantiatorTest.php
@@ -164,10 +164,38 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
+     */
+    public function can_set_attributes_that_should_be_optional_legacy(): void
+    {
+        $object = Instantiator::withConstructor()->allowExtraAttributes(['extra'])([
+            'propB' => 'B',
+            'extra' => 'foo',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('constructor B', $object->getPropB());
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function can_always_allow_extra_attributes_legacy(): void
+    {
+        $object = Instantiator::withConstructor()->allowExtraAttributes()([
+            'propB' => 'B',
+            'extra' => 'foo',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('constructor B', $object->getPropB());
+    }
+
+    /**
+     * @test
      */
     public function can_set_attributes_that_should_be_optional(): void
     {
-        $object = Instantiator::withConstructor()->allowExtraAttributes(['extra'])([
+        $object = Instantiator::withConstructor()->allowExtra('extra')([
             'propB' => 'B',
             'extra' => 'foo',
         ], InstantiatorDummy::class);
@@ -183,7 +211,7 @@ final class InstantiatorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot set attribute "extra2" for object "Zenstruck\Foundry\Tests\Unit\InstantiatorDummy" (not public and no setter).');
 
-        Instantiator::withConstructor()->allowExtraAttributes(['extra1'])([
+        Instantiator::withConstructor()->allowExtra('extra1')([
             'propB' => 'B',
             'extra1' => 'foo',
             'extra2' => 'bar',
@@ -196,7 +224,7 @@ final class InstantiatorTest extends TestCase
      */
     public function can_prefix_extra_attribute_key_with_optional_to_avoid_exception(): void
     {
-        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtraAttributes() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "optional:" attribute prefixes is deprecated, use Instantiator::allowExtra() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
 
         $object = Instantiator::withConstructor()([
             'propB' => 'B',
@@ -211,7 +239,7 @@ final class InstantiatorTest extends TestCase
      */
     public function can_always_allow_extra_attributes(): void
     {
-        $object = Instantiator::withConstructor()->allowExtraAttributes()([
+        $object = Instantiator::withConstructor()->allowExtra()([
             'propB' => 'B',
             'extra' => 'foo',
         ], InstantiatorDummy::class);
@@ -240,10 +268,25 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
+     */
+    public function can_set_attributes_that_should_be_force_set_legacy(): void
+    {
+        $object = Instantiator::withoutConstructor()->alwaysForceProperties(['propD'])([
+            'propB' => 'B',
+            'propD' => 'D',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('setter B', $object->getPropB());
+        $this->assertSame('D', $object->getPropD());
+    }
+
+    /**
+     * @test
      */
     public function can_set_attributes_that_should_be_force_set(): void
     {
-        $object = Instantiator::withoutConstructor()->alwaysForceProperties(['propD'])([
+        $object = Instantiator::withoutConstructor()->alwaysForce('propD')([
             'propB' => 'B',
             'propD' => 'D',
         ], InstantiatorDummy::class);
@@ -278,7 +321,7 @@ final class InstantiatorTest extends TestCase
      */
     public function prefixing_attribute_key_with_force_sets_the_property_directly(): void
     {
-        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForce() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
 
         $object = Instantiator::withConstructor()([
             'propA' => 'A',
@@ -300,7 +343,7 @@ final class InstantiatorTest extends TestCase
      */
     public function prefixing_snake_case_attribute_key_with_force_sets_the_property_directly(): void
     {
-        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForce() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
 
         $object = Instantiator::withConstructor()([
             'prop_a' => 'A',
@@ -322,7 +365,7 @@ final class InstantiatorTest extends TestCase
      */
     public function prefixing_kebab_case_attribute_key_with_force_sets_the_property_directly(): void
     {
-        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForce() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
 
         $object = Instantiator::withConstructor()([
             'prop-a' => 'A',
@@ -344,7 +387,7 @@ final class InstantiatorTest extends TestCase
      */
     public function prefixing_invalid_attribute_key_with_force_throws_exception(): void
     {
-        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForceProperties() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
+        $this->expectDeprecation('Since zenstruck\foundry 1.5.0: Using "force:" property prefixes is deprecated, use Instantiator::alwaysForce() instead (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#instantiation).');
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Class "Zenstruck\Foundry\Tests\Unit\InstantiatorDummy" does not have property "extra".');
 
@@ -425,10 +468,30 @@ final class InstantiatorTest extends TestCase
 
     /**
      * @test
+     * @group legacy
+     */
+    public function can_use_always_force_mode_legacy(): void
+    {
+        $object = Instantiator::withConstructor()->alwaysForceProperties()([
+            'propA' => 'A',
+            'propB' => 'B',
+            'propC' => 'C',
+            'propD' => 'D',
+        ], InstantiatorDummy::class);
+
+        $this->assertSame('A', $object->propA);
+        $this->assertSame('A', $object->getPropA());
+        $this->assertSame('constructor B', $object->getPropB());
+        $this->assertSame('constructor C', $object->getPropC());
+        $this->assertSame('D', $object->getPropD());
+    }
+
+    /**
+     * @test
      */
     public function can_use_always_force_mode(): void
     {
-        $object = Instantiator::withConstructor()->alwaysForceProperties()([
+        $object = Instantiator::withConstructor()->alwaysForce()([
             'propA' => 'A',
             'propB' => 'B',
             'propC' => 'C',
@@ -494,7 +557,7 @@ final class InstantiatorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Class "Zenstruck\Foundry\Tests\Unit\InstantiatorDummy" does not have property "extra".');
 
-        Instantiator::withConstructor()->alwaysForceProperties()([
+        Instantiator::withConstructor()->alwaysForce()([
             'propB' => 'B',
             'extra' => 'foo',
         ], InstantiatorDummy::class);
@@ -522,7 +585,7 @@ final class InstantiatorTest extends TestCase
      */
     public function always_force_mode_with_allow_extra_attributes_mode(): void
     {
-        $object = Instantiator::withConstructor()->allowExtraAttributes()->alwaysForceProperties()([
+        $object = Instantiator::withConstructor()->allowExtra()->alwaysForce()([
             'propB' => 'B',
             'propD' => 'D',
             'extra' => 'foo',
@@ -536,7 +599,7 @@ final class InstantiatorTest extends TestCase
      */
     public function always_force_mode_can_set_parent_class_properties(): void
     {
-        $object = Instantiator::withConstructor()->alwaysForceProperties()([
+        $object = Instantiator::withConstructor()->alwaysForce()([
             'propA' => 'A',
             'propB' => 'B',
             'propC' => 'C',
@@ -559,7 +622,7 @@ final class InstantiatorTest extends TestCase
     {
         $this->expectException(\Throwable::class);
 
-        Instantiator::withConstructor()->allowExtraAttributes()([
+        Instantiator::withConstructor()->allowExtra()([
             'propB' => 'B',
             'propF' => 'F',
         ], InstantiatorDummy::class);


### PR DESCRIPTION
I was pretty certain this was already done but... nope!

provides BC layer for `Instantiator::allowExtra()` and `Instantiator::alwaysForce()`

I've not made anything about the namespace change (`\Zenstruck\Foundry\Instantiator` => `\Zenstruck\Foundry\Object\Instantiator`) because we still need to figure out how this should be made