### PR TITLE
feat: introduce rector rules :tada: 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,6 @@
 /phpunit-dama-doctrine.xml.dist export-ignore
 /phpunit.xml.dist               export-ignore
 /tests                          export-ignore
+/utils/rector/tests             export-ignore
+/utils/rector/composer.json     export-ignore
+/utils/rector/phpunit.xml.dist  export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,30 @@ jobs:
       - name: Run Psalm on factories generated with maker
         run: bin/tools/psalm/vendor/vimeo/psalm/psalm
 
+  test-rector-rules:
+    name: Test rector rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --prefer-dist
+          working-directory: "./utils/rector"
+
+      - name: Test
+        run: vendor/bin/phpunit
+        shell: bash
+        working-directory: "./utils/rector"
+
   fixcs:
     name: Run php-cs-fixer
     needs: sync-with-template

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /.env.local
 /docker-compose.override.yaml
 /tests/Fixtures/Migrations/
+/utils/rector/vendor
+/utils/rector/.phpunit.result.cache
+/utils/rector/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
         "doctrine/mongodb-odm": "2.5.0"
     },
     "autoload": {
-        "psr-4": {"Zenstruck\\Foundry\\": "src/"},
+        "psr-4": {
+            "Zenstruck\\Foundry\\": "src/",
+            "Zenstruck\\Foundry\\Utils\\Rector\\": "utils/rector/src/"
+        },
         "files": [
             "src/functions.php",
             "src/Persistence/functions.php"

--- a/utils/rector/composer.json
+++ b/utils/rector/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "zenstruck/foundry-rector",
+    "autoload": {
+        "psr-4": {
+            "Zenstruck\\Foundry\\Utils\\Rector\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Zenstruck\\Foundry\\Utils\\Rector\\Tests\\": "tests/"
+        }
+    },
+    "authors": [
+        {
+            "name": "Nicolas PHILIPPE",
+            "email": "nikophil@gmail.com"
+        }
+    ],
+    "require-dev": {
+        "rector/rector": "^0.18.13",
+        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan-doctrine": "^1.3",
+        "zenstruck/foundry": "dev-1.x-bc",
+        "symfony/var-dumper": "^7.0",
+        "doctrine/orm": "^2.17",
+        "symfony/framework-bundle": "^7.0"
+    },
+    "require": {
+        "symfony/cache": "^7.0"
+    }
+}

--- a/utils/rector/config/foundry-set.php
+++ b/utils/rector/config/foundry-set.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\AddProxyToFactoryCollectionTypeInPhpDoc;
+use Zenstruck\Foundry\Utils\Rector\ChangeDisableEnablePersist;
+use Zenstruck\Foundry\Utils\Rector\ChangeFactoryBaseClass;
+use Zenstruck\Foundry\Utils\Rector\ChangeFactoryMethodCalls;
+use Zenstruck\Foundry\Utils\Rector\ChangeFunctionsCalls;
+use Zenstruck\Foundry\Utils\Rector\ChangeInstantiatorMethodCalls;
+use Zenstruck\Foundry\Utils\Rector\ChangeLegacyClassImports;
+use Zenstruck\Foundry\Utils\Rector\ChangeProxyMethodCalls;
+use Zenstruck\Foundry\Utils\Rector\PersistenceResolver;
+use Zenstruck\Foundry\Utils\Rector\RemoveProxyRealObjectMethodCallsForNotProxifiedObjects;
+use Zenstruck\Foundry\Utils\Rector\RuleRequirementsChecker;
+
+return static function (RectorConfig $rectorConfig): void {
+    RuleRequirementsChecker::checkRequirements();
+
+    /**
+     * This must be overridden in user's `rector.php` to provide a path to the object manager
+     * @see https://github.com/phpstan/phpstan-doctrine#configuration
+     */
+    $rectorConfig->singleton(PersistenceResolver::class);
+
+    $rectorConfig->rules([
+        ChangeFactoryBaseClass::class,
+        ChangeLegacyClassImports::class,
+        RemoveProxyRealObjectMethodCallsForNotProxifiedObjects::class,
+        ChangeInstantiatorMethodCalls::class,
+        ChangeDisableEnablePersist::class,
+        AddProxyToFactoryCollectionTypeInPhpDoc::class,
+        ChangeFactoryMethodCalls::class,
+        ChangeFunctionsCalls::class,
+        ChangeProxyMethodCalls::class,
+    ]);
+};

--- a/utils/rector/phpunit.xml.dist
+++ b/utils/rector/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.readthedocs.io/en/9.5/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/utils/rector/src/AddProxyToFactoryCollectionTypeInPhpDoc.php
+++ b/utils/rector/src/AddProxyToFactoryCollectionTypeInPhpDoc.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Core\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+final class AddProxyToFactoryCollectionTypeInPhpDoc extends AbstractRector
+{
+    private PersistenceResolver $persistenceResolver;
+
+    public function __construct(
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private StaticTypeMapper $staticTypeMapper,
+        private DocBlockUpdater $docBlockUpdater,
+        PersistenceResolver|null $persistenceResolver,
+    ) {
+        $this->persistenceResolver = $persistenceResolver ?? new PersistenceResolver();
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add "Proxy" generic type to FactoryCollection in docblock if missing. This will only affect persistent objects using proxy.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @param FactoryCollection<SomeObject> $factoryCollection
+                     */
+                    public function foo(FactoryCollection $factoryCollection);
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @param FactoryCollection<\Zenstruck\Foundry\Persistence\Proxy<SomeObject>> $factoryCollection
+                     */
+                    public function foo(FactoryCollection $factoryCollection);
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\ClassMethod::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return match ($node::class) {
+            Node\Stmt\ClassMethod::class => $this->changeParamFactoryCollection($node) ? $node : null,
+            default => null
+        };
+    }
+
+    private function changeParamFactoryCollection(Node\Stmt\ClassMethod $node): bool
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+
+        if (!$phpDocInfo) {
+            return false;
+        }
+
+        $hasChanged = false;
+
+        $phpDocNode = $phpDocInfo->getPhpDocNode();
+        foreach ($phpDocNode->children as $phpDocChildNode) {
+            // assert we have a param with format `@param FactoryCollection<Something>`
+            if (!$phpDocChildNode instanceof PhpDocTagNode
+                || $phpDocChildNode->name !== '@param'
+                || !$phpDocChildNode->value instanceof ParamTagValueNode
+                || !($genericTypeNode = $phpDocChildNode->value->type) instanceof GenericTypeNode
+                || !str_contains((string)$phpDocChildNode, 'FactoryCollection<')
+                || count($genericTypeNode->genericTypes) !== 1
+                || $genericTypeNode->genericTypes[0] instanceof GenericTypeNode
+            ) {
+                continue;
+            }
+
+            // assert we really have a `FactoryCollection` from foundry
+            if ($this->getFullyQualifiedClassName($genericTypeNode->type, $node) !== FactoryCollection::class) {
+                continue;
+            }
+
+            // assert generic type will effectively come from PersistentProxyObjectFactory
+            $targetClassName = $this->getFullyQualifiedClassName($genericTypeNode->genericTypes[0], $node);
+            if (!$targetClassName || !$this->persistenceResolver->shouldUseProxyFactory($targetClassName)) {
+                continue;
+            }
+
+            $hasChanged = true;
+            $phpDocChildNode->value->type->genericTypes = [new GenericTypeNode(new IdentifierTypeNode('\\'.Proxy::class), $genericTypeNode->genericTypes)];
+        }
+
+        if ($hasChanged) {
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+        }
+
+        return $hasChanged;
+    }
+
+    /**
+     * @return class-string
+     */
+    private function getFullyQualifiedClassName(TypeNode $typeNode, Node $node): string|null
+    {
+        $type = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $node);
+
+        return match ($type::class) {
+            FullyQualifiedObjectType::class => $type->getClassName(),
+            ShortenedObjectType::class => $type->getFullyQualifiedName(),
+            default => null,
+        };
+    }
+}

--- a/utils/rector/src/ChangeDisableEnablePersist.php
+++ b/utils/rector/src/ChangeDisableEnablePersist.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PHPStan\Type\ThisType;
+use PHPUnit\Framework\TestCase;
+use Rector\Core\Rector\AbstractRector;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ChangeDisableEnablePersist extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Deprecated functions Factories::disablePersist() should either be moved to new persistence function if called in a KernelTestCase or removed otherwise.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    class SomeTest extends TestCase
+                    {
+                        use Factories;
+
+                        protected function setUp(): void
+                        {
+                            $this->enablePersist();
+                            $this->disablePersist();
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                    class SomeTest extends TestCase
+                    {
+                        use Factories;
+
+                        protected function setUp(): void
+                        {
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    class SomeTest extends TestCase
+                    {
+                        use Factories;
+
+                        protected function setUp(): void
+                        {
+                            $this->enablePersist();
+                            $this->disablePersist();
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                    class SomeTest extends TestCase
+                    {
+                        use Factories;
+
+                        protected function setUp(): void
+                        {
+                            \Zenstruck\Foundry\Persistence\enable_persisting();
+                            \Zenstruck\Foundry\Persistence\disable_persisting();
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Expression::class];
+    }
+
+    /**
+     * @param Node\Stmt\Expression $node
+     */
+    public function refactor(Node $node): Node|int|null
+    {
+        $expr = $node->expr;
+
+        if (!$expr instanceof Node\Expr\MethodCall) {
+            return null;
+        }
+
+        if ($this->isCallOnThisInPhpUnitTestCase($expr)) {
+            return match ((string)$expr->name) {
+                'disablePersist', 'enablePersist' => NodeTraverser::REMOVE_NODE,
+                default => null,
+            };
+        } elseif ($this->isCallOnThisInPhpUnitKernelTestCase($expr)) {
+            return match ((string)$expr->name) {
+                'disablePersist' => new Node\Stmt\Expression(
+                    new Node\Expr\FuncCall(
+                        new Node\Name('\Zenstruck\Foundry\Persistence\disable_persisting'), $node->expr->args
+                    )
+                ),
+                'enablePersist' => new Node\Stmt\Expression(
+                    new Node\Expr\FuncCall(
+                        new Node\Name('\Zenstruck\Foundry\Persistence\enable_persisting'), $node->expr->args
+                    )
+                ),
+                default => null,
+            };
+        }
+
+        return null;
+    }
+
+    private function isCallOnThisInPhpUnitTestCase(Node\Expr\MethodCall $node): bool
+    {
+        $type = $this->getType($node->var);
+
+        return $type instanceof ThisType
+            && is_a($type->getClassName(), TestCase::class, allow_string: true)
+            && !is_a($type->getClassName(), KernelTestCase::class, allow_string: true);
+    }
+
+    private function isCallOnThisInPhpUnitKernelTestCase(Node\Expr\MethodCall $node): bool
+    {
+        $type = $this->getType($node->var);
+
+        return $type instanceof ThisType
+            && is_a($type->getClassName(), KernelTestCase::class, allow_string: true);
+    }
+}

--- a/utils/rector/src/ChangeFactoryBaseClass.php
+++ b/utils/rector/src/ChangeFactoryBaseClass.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ExtendsTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\ObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\RepositoryDecorator;
+
+final class ChangeFactoryBaseClass extends AbstractRector
+{
+    public function __construct(
+        private PhpDocTagRemover $phpDocTagRemover,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private DocBlockUpdater $docBlockUpdater,
+        private PersistenceResolver $persistenceResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            <<<DESCRIPTION
+            Changes legacy ModelFactory into new factories. This implies few things:
+              - changes the base class:
+                  - `ObjectFactory` will be chosen if target class is not an entity (ORM) or a document (ODM)
+                  - `PersistentProxyObjectFactory` will be chosen otherwise (this rector currently doesn't use `PersistentProxyObjectFactory`)
+              - migrates `getDefaults()`, `class()` and `initialize()` methods to new name/prototype
+              - modifies PhpDoc:
+                - updates `@extends` annotation
+                - removes `@method` annotations when using `ObjectFactory`
+                - change `@method` annotations for method `repository()` when using `PersistentProxyObjectFactory`. Otherwise it breaks type system
+            DESCRIPTION,
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @extends ModelFactory<DummyObject>
+                     *
+                     * @method        DummyObject|Proxy     create(array|callable $attributes = [])
+                     * @method static DummyObject|Proxy     createOne(array $attributes = [])
+                     * @method static DummyObject[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+                     * @method static DummyObject[]|Proxy[] createSequence(iterable|callable $sequence)
+                     */
+                    final class DummyObjectFactory extends ModelFactory
+                    {
+                        protected function getDefaults(): array
+                        {
+                            return [];
+                        }
+
+                        protected function initialize(): self
+                        {
+                            return $this;
+                        }
+
+                        protected static function getClass(): string
+                        {
+                            return DummyObject::class;
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @extends \Zenstruck\Foundry\ObjectFactory<DummyObject>
+                     */
+                    final class DummyObjectFactory extends \Zenstruck\Foundry\ObjectFactory
+                    {
+                        protected function defaults(): array
+                        {
+                            return [];
+                        }
+
+                        protected function initialize(): static
+                        {
+                            return $this;
+                        }
+
+                        public static function class(): string
+                        {
+                            return DummyObject::class;
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @extends ModelFactory<DummyPersistentObject>
+                     *
+                     * @method static RepositoryProxy|EntityRepository repository()
+                     * @method static RepositoryProxy repository()
+                     * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+                     *
+                     * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+                     * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+                     * @phpstan-method static RepositoryProxy<DummyPersistentObject> repository()
+                     */
+                    final class DummyPersistentProxyFactory extends ModelFactory
+                    {
+                        protected function getDefaults(): array
+                        {
+                            return [];
+                        }
+
+                        protected function initialize(): self
+                        {
+                            return $this;
+                        }
+
+                        protected static function getClass(): string
+                        {
+                            return DummyPersistentObject::class;
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    /**
+                     * @extends \Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory<DummyPersistentObject>
+                     *
+                     * @method static EntityRepository|\Zenstruck\Foundry\Persistence\RepositoryDecorator repository()
+                     * @method static \Zenstruck\Foundry\Persistence\RepositoryDecorator repository()
+                     * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+                     *
+                     * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+                     * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+                     * @phpstan-method static \Zenstruck\Foundry\Persistence\RepositoryDecorator<DummyPersistentObject> repository()
+                     */
+                    final class DummyPersistentProxyFactory extends \Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory
+                    {
+                        protected function defaults(): array
+                        {
+                            return [];
+                        }
+
+                        protected function initialize(): static
+                        {
+                            return $this;
+                        }
+
+                        public static function class(): string
+                        {
+                            return DummyPersistentObject::class;
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    /**
+     * @param Node\Stmt\Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isObjectType($node, new ObjectType(ModelFactory::class))) {
+            return null;
+        }
+
+        $this->changeBaseClass($node);
+        $this->changeFactoryMethods($node);
+
+        return $node;
+    }
+
+    private function changeBaseClass(Node\Stmt\Class_ $node): Node\Stmt\Class_|null
+    {
+        if ($this->persistenceResolver->shouldTransformFactoryIntoObjectFactory($this->getName($node))) {
+            $newFactoryClass = '\\' . ObjectFactory::class;
+            $node->extends = new Node\Name($newFactoryClass);
+        } else {
+            $newFactoryClass = '\\' . PersistentProxyObjectFactory::class;
+            $node->extends = new Node\Name($newFactoryClass);
+        }
+
+        $this->updatePhpDoc($node, $newFactoryClass);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    /**
+     * - updates `@extends` annotation
+     * - removes `@method` annotations when not using proxies anymore
+     * - change `@method` annotations for method `repository()` otherwise it breaks type system
+     */
+    private function updatePhpDoc(Node\Stmt\Class_ $node, string $newFactoryClass): void
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+
+        if (!$phpDocInfo) {
+            return;
+        }
+
+        $phpDocNode = $phpDocInfo->getPhpDocNode();
+        foreach ($phpDocNode->children as $phpDocChildNode) {
+            if (!$phpDocChildNode instanceof PhpDocTagNode
+                || $phpDocChildNode->name !== '@extends'
+                || !$phpDocChildNode->value instanceof ExtendsTagValueNode
+                || count($phpDocChildNode->value->type->genericTypes) !== 1
+            ) {
+                continue;
+            }
+
+            $phpDocChildNode->value->type->type = new IdentifierTypeNode($newFactoryClass);
+            break;
+        }
+
+        if ($newFactoryClass === '\\' . ObjectFactory::class) {
+            $this->phpDocTagRemover->removeByName($phpDocInfo, 'method');
+            $this->phpDocTagRemover->removeByName($phpDocInfo, 'phpstan-method');
+            $this->phpDocTagRemover->removeByName($phpDocInfo, 'psalm-method');
+        } else {
+            /** @var MethodTagValueNode[] $methodNodes */
+            $methodNodes = [
+                ...$phpDocNode->getMethodTagValues(),
+                ...$phpDocNode->getMethodTagValues('@phpstan-method'),
+                ...$phpDocNode->getMethodTagValues('@psalm-method'),
+            ];
+
+            foreach ($methodNodes as $methodNode) {
+                if (!str_contains((string) $methodNode->returnType, 'RepositoryProxy')) {
+                    continue;
+                }
+
+                match(true){
+                    $methodNode->returnType instanceof IdentifierTypeNode => $methodNode->returnType = new IdentifierTypeNode('\\'.RepositoryDecorator::class),
+                    $methodNode->returnType instanceof GenericTypeNode => $methodNode->returnType->type = new IdentifierTypeNode('\\'.RepositoryDecorator::class),
+                    $methodNode->returnType instanceof UnionTypeNode => (static function() use ($methodNode){
+                        foreach ($methodNode->returnType->types as $key => $type) {
+                            if ($type instanceof IdentifierTypeNode && str_contains($type->name, 'RepositoryProxy')) {
+                                // does not work by just updating node's name
+                                unset($methodNode->returnType->types[$key]);
+                                $methodNode->returnType->types[] = new IdentifierTypeNode('\\'.RepositoryDecorator::class);
+                            }
+                        }
+                    })(),
+                    default => null
+                };
+            }
+        }
+    }
+
+    private function changeFactoryMethods(Node\Stmt\Class_ $node): void
+    {
+        foreach ($node->getMethods() as $method) {
+            $methodName = $this->getName($method);
+
+            if ($methodName == 'getDefaults') {
+                $method->name = new Node\Identifier('defaults');
+            }
+
+            if ($methodName == 'getClass') {
+                $method->name = new Node\Identifier('class');
+                $method->flags = Class_::MODIFIER_PUBLIC | Class_::MODIFIER_STATIC;
+            }
+
+            if ($methodName == 'initialize') {
+                $method->returnType = new Node\Identifier('static');
+            }
+        }
+    }
+}

--- a/utils/rector/src/ChangeFactoryMethodCalls.php
+++ b/utils/rector/src/ChangeFactoryMethodCalls.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\Factory;
+
+final class ChangeFactoryMethodCalls extends AbstractRector
+{
+    public function __construct(
+        private PersistenceResolver $persistenceResolver,
+    )
+    {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change old factory methods to the new ones.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    protected function someMethod()
+                    {
+                        DummyObjectFactory::new()->withAttributes(['publish' => true]);
+                    }
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    protected function someMethod()
+                    {
+                        DummyObjectFactory::new()->with(['publish' => true]);
+                    }
+                    CODE_SAMPLE
+                ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    final class SomeFactory extends ObjectFactory
+                    {
+                        // mandatory functions...
+
+                        public function published(): static
+                        {
+                            return $this->addState(['publish' => true]);
+                        }
+                    }
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    final class SomeFactory extends ObjectFactory
+                    {
+                        // mandatory functions...
+
+                        public function published(): static
+                        {
+                            return $this->with(['publish' => true]);
+                        }
+                    }
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): Node|int|null
+    {
+        if (!$this->isObjectType($node->var, new ObjectType(Factory::class))) {
+            return null;
+        }
+
+        if (in_array((string)$node->name, ['addState', 'withAttributes'], true)) {
+            $node->name = new Node\Identifier('with');
+
+            return $node;
+        }
+
+        if ((string)$node->name === 'withoutPersisting') {
+            $type = $this->getType($node->var);
+            $classes = $type->getObjectClassNames();
+            if (\count($classes) === 1 &&  $this->persistenceResolver->shouldTransformFactoryIntoObjectFactory($classes[0])) {
+                return $node->var;
+            }
+
+           return null;
+        }
+
+        return null;
+    }
+}

--- a/utils/rector/src/ChangeFunctionsCalls.php
+++ b/utils/rector/src/ChangeFunctionsCalls.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ThisType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Test\TestState;
+use Zenstruck\Foundry\Test\UnitTestConfig;
+
+final class ChangeFunctionsCalls extends AbstractRector
+{
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\FuncCall::class, Node\Expr\StaticCall::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change method calls of legacy functions and static calls.',
+            [
+                new CodeSample(
+                    <<<CODE_SAMPLE
+                    use Zenstruck\Foundry\Factory;
+                    use Zenstruck\Foundry\Test\TestState;
+                    use function Zenstruck\Foundry\create;
+                    use function Zenstruck\Foundry\instantiate;
+                    use function Zenstruck\Foundry\repository;
+                    create(SomeClass::class, []);
+                    instantiate(SomeClass::class, ['published' => true]);
+                    repository(\$someObject);
+                    Factory::delayFlush(static fn() => true);
+                    TestState::configure(faker: null);
+                    CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                    \Zenstruck\Foundry\Persistence\persist(SomeClass::class, []);
+                    \Zenstruck\Foundry\object(SomeClass::class, ['published' => true]);
+                    \Zenstruck\Foundry\Persistence\repository(\$someObject);
+                    \Zenstruck\Foundry\Persistence\flush_after(static fn() => true);
+                    \Zenstruck\Foundry\Test\UnitTestConfig::configure(faker: null);
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function refactor(Node $node): Node|int|null
+    {
+        return match ($node::class) {
+            Node\Expr\FuncCall::class => $this->replaceFunctions($node),
+            Node\Expr\StaticCall::class => $this->replaceLegacyMethodCalls($node),
+            default => null
+        };
+    }
+
+    private function replaceFunctions(Node\Expr\FuncCall $node): Node|null
+    {
+        if (!$node->name instanceof Node\Name) {
+            return null;
+        }
+
+        switch ((string)$node->name) {
+            case 'Zenstruck\Foundry\create':
+                $node->name = new Node\Name('\Zenstruck\Foundry\Persistence\persist');
+                return $node;
+            case 'Zenstruck\Foundry\instantiate':
+                $node->name = new Node\Name('\Zenstruck\Foundry\object');
+                return $node;
+            case 'Zenstruck\Foundry\repository':
+                $node->name = new Node\Name('\Zenstruck\Foundry\Persistence\repository');
+                return $node;
+            default:
+                return null;
+        }
+    }
+
+    private function replaceLegacyMethodCalls(Node\Expr\StaticCall $node): Node|null
+    {
+        if (
+            $node->name instanceof Identifier
+            && (string)$node->name === 'delayFlush'
+            && $node->class instanceof Node\Name
+            && is_a((string)$node->class, Factory::class, allow_string: true)
+        ) {
+            return new Node\Expr\FuncCall(new Node\Name('\Zenstruck\Foundry\Persistence\flush_after'), $node->args);
+        }
+
+        if (
+            $node->name instanceof Identifier
+            && (string)$node->name === 'configure'
+            && $node->class instanceof Node\Name
+            && (string)$node->class === TestState::class
+        ) {
+            return new Node\Expr\StaticCall(new Node\Name('\\' . UnitTestConfig::class), 'configure', $node->args);
+        }
+
+        return null;
+    }
+}

--- a/utils/rector/src/ChangeInstantiatorMethodCalls.php
+++ b/utils/rector/src/ChangeInstantiatorMethodCalls.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractScopeAwareRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ObjectFactory;
+
+final class ChangeInstantiatorMethodCalls extends AbstractScopeAwareRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Create Instantiator with named constructor + change legacy methods.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    (new Instantiator())
+                        ->allowExtraAttributes(['some', 'fields'])
+                        ->alwaysForceProperties(['other', 'fields'])
+                        ->allowExtraAttributes()
+                        ->alwaysForceProperties()
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    (\Zenstruck\Foundry\Object\Instantiator::withConstructor())
+                        ->allowExtra(...['some', 'fields'])
+                        ->alwaysForce(...['other', 'fields'])
+                        ->allowExtra()
+                        ->alwaysForce()
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class, Node\Expr\New_::class];
+    }
+
+    public function refactorWithScope(Node $node, Scope $scope)
+    {
+        return match(true){
+            $node instanceof Node\Expr\MethodCall => $this->changeMethodCalls($node),
+            $node instanceof Node\Expr\New_ => $this->useNamedConstructor($node, $scope),
+            default => null
+        };
+    }
+
+    /**
+     * We cannot remove `->withoutConstructor()` calls without risk, so users should rely on deprecations
+     */
+    private function changeMethodCalls(Node\Expr\MethodCall $node): Node|null
+    {
+        if (!$this->isObjectType($node->var, new ObjectType(Instantiator::class))) {
+            return null;
+        }
+
+        switch((string)$node->name){
+            case 'allowExtraAttributes':
+                $node->name = new Node\Identifier('allowExtra');
+                if (count($node->args) === 1) {
+                    $node->args[0]->unpack = true;
+                }
+
+                return $node;
+            case 'alwaysForceProperties':
+                $node->name = new Node\Identifier('alwaysForce');
+                if (count($node->args) === 1) {
+                    $node->args[0]->unpack = true;
+                }
+
+                return $node;
+            default: return null;
+        }
+    }
+
+    private function useNamedConstructor(Node\Expr\New_ $node, Scope $scope): Node|null
+    {
+        if (!$node->class instanceof FullyQualified) {
+            return null;
+        }
+
+        if (!is_a($node->class->toString(), Instantiator::class, allow_string: true)) {
+            return null;
+        }
+
+        $factoryClass = $scope->getClassReflection()?->getName();
+        if ($factoryClass && is_a($factoryClass, ObjectFactory::class, allow_string: true)) {
+            $targetClass = is_a($factoryClass, ModelFactory::class, allow_string: true)
+                ? (new \ReflectionClass($factoryClass))->getMethod('getClass')->invoke(null)
+                : $factoryClass::class();
+            $targetClassConstructorIsPublic = (new \ReflectionClass($targetClass))->getConstructor()?->isPublic() ?? true;
+
+            if (!$targetClassConstructorIsPublic) {
+                /**
+                 * The only case where we can safely use `withoutConstructor()` is when target's class' constructor
+                 * is not public: foundry 1.x fallbacks on "withoutConstructor" behavior,
+                 * while foundry 2 throws an exception.
+                 */
+                return new Node\Expr\StaticCall(new Node\Name('\\'.Instantiator::class), 'withoutConstructor');
+            }
+        }
+
+        return new Node\Expr\StaticCall(new Node\Name('\\'.Instantiator::class), 'withConstructor');
+    }
+}

--- a/utils/rector/src/ChangeLegacyClassImports.php
+++ b/utils/rector/src/ChangeLegacyClassImports.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\RepositoryAssertions;
+use Zenstruck\Foundry\Persistence\RepositoryDecorator;
+
+/**
+ * Let's only change type hints in "use" statements
+ *
+ * We don't check for FQCN which would be used directly in PHPdoc, return types and parameter types,
+ * that would increase the complexity by a lot, for something people are not very likely to use.
+ */
+final class ChangeLegacyClassImports extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change FQCN in imports for some deprecated classes with their replacements.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    use Zenstruck\Foundry\Proxy;
+                    use Zenstruck\Foundry\Instantiator;
+                    use Zenstruck\Foundry\RepositoryProxy;
+                    use Zenstruck\Foundry\RepositoryAssertions;
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    use Zenstruck\Foundry\Persistence\Proxy;
+                    use Zenstruck\Foundry\Object\Instantiator;
+                    use Zenstruck\Foundry\Persistence\RepositoryDecorator;
+                    use Zenstruck\Foundry\Persistence\RepositoryAssertions;
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\UseUse::class];
+    }
+
+    /**
+     * @param Node\Stmt\UseUse $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        switch((string)$node->name){
+            case \Zenstruck\Foundry\Proxy::class:
+                $node->name = new Node\Name(Proxy::class);
+                return $node;
+            case \Zenstruck\Foundry\Instantiator::class:
+                $node->name = new Node\Name(Instantiator::class);
+                return $node;
+            case \Zenstruck\Foundry\RepositoryProxy::class:
+                $node->name = new Node\Name(RepositoryDecorator::class);
+                return $node;
+            case \Zenstruck\Foundry\RepositoryAssertions::class:
+                $node->name = new Node\Name(RepositoryAssertions::class);
+                return $node;
+            default: return null;
+        }
+    }
+}

--- a/utils/rector/src/ChangeProxyMethodCalls.php
+++ b/utils/rector/src/ChangeProxyMethodCalls.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+// we're not using Rector's built-in rule RenameMethodRector because it does not support NullsafeMethodCall
+final class ChangeProxyMethodCalls extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+
+        return new RuleDefinition(
+            'Change from deprecated proxy methods to new methods.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    $proxy->object();
+                    $proxy->save();
+                    $proxy->remove();
+                    $proxy->refresh();
+                    $proxy->forceSet();
+                    $proxy->get();
+                    $proxy->repository();
+                    $proxy->enableAutoRefresh();
+                    $proxy->disableAutoRefresh();
+                    $proxy->withoutAutoRefresh();
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    $proxy->_real();
+                    $proxy->_save();
+                    $proxy->_delete();
+                    $proxy->_refresh();
+                    $proxy->_set();
+                    $proxy->_get();
+                    $proxy->_repository();
+                    $proxy->_enableAutoRefresh();
+                    $proxy->_disableAutoRefresh();
+                    $proxy->_withoutAutoRefresh();
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class, Node\Expr\NullsafeMethodCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall|Node\Expr\NullsafeMethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isObjectType($node->var, new ObjectType(Proxy::class)) && !$this->isObjectType($node->var, new ObjectType(\Zenstruck\Foundry\Proxy::class))) {
+            return null;
+        }
+
+        switch((string)$node->name){
+            case 'object':
+                $node->name = new Node\Identifier('_real');
+                return $node;
+            case 'save':
+                $node->name = new Node\Identifier('_save');
+                return $node;
+            case 'remove':
+                $node->name = new Node\Identifier('_delete');
+                return $node;
+            case 'refresh':
+                $node->name = new Node\Identifier('_refresh');
+                return $node;
+            case 'forceSet':
+                $node->name = new Node\Identifier('_set');
+                return $node;
+            case 'get':
+                $node->name = new Node\Identifier('_get');
+                return $node;
+            case 'repository':
+                $node->name = new Node\Identifier('_repository');
+                return $node;
+            case 'enableAutoRefresh':
+                $node->name = new Node\Identifier('_enableAutoRefresh');
+                return $node;
+            case 'disableAutoRefresh':
+                $node->name = new Node\Identifier('_disableAutoRefresh');
+                return $node;
+            case 'withoutAutoRefresh':
+                $node->name = new Node\Identifier('_withoutAutoRefresh');
+                return $node;
+            default: return null;
+        }
+    }
+}

--- a/utils/rector/src/PersistenceResolver.php
+++ b/utils/rector/src/PersistenceResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\ObjectFactory;
+
+/**
+ * This class will guess if a target class is persisted.
+ * This leverages phpstan/phpstan-doctrine.
+ *
+ * By default it only uses AttributeDriver or AnnotationDriver, but one can provide an "objectManagerLoader"
+ * which can read any Doctrine's mapping (even the ones declared outside the entities)
+ *
+ * @see https://github.com/phpstan/phpstan-doctrine#configuration
+ */
+final class PersistenceResolver
+{
+    /** @var array<class-string<ObjectFactory>, class-string> */
+    private array $factoryToTargetClass = [];
+
+    private ObjectMetadataResolver $doctrineMetadataResolver;
+
+    public function __construct(string|null $objectManagerLoader = null)
+    {
+        $this->doctrineMetadataResolver = new ObjectMetadataResolver($objectManagerLoader, sys_get_temp_dir().'/rector-doctrine');
+    }
+
+    /** @param class-string<ObjectFactory> $factoryClass */
+    public function shouldTransformFactoryIntoObjectFactory(string $factoryClass): bool
+    {
+        $targetClass = $this->targetClass($factoryClass);
+
+        return !$this->shouldUseProxyFactory($targetClass);
+    }
+
+    /**
+     * @param class-string $targetClass
+     */
+    public function shouldUseProxyFactory(string $targetClass): bool
+    {
+        return !(new \ReflectionClass($targetClass))->isFinal() && $this->isPersisted($targetClass);
+    }
+
+    /**
+     * @param class-string<ObjectFactory> $factoryClass
+     * @return class-string
+     */
+    private function targetClass(string $factoryClass): string
+    {
+        return $this->factoryToTargetClass[$factoryClass] ??= (static function () use ($factoryClass) {
+            return is_a($factoryClass, ModelFactory::class, allow_string: true)
+                ? (new \ReflectionClass($factoryClass))->getMethod('getClass')->invoke(null)
+                : $factoryClass::class();
+        })();
+    }
+
+    private function isPersisted(string $targetClass): bool
+    {
+        return (bool) $this->doctrineMetadataResolver->getClassMetadata($targetClass);
+    }
+}

--- a/utils/rector/src/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects.php
+++ b/utils/rector/src/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PhpParser\Node;
+use PHPStan\Analyser\MutatingScope;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+final class RemoveProxyRealObjectMethodCallsForNotProxifiedObjects extends AbstractRector
+{
+    private PersistenceResolver $persistenceResolver;
+
+    public function __construct(
+        PersistenceResolver|null $persistenceResolver,
+    ) {
+        $this->persistenceResolver = $persistenceResolver ?? new PersistenceResolver();
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove `->object()`/`->_real()` calls on objects created by `ObjectFactory`.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    SomeObjectFactory::new()->create()->object();
+                    SomeObjectFactory::new()->create()->_real();
+                    CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                    SomeObjectFactory::new()->create();
+                    SomeObjectFactory::new()->create();
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class, Node\Expr\NullsafeMethodCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall|Node\Expr\NullsafeMethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!in_array((string)$node->name, ['object', '_real'], true)) {
+            return null;
+        }
+
+        /**
+         * If "object()" or "_real()" is called on an object which is a proxy,
+         * we should check if this object will use `ObjectFactory` as factory.
+         * If it does, we must remove the call
+         */
+        if ($this->isProxyOfFutureObjectFactory($node->var)) {
+            return $node->var;
+        }
+
+        /**
+         * If "object()" or "_real()" is called on an object which is not a proxy,
+         * we MAY have already changed the base factory class.
+         * Then, if the method does not exist on the object's class, it is very likely we can safely remove the method call
+         */
+        if ($this->isRegularObjectWithoutGivenMethod($node)) {
+            return $node->var;
+        }
+
+        return null;
+    }
+
+    /**
+     * We only consider two cases:
+     *    - proxy is nullable (ie: UnionType with a NullType)
+     *    - proxy is a GenericObjectType
+     *
+     * Complex cases are not handled here.
+     */
+    private function isProxyOfFutureObjectFactory(Node\Expr $var): bool
+    {
+        // not a proxy
+        if (!$this->isObjectType($var, new ObjectType(Proxy::class)) && !$this->isObjectType(
+                $var,
+                new ObjectType(\Zenstruck\Foundry\Proxy::class)
+            )) {
+            return false;
+        }
+
+        /** @var MutatingScope */
+        $mutatingScope = $var->getAttribute('scope');
+
+        $type = $mutatingScope->getType($var);
+
+        // Proxy is nullable: we extract the proxy type
+        if ($type instanceof UnionType) {
+            $types = $type->getTypes();
+
+            if (count($types) > 2) {
+                return false;
+            }
+
+            if ($types[0] instanceof NullType) {
+                $type = $types[1];
+            } elseif ($types[1] instanceof NullType) {
+                $type = $types[0];
+            } else {
+                return false;
+            }
+        }
+
+        return $type instanceof GenericObjectType
+            && count($types = $type->getTypes()) === 1
+            && $types[0] instanceof ObjectType
+            && !$this->persistenceResolver->shouldUseProxyFactory($types[0]->getClassName());
+    }
+
+    private function isRegularObjectWithoutGivenMethod(Node\Expr\MethodCall|Node\Expr\NullsafeMethodCall $node): bool
+    {
+        $type = $this->getType($node->var);
+
+        if (!$type instanceof FullyQualifiedObjectType) {
+            return false;
+        }
+
+        try {
+            (new \ReflectionClass($type->getClassName()))->getMethod((string)$node->name);
+
+            return false;
+        } catch (\ReflectionException) {
+            return true;
+        }
+    }
+}

--- a/utils/rector/src/RuleRequirementsChecker.php
+++ b/utils/rector/src/RuleRequirementsChecker.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector;
+
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use Rector\Config\RectorConfig;
+
+final class RuleRequirementsChecker
+{
+    public static function checkRequirements(): void
+    {
+        if (!method_exists(RectorConfig::class, 'enableCollectors')) {
+            throw new \RuntimeException(
+                'Foundry\'s Rector rules need package rector/rector to be at least at version 0.18. Please update it with command "composer update rector/rector"'
+            );
+        }
+
+        if (!class_exists(ObjectMetadataResolver::class)) {
+            throw new \RuntimeException(
+                'Foundry\'s Rector rules need package phpstan/phpstan-doctrine. Please install it with command "composer require phpstan/phpstan-doctrine --dev"'
+            );
+        }
+    }
+}

--- a/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/AddProxyToFactoryCollectionTypeInPhpDocTest.php
+++ b/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/AddProxyToFactoryCollectionTypeInPhpDocTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\AddProxyToFactoryCollectionTypeInPhpDoc;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddProxyToFactoryCollectionTypeInPhpDocTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/Fixtures/add-proxy-generic-type.php.inc
+++ b/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/Fixtures/add-proxy-generic-type.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+
+class Foo
+{
+    /**
+     * @param FactoryCollection<DummyPersistentObject> $factoryCollection
+     */
+    public function foo(FactoryCollection $factoryCollection)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+
+class Foo
+{
+    /**
+     * @param FactoryCollection<\Zenstruck\Foundry\Persistence\Proxy<DummyPersistentObject>> $factoryCollection
+     */
+    public function foo(FactoryCollection $factoryCollection)
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/Fixtures/skip-if-not-persistent-type.php.inc
+++ b/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/Fixtures/skip-if-not-persistent-type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\FactoryCollection;
+
+class Foo
+{
+    /**
+     * @param FactoryCollection<DummyObject> $factoryCollection
+     */
+    public function foo(FactoryCollection $factoryCollection)
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/config.php
+++ b/utils/rector/tests/AddProxyToFactoryCollectionTypeInPhpDoc/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\AddProxyToFactoryCollectionTypeInPhpDoc;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddProxyToFactoryCollectionTypeInPhpDoc::class);
+};

--- a/utils/rector/tests/AllRules/AllRulesTest.php
+++ b/utils/rector/tests/AllRules/AllRulesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\AddProxyToFactoryCollectionTypeInPhpDoc;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AllRulesTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/AllRules/Fixtures/object-factory.php.inc
+++ b/utils/rector/tests/AllRules/Fixtures/object-factory.php.inc
@@ -1,0 +1,91 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+/**
+ * @extends ModelFactory<DummyObject>
+ *
+ * @method        DummyObject|Proxy     create(array|callable $attributes = [])
+ * @method static DummyObject|Proxy     createOne(array $attributes = [])
+ * @method static DummyObject[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @method static DummyObject[]|Proxy[] createSequence(iterable|callable $sequence)
+ */
+final class DummyObjectModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this->addState(['published' => true]);
+    }
+
+    protected function initialize(): self
+    {
+        return $this
+            ->withoutPersisting()
+            ->instantiateWith(
+            static fn() => (new Instantiator())
+                ->allowExtraAttributes(['some', 'fields'])
+                ->alwaysForceProperties(['other', 'fields'])
+                ->allowExtraAttributes()
+                ->alwaysForceProperties()
+        );
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\ObjectFactory;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+
+/**
+ * @extends ObjectFactory<DummyObject>
+ */
+final class DummyObjectModelFactory extends \Zenstruck\Foundry\ObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this->with(['published' => true]);
+    }
+
+    protected function initialize(): static
+    {
+        return $this
+            ->instantiateWith(
+            static fn() => (\Zenstruck\Foundry\Object\Instantiator::withoutConstructor())
+                ->allowExtra(...['some', 'fields'])
+                ->alwaysForce(...['other', 'fields'])
+                ->allowExtra()
+                ->alwaysForce()
+        );
+    }
+
+    public static function class(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/AllRules/Fixtures/proxy-factory.php.inc
+++ b/utils/rector/tests/AllRules/Fixtures/proxy-factory.php.inc
@@ -1,0 +1,83 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Doctrine\ORM\EntityRepository;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends ModelFactory<DummyPersistentObject>
+ *
+ * @method static RepositoryProxy|EntityRepository repository()
+ * @method static RepositoryProxy repository()
+ * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+ *
+ * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+ * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+ * @phpstan-method static RepositoryProxy<DummyPersistentObject> repository()
+ */
+final class DummyPersistentModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): self
+    {
+        return $this
+            ->withoutPersisting();
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Doctrine\ORM\EntityRepository;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Persistence\RepositoryDecorator;
+
+/**
+ * @extends PersistentProxyObjectFactory<DummyPersistentObject>
+ *
+ * @method static EntityRepository|RepositoryDecorator repository()
+ * @method static RepositoryDecorator repository()
+ * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+ *
+ * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+ * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+ * @phpstan-method static RepositoryDecorator<DummyPersistentObject> repository()
+ */
+final class DummyPersistentModelFactory extends \Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): static
+    {
+        return $this
+            ->withoutPersisting();
+    }
+
+    public static function class(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/AllRules/Fixtures/test-case.php.inc
+++ b/utils/rector/tests/AllRules/Fixtures/test-case.php.inc
@@ -1,0 +1,93 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObjectModelFactory;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentModelFactory;
+
+class DummyKernelTestCase extends KernelTestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        $this->enablePersist();
+        $this->disablePersist();
+    }
+
+    /**
+     * @param FactoryCollection<DummyPersistentObject> $factoryCollectionWithProxy
+     * @param FactoryCollection<DummyObject> $factoryCollectionWithoutProxy
+     */
+    public function testSomething(FactoryCollection $factoryCollectionWithProxy, FactoryCollection $factoryCollectionWithoutProxy): void
+    {
+        DummyObjectModelFactory::new()->withAttributes(['published' => true])->object();
+        DummyPersistentModelFactory::createOne()->object();
+
+        /** @var Proxy<DummyPersistentObject> */
+        $object = DummyPersistentModelFactory::createOne();
+        $object->refresh();
+
+        \Zenstruck\Foundry\create(SomeClass::class, []);
+        \Zenstruck\Foundry\instantiate(SomeClass::class, ['published' => true]);
+        \Zenstruck\Foundry\repository($object);
+
+        \Zenstruck\Foundry\Factory::delayFlush(static fn() => true);
+        \Zenstruck\Foundry\Test\TestState::configure(faker: null);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObjectModelFactory;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentModelFactory;
+
+class DummyKernelTestCase extends KernelTestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        \Zenstruck\Foundry\Persistence\enable_persisting();
+        \Zenstruck\Foundry\Persistence\disable_persisting();
+    }
+
+    /**
+     * @param FactoryCollection<Proxy<DummyPersistentObject>> $factoryCollectionWithProxy
+     * @param FactoryCollection<DummyObject> $factoryCollectionWithoutProxy
+     */
+    public function testSomething(FactoryCollection $factoryCollectionWithProxy, FactoryCollection $factoryCollectionWithoutProxy): void
+    {
+        DummyObjectModelFactory::new()->with(['published' => true]);
+        DummyPersistentModelFactory::createOne()->_real();
+
+        /** @var Proxy<DummyPersistentObject> */
+        $object = DummyPersistentModelFactory::createOne();
+        $object->_refresh();
+
+        \Zenstruck\Foundry\Persistence\persist(SomeClass::class, []);
+        \Zenstruck\Foundry\object(SomeClass::class, ['published' => true]);
+        \Zenstruck\Foundry\Persistence\repository($object);
+
+        \Zenstruck\Foundry\Persistence\flush_after(static fn() => true);
+        \Zenstruck\Foundry\Test\UnitTestConfig::configure(faker: null);
+    }
+}
+
+?>

--- a/utils/rector/tests/AllRules/config.php
+++ b/utils/rector/tests/AllRules/config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\FoundryRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->removeUnusedImports();
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
+
+    $rectorConfig->import(__DIR__.'/../../config/foundry-set.php');
+};

--- a/utils/rector/tests/ChangeDisableEnablePersist/ChangeDisableEnablePersistTest.php
+++ b/utils/rector/tests/ChangeDisableEnablePersist/ChangeDisableEnablePersistTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeDisableEnablePersist;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeDisableEnablePersistTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeDisableEnablePersist/Fixtures/change-legacy-function-when-in-kernel-test-case.php.inc
+++ b/utils/rector/tests/ChangeDisableEnablePersist/Fixtures/change-legacy-function-when-in-kernel-test-case.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+
+class DummyKernelTestCase extends KernelTestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        $this->enablePersist();
+        $this->disablePersist();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+
+class DummyKernelTestCase extends KernelTestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        \Zenstruck\Foundry\Persistence\enable_persisting();
+        \Zenstruck\Foundry\Persistence\disable_persisting();
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeDisableEnablePersist/Fixtures/remove-legacy-function-when-in-unit-test.php.inc
+++ b/utils/rector/tests/ChangeDisableEnablePersist/Fixtures/remove-legacy-function-when-in-unit-test.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+
+class DummyTestCase extends TestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        $this->enablePersist();
+        $this->disablePersist();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Test\Factories;
+
+class DummyTestCase extends TestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeDisableEnablePersist/config.php
+++ b/utils/rector/tests/ChangeDisableEnablePersist/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeDisableEnablePersist;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeDisableEnablePersist::class);
+};

--- a/utils/rector/tests/ChangeFactoryBaseClass/ChangeFactoryBaseClassTest.php
+++ b/utils/rector/tests/ChangeFactoryBaseClass/ChangeFactoryBaseClassTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeFactoryBaseClass;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeFactoryBaseClassTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeFactoryBaseClass/ChangeFactoryBaseClassWithObjectManagerTest.php
+++ b/utils/rector/tests/ChangeFactoryBaseClass/ChangeFactoryBaseClassWithObjectManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeFactoryBaseClass;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeFactoryBaseClassWithObjectManagerTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config-with-object-manager.php';
+    }
+}

--- a/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-to-object-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-to-object-factory.php.inc
@@ -1,0 +1,66 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+/**
+ * @extends ModelFactory<DummyObject>
+ *
+ * @method        DummyObject|Proxy     create(array|callable $attributes = [])
+ * @method static DummyObject|Proxy     createOne(array $attributes = [])
+ * @method static DummyObject[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @method static DummyObject[]|Proxy[] createSequence(iterable|callable $sequence)
+ */
+final class DummyObjectModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+/**
+ * @extends \Zenstruck\Foundry\ObjectFactory<DummyObject>
+ */
+final class DummyObjectModelFactory extends \Zenstruck\Foundry\ObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    public static function class(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-to-proxy-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-to-proxy-factory.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Doctrine\ORM\EntityRepository;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends ModelFactory<DummyPersistentObject>
+ *
+ * @method static RepositoryProxy|EntityRepository repository()
+ * @method static RepositoryProxy repository()
+ * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+ *
+ * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+ * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+ * @phpstan-method static RepositoryProxy<DummyPersistentObject> repository()
+ */
+final class DummyPersistentModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Doctrine\ORM\EntityRepository;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends \Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory<DummyPersistentObject>
+ *
+ * @method static EntityRepository|\Zenstruck\Foundry\Persistence\RepositoryDecorator repository()
+ * @method static \Zenstruck\Foundry\Persistence\RepositoryDecorator repository()
+ * @method        DummyPersistentObject|Proxy create(array|callable $attributes = [])
+ *
+ * @phpstan-method Proxy<DummyPersistentObject> create(array|callable $attributes = [])
+ * @phpstan-method static Proxy<DummyPersistentObject> createOne(array $attributes = [])
+ * @phpstan-method static \Zenstruck\Foundry\Persistence\RepositoryDecorator<DummyPersistentObject> repository()
+ */
+final class DummyPersistentModelFactory extends \Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    public static function class(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeFactoryBaseClass/config-with-object-manager.php
+++ b/utils/rector/tests/ChangeFactoryBaseClass/config-with-object-manager.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeFactoryBaseClass;
+use Zenstruck\Foundry\Utils\Rector\PersistenceResolver;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->singleton(
+        PersistenceResolver::class,
+        static fn() => new PersistenceResolver(__DIR__ . '/entity-manager.php')
+    );
+    $rectorConfig->rule(ChangeFactoryBaseClass::class);
+};

--- a/utils/rector/tests/ChangeFactoryBaseClass/config.php
+++ b/utils/rector/tests/ChangeFactoryBaseClass/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeFactoryBaseClass;
+use Zenstruck\Foundry\Utils\Rector\PersistenceResolver;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeFactoryBaseClass::class);
+};

--- a/utils/rector/tests/ChangeFactoryBaseClass/entity-manager.php
+++ b/utils/rector/tests/ChangeFactoryBaseClass/entity-manager.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('Zenstruck\Foundry\Utils\Rector\Tests\ChangeFactoryBaseClass\OrmProxies');
+$config->setMetadataCache(new ArrayAdapter());
+
+$metadataDriver = new MappingDriverChain();
+$metadataDriver->addDriver(new AttributeDriver([]), 'Zenstruck\\Foundry\\Utils\\Rector\\Tests\\Fixtures\\');
+
+$config->setMetadataDriverImpl($metadataDriver);
+
+return EntityManager::create(
+    [
+        'driver' => 'pdo_sqlite',
+        'memory' => true,
+    ],
+    $config
+);

--- a/utils/rector/tests/ChangeFactoryMethodCalls/ChangeFactoryMethodCallsTest.php
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/ChangeFactoryMethodCallsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeFactoryMethodCalls;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeFactoryMethodCallsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-object-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-object-factory.php.inc
@@ -1,0 +1,60 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyObjectModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this
+            ->withoutPersisting()
+            ->addState([])
+            ->withAttributes([]);
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyObjectModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this
+            ->with([])
+            ->with([]);
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-other-class.php.inc
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-other-class.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class SomeClass
+{
+    protected function someMethod()
+    {
+        DummyObjectModelFactory::new()->withoutPersisting()->withAttributes([]);
+        DummyPersistentModelFactory::new()->withoutPersisting()->withAttributes([]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class SomeClass
+{
+    protected function someMethod()
+    {
+        DummyObjectModelFactory::new()->with([]);
+        DummyPersistentModelFactory::new()->withoutPersisting()->with([]);
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-proxy-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-legacy-factory-methods-in-proxy-factory.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyPersistentModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this
+            ->withoutPersisting()
+            ->addState([])
+            ->withAttributes([]);
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyPersistentModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    public function published(): static
+    {
+        return $this
+            ->withoutPersisting()
+            ->with([])
+            ->with([]);
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeFactoryMethodCalls/config.php
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeFactoryMethodCalls;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeFactoryMethodCalls::class);
+};

--- a/utils/rector/tests/ChangeFunctionsCalls/ChangeFunctionsCallsTest.php
+++ b/utils/rector/tests/ChangeFunctionsCalls/ChangeFunctionsCallsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeFunctionsCalls;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeFunctionsCallsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeFunctionsCalls/Fixtures/functions-with-fqcn.php.inc
+++ b/utils/rector/tests/ChangeFunctionsCalls/Fixtures/functions-with-fqcn.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+\Zenstruck\Foundry\create(SomeClass::class, []);
+\Zenstruck\Foundry\instantiate(SomeClass::class, ['published' => true]);
+\Zenstruck\Foundry\repository($someObject);
+
+\Zenstruck\Foundry\Factory::delayFlush(static fn() => true);
+\Zenstruck\Foundry\Test\TestState::configure(faker: null);
+
+?>
+-----
+<?php
+
+\Zenstruck\Foundry\Persistence\persist(SomeClass::class, []);
+\Zenstruck\Foundry\object(SomeClass::class, ['published' => true]);
+\Zenstruck\Foundry\Persistence\repository($someObject);
+
+\Zenstruck\Foundry\Persistence\flush_after(static fn() => true);
+\Zenstruck\Foundry\Test\UnitTestConfig::configure(faker: null);
+
+?>

--- a/utils/rector/tests/ChangeFunctionsCalls/Fixtures/functions-with-use.php.inc
+++ b/utils/rector/tests/ChangeFunctionsCalls/Fixtures/functions-with-use.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Test\TestState;
+
+use function Zenstruck\Foundry\create;
+use function Zenstruck\Foundry\instantiate;
+use function Zenstruck\Foundry\repository;
+
+create(SomeClass::class, []);
+instantiate(SomeClass::class, ['published' => true]);
+repository($someObject);
+
+Factory::delayFlush(static fn() => true);
+TestState::configure(faker: null);
+
+?>
+-----
+<?php
+
+\Zenstruck\Foundry\Persistence\persist(SomeClass::class, []);
+\Zenstruck\Foundry\object(SomeClass::class, ['published' => true]);
+\Zenstruck\Foundry\Persistence\repository($someObject);
+
+\Zenstruck\Foundry\Persistence\flush_after(static fn() => true);
+\Zenstruck\Foundry\Test\UnitTestConfig::configure(faker: null);
+
+?>

--- a/utils/rector/tests/ChangeFunctionsCalls/config.php
+++ b/utils/rector/tests/ChangeFunctionsCalls/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeFunctionsCalls;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->removeUnusedImports(true);
+    $rectorConfig->rule(ChangeFunctionsCalls::class);
+};

--- a/utils/rector/tests/ChangeInstantiatorMethodCalls/ChangeInstantiatorMethodCallsTest.php
+++ b/utils/rector/tests/ChangeInstantiatorMethodCalls/ChangeInstantiatorMethodCallsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeInstantiatorMethodCalls;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeInstantiatorMethodCallsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-in-model-factory.php.inc
+++ b/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-in-model-factory.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ObjectFactory;
+
+class DummyPersistentModelFactory extends ObjectFactory
+{
+    public function someMethod(): Instantiator
+    {
+        return (new Instantiator())
+            ->allowExtraAttributes(['some', 'fields'])
+            ->alwaysForceProperties(['other', 'fields'])
+            ->allowExtraAttributes()
+            ->alwaysForceProperties();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ObjectFactory;
+
+class DummyPersistentModelFactory extends ObjectFactory
+{
+    public function someMethod(): Instantiator
+    {
+        return (\Zenstruck\Foundry\Object\Instantiator::withConstructor())
+            ->allowExtra(...['some', 'fields'])
+            ->alwaysForce(...['other', 'fields'])
+            ->allowExtra()
+            ->alwaysForce();
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-in-object-factory-with-private-ctor.php.inc
+++ b/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-in-object-factory-with-private-ctor.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ObjectFactory;
+
+class DummyObjectFactory extends ObjectFactory
+{
+    public function someMethod(): Instantiator
+    {
+        return (new Instantiator())
+            ->allowExtraAttributes(['some', 'fields'])
+            ->alwaysForceProperties(['other', 'fields'])
+            ->allowExtraAttributes()
+            ->alwaysForceProperties();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ObjectFactory;
+
+class DummyObjectFactory extends ObjectFactory
+{
+    public function someMethod(): Instantiator
+    {
+        return (\Zenstruck\Foundry\Object\Instantiator::withoutConstructor())
+            ->allowExtra(...['some', 'fields'])
+            ->alwaysForce(...['other', 'fields'])
+            ->allowExtra()
+            ->alwaysForce();
+    }
+}
+
+?>

--- a/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-outside-of-class.php.inc
+++ b/utils/rector/tests/ChangeInstantiatorMethodCalls/Fixtures/call-outside-of-class.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Object\Instantiator;
+
+(new Instantiator())
+    ->allowExtraAttributes(['some', 'fields'])
+    ->alwaysForceProperties(['other', 'fields'])
+    ->allowExtraAttributes()
+    ->alwaysForceProperties()
+
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+(\Zenstruck\Foundry\Object\Instantiator::withConstructor())
+    ->allowExtra(...['some', 'fields'])
+    ->alwaysForce(...['other', 'fields'])
+    ->allowExtra()
+    ->alwaysForce()
+
+?>

--- a/utils/rector/tests/ChangeInstantiatorMethodCalls/config.php
+++ b/utils/rector/tests/ChangeInstantiatorMethodCalls/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeInstantiatorMethodCalls;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->removeUnusedImports(true);
+    $rectorConfig->rule(ChangeInstantiatorMethodCalls::class);
+};

--- a/utils/rector/tests/ChangeLegacyClassImports/ChangeLegacyClassImportsTest.php
+++ b/utils/rector/tests/ChangeLegacyClassImports/ChangeLegacyClassImportsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeLegacyClassUses;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeLegacyClassImportsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeLegacyClassImports/Fixtures/change-legacy-classes-import.php.inc
+++ b/utils/rector/tests/ChangeLegacyClassImports/Fixtures/change-legacy-classes-import.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\Instantiator;
+use Zenstruck\Foundry\RepositoryProxy;
+use Zenstruck\Foundry\RepositoryAssertions;
+
+class SomeClass
+{
+}
+
+?>
+-----
+<?php
+
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\Persistence\RepositoryDecorator;
+use Zenstruck\Foundry\Persistence\RepositoryAssertions;
+
+class SomeClass
+{
+}
+
+?>

--- a/utils/rector/tests/ChangeLegacyClassImports/config.php
+++ b/utils/rector/tests/ChangeLegacyClassImports/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeLegacyClassImports;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeLegacyClassImports::class);
+};

--- a/utils/rector/tests/ChangeProxyMethhodCalls/ChangeProxyMethodCallsTest.php
+++ b/utils/rector/tests/ChangeProxyMethhodCalls/ChangeProxyMethodCallsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeLegacyClassUses;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeProxyMethodCallsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/ChangeProxyMethhodCalls/Fixtures/change-legacy-proxy-methods.php.inc
+++ b/utils/rector/tests/ChangeProxyMethhodCalls/Fixtures/change-legacy-proxy-methods.php.inc
@@ -1,0 +1,67 @@
+<?php
+
+function legacyProxy(\Zenstruck\Foundry\Proxy $proxy): void
+{
+    $proxy->object();
+    $proxy?->object();
+    $proxy->save();
+    $proxy->remove();
+    $proxy->refresh();
+    $proxy->forceSet();
+    $proxy->get();
+    $proxy->repository();
+    $proxy->enableAutoRefresh();
+    $proxy->disableAutoRefresh();
+    $proxy->withoutAutoRefresh();
+}
+
+function newProxy(\Zenstruck\Foundry\Persistence\Proxy $proxy): void
+{
+    $proxy->object();
+    $proxy?->object();
+    $proxy->save();
+    $proxy->remove();
+    $proxy->refresh();
+    $proxy->forceSet();
+    $proxy->get();
+    $proxy->repository();
+    $proxy->enableAutoRefresh();
+    $proxy->disableAutoRefresh();
+    $proxy->withoutAutoRefresh();
+}
+
+?>
+-----
+<?php
+
+function legacyProxy(\Zenstruck\Foundry\Proxy $proxy): void
+{
+    $proxy->_real();
+    $proxy?->_real();
+    $proxy->_save();
+    $proxy->_delete();
+    $proxy->_refresh();
+    $proxy->_set();
+    $proxy->_get();
+    $proxy->_repository();
+    $proxy->_enableAutoRefresh();
+    $proxy->_disableAutoRefresh();
+    $proxy->_withoutAutoRefresh();
+}
+
+function newProxy(\Zenstruck\Foundry\Persistence\Proxy $proxy): void
+{
+    $proxy->_real();
+    $proxy?->_real();
+    $proxy->_save();
+    $proxy->_delete();
+    $proxy->_refresh();
+    $proxy->_set();
+    $proxy->_get();
+    $proxy->_repository();
+    $proxy->_enableAutoRefresh();
+    $proxy->_disableAutoRefresh();
+    $proxy->_withoutAutoRefresh();
+}
+
+?>

--- a/utils/rector/tests/ChangeProxyMethhodCalls/config.php
+++ b/utils/rector/tests/ChangeProxyMethhodCalls/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\ChangeProxyMethodCalls;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeProxyMethodCalls::class);
+};

--- a/utils/rector/tests/Fixtures/DummyKernelTestCase.php
+++ b/utils/rector/tests/Fixtures/DummyKernelTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * This is a totally dummy file, which is only helpful for autoloader:
+ * when this file exist, this class exists, and fixtures files using same class name will be considered as existing
+ *
+ * @see tests/Rector/ChangeDisableEnablePersist/Fixtures/change-legacy-function-when-in-kernel-test-case.php.inc
+ */
+class DummyKernelTestCase extends KernelTestCase
+{
+
+}

--- a/utils/rector/tests/Fixtures/DummyObject.php
+++ b/utils/rector/tests/Fixtures/DummyObject.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class DummyObject
+{
+    public int|null $id = null;
+
+    private function __construct()
+    {
+    }
+
+    public static function new(): static
+    {
+        return new self();
+    }
+}

--- a/utils/rector/tests/Fixtures/DummyObjectFactory.php
+++ b/utils/rector/tests/Fixtures/DummyObjectFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\ObjectFactory;
+
+final class DummyObjectFactory extends ObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    public static function class(): string
+    {
+        return DummyObject::class;
+    }
+}

--- a/utils/rector/tests/Fixtures/DummyObjectModelFactory.php
+++ b/utils/rector/tests/Fixtures/DummyObjectModelFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\ModelFactory;
+
+final class DummyObjectModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}

--- a/utils/rector/tests/Fixtures/DummyPersistentModelFactory.php
+++ b/utils/rector/tests/Fixtures/DummyPersistentModelFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\ModelFactory;
+
+final class DummyPersistentModelFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyPersistentObject::class;
+    }
+}

--- a/utils/rector/tests/Fixtures/DummyPersistentObject.php
+++ b/utils/rector/tests/Fixtures/DummyPersistentObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity()]
+class DummyPersistentObject
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    public int|null $id;
+}

--- a/utils/rector/tests/Fixtures/DummyTestCase.php
+++ b/utils/rector/tests/Fixtures/DummyTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This is a totally dummy file, which is only helpful for autoloader:
+ * when this file exist, this class exists, and fixtures files using same class name will be considered as existing
+ *
+ * @see tests/Rector/ChangeDisableEnablePersist/Fixtures/change-legacy-function-when-in-kernel-test-case.php.inc
+ */
+class DummyTestCase extends TestCase
+{
+
+}

--- a/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/Fixtures/remove-object-calls-on-not-persistent-objects.php.inc
+++ b/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/Fixtures/remove-object-calls-on-not-persistent-objects.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+$proxy = new \Zenstruck\Foundry\Proxy(DummyObject::new());
+$proxy->_real();
+$proxy->object();
+
+/**
+ * @param Proxy<DummyObject> $proxy
+ */
+function foo(Proxy $proxy): void
+{
+    $proxy->_real();
+    $proxy->object();
+}
+
+?>
+-----
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+$proxy = new \Zenstruck\Foundry\Proxy(DummyObject::new());
+$proxy;
+$proxy;
+
+/**
+ * @param Proxy<DummyObject> $proxy
+ */
+function foo(Proxy $proxy): void
+{
+    $proxy;
+    $proxy;
+}
+
+?>

--- a/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/Fixtures/skip-remove-object-calls-on-persistent-objects.php.inc
+++ b/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/Fixtures/skip-remove-object-calls-on-persistent-objects.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyPersistentObject;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+$proxy = new \Zenstruck\Foundry\Proxy(new DummyPersistentObject());
+$proxy->_real();
+$proxy->object();
+
+/**
+ * @param Proxy<DummyPersistentObject> $proxy
+ */
+function foo(Proxy $proxy): void
+{
+    $proxy->_real();
+    $proxy->object();
+}
+
+?>
+

--- a/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/RemoveProxyRealObjectMethodCallsForNotProxifiedObjectsTest.php
+++ b/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/RemoveProxyRealObjectMethodCallsForNotProxifiedObjectsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\ChangeLegacyClassUses;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveProxyRealObjectMethodCallsForNotProxifiedObjectsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/config.php
+++ b/utils/rector/tests/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Zenstruck\Foundry\Utils\Rector\RemoveProxyRealObjectMethodCallsForNotProxifiedObjects;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveProxyRealObjectMethodCallsForNotProxifiedObjects::class);
+};


### PR DESCRIPTION
Hi!

here is my present for christmas :gift: :santa: 

I really felt this migration path was too much pain, so I decided to try to work on rector rules!

When my project is updated with the last `1.x-bc` version (actually, the one which has `ObjectFactory`, still not merged), I have these results:

BEFORE using rector:
```
PhpUnit: Remaining direct deprecation notices (19782)
PhpStan: Found 85 errors
```

AFTER using rector (and polishing some stuff):

```
PhpUnit: Remaining direct deprecation notices (8)
PhpStan: Found 0 errors
```
(of course in both cases, tests are green.)

Actually the only deprecation left is:
> Calling instance method "Zenstruck\Foundry\Object\Instantiator::withoutConstructor()"

There is no way with Rector to make it 100% accurate (or I haven't found how 😅)

The rector rules decide automatically if it must use `ObjectFactory` or `PersistentProxyObjectFactory` based on if the target class is final and if it is persisted.
Based on that, it automatically removes `->object()` calls. Actually, I've introduced in my code a method `unproxify()`, and the only thing I have to do to make the tests pass is to remove by hand these calls, impossible to automatize this.

I think the way I've incorporated to Foundry is a bit clumsy, I followed their [guide](https://getrector.com/documentation/custom-rule) and applied the structure they suggest, I'll have to work on this. I don't even know if we should ship this in this repo, but I really think we should ship it somehow, I'm pretty happy with the result :grin: 

There are some things that are still needed:
- ~create a rector "set" with the list of the rules.~ ✅
- And add an "how to" in the upgrade docs
- ~add a way to read Symfony's config to be able to detect doctrine's mapping which have not been create with attributes~ ✅
- I don't think I'll bother to create a rector for the bundle's configuration: it's not so boring to do by hand in userland

merry christmas!