### PR TITLE
fix(bc-layer): few improvments

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -204,8 +204,6 @@ class Factory
     final public function sequence(iterable|callable $sequence): FactoryCollection
     {
         if (\is_callable($sequence)) {
-            trigger_deprecation('zenstruck\foundry', '1.37.0', 'Passing a callable to method "%s()" is deprecated and will be removed in 2.0.', __METHOD__);
-
             $sequence = $sequence();
         }
 

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -89,7 +89,7 @@ interface Proxy
     /**
      * @deprecated Use method "_get()" instead
      */
-    public function get(string $property): mixed;
+    public function forceGet(string $property): mixed;
 
     /**
      * @deprecated Use method "_repository()" instead

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -280,7 +280,7 @@ final class Proxy implements \Stringable, ProxyBase
     /**
      * @deprecated Use method "_get()" instead
      */
-    public function get(string $property): mixed
+    public function forceGet(string $property): mixed
     {
         trigger_deprecation('zenstruck\foundry', '1.37.0', 'Method "%s()" is deprecated and will be removed in 2.0. Use "%s::_get()" instead.', __METHOD__, self::class);
 

--- a/tests/Functional/ModelFactoryTest.php
+++ b/tests/Functional/ModelFactoryTest.php
@@ -326,7 +326,6 @@ abstract class ModelFactoryTest extends KernelTestCase
 
     /**
      * @dataProvider sequenceProvider
-     * @group legacy
      */
     public function can_create_sequence_with_callable(callable $sequence): void
     {

--- a/utils/rector/src/ChangeFactoryMethodCalls.php
+++ b/utils/rector/src/ChangeFactoryMethodCalls.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Utils\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -24,7 +26,7 @@ final class ChangeFactoryMethodCalls extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [Node\Expr\MethodCall::class];
+        return [Node\Expr\MethodCall::class, Node\Expr\StaticCall::class];
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -74,10 +76,16 @@ final class ChangeFactoryMethodCalls extends AbstractRector
         );
     }
 
-    /**
-     * @param Node\Expr\MethodCall $node
-     */
     public function refactor(Node $node): Node|int|null
+    {
+        return match($node::class) {
+            Node\Expr\MethodCall::class => $this->changeMethodCall($node),
+            Node\Expr\StaticCall::class => $this->changeStaticCall($node),
+            default => null,
+        };
+    }
+
+    public function changeMethodCall(MethodCall $node): Node|int|null
     {
         if (!$this->isObjectType($node->var, new ObjectType(Factory::class))) {
             return null;
@@ -97,6 +105,21 @@ final class ChangeFactoryMethodCalls extends AbstractRector
             }
 
            return null;
+        }
+
+        return null;
+    }
+
+    private function changeStaticCall(StaticCall $node): Node|null
+    {
+        if (!$this->isObjectType($node->class, new ObjectType(Factory::class))) {
+            return null;
+        }
+
+        if ((string)$node->name === 'getDefaults') {
+            $node->name = new Node\Identifier('defaults');
+
+            return $node;
         }
 
         return null;

--- a/utils/rector/src/ChangeProxyMethodCalls.php
+++ b/utils/rector/src/ChangeProxyMethodCalls.php
@@ -83,7 +83,7 @@ final class ChangeProxyMethodCalls extends AbstractRector
             case 'forceSet':
                 $node->name = new Node\Identifier('_set');
                 return $node;
-            case 'get':
+            case 'forceGet':
                 $node->name = new Node\Identifier('_get');
                 return $node;
             case 'repository':

--- a/utils/rector/src/ChangeProxyMethodCalls.php
+++ b/utils/rector/src/ChangeProxyMethodCalls.php
@@ -27,7 +27,7 @@ final class ChangeProxyMethodCalls extends AbstractRector
                     $proxy->remove();
                     $proxy->refresh();
                     $proxy->forceSet();
-                    $proxy->get();
+                    $proxy->forceGet();
                     $proxy->repository();
                     $proxy->enableAutoRefresh();
                     $proxy->disableAutoRefresh();

--- a/utils/rector/src/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects.php
+++ b/utils/rector/src/RemoveProxyRealObjectMethodCallsForNotProxifiedObjects.php
@@ -100,7 +100,7 @@ final class RemoveProxyRealObjectMethodCallsForNotProxifiedObjects extends Abstr
             return false;
         }
 
-        /** @var MutatingScope */
+        /** @var MutatingScope $mutatingScope */
         $mutatingScope = $var->getAttribute('scope');
 
         $type = $mutatingScope->getType($var);

--- a/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-factory-extending-user-defined-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryBaseClass/Fixtures/change-factory-extending-user-defined-factory.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyModelFactoryExtendingUserFactory extends DummyObjectModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyModelFactoryExtendingUserFactory extends DummyObjectModelFactory
+{
+    protected function defaults(): array
+    {
+        return [];
+    }
+
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    public static function class(): string
+    {
+        return DummyObject::class;
+    }
+}
+?>

--- a/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-factory-extending-user-defined-factory.php.inc
+++ b/utils/rector/tests/ChangeFactoryMethodCalls/Fixtures/change-factory-extending-user-defined-factory.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyModelFactoryExtendingUserFactory extends DummyObjectModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return self::getDefaults();
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+?>
+-----
+<?php
+
+namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
+
+use Zenstruck\Foundry\Utils\Rector\Tests\Fixtures\DummyObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+
+final class DummyModelFactoryExtendingUserFactory extends DummyObjectModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return self::defaults();
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return DummyObject::class;
+    }
+}
+?>

--- a/utils/rector/tests/ChangeProxyMethhodCalls/Fixtures/change-legacy-proxy-methods.php.inc
+++ b/utils/rector/tests/ChangeProxyMethhodCalls/Fixtures/change-legacy-proxy-methods.php.inc
@@ -8,7 +8,7 @@ function legacyProxy(\Zenstruck\Foundry\Proxy $proxy): void
     $proxy->remove();
     $proxy->refresh();
     $proxy->forceSet();
-    $proxy->get();
+    $proxy->forceGet();
     $proxy->repository();
     $proxy->enableAutoRefresh();
     $proxy->disableAutoRefresh();
@@ -23,7 +23,7 @@ function newProxy(\Zenstruck\Foundry\Persistence\Proxy $proxy): void
     $proxy->remove();
     $proxy->refresh();
     $proxy->forceSet();
-    $proxy->get();
+    $proxy->forceGet();
     $proxy->repository();
     $proxy->enableAutoRefresh();
     $proxy->disableAutoRefresh();

--- a/utils/rector/tests/Fixtures/DummyModelFactoryExtendingUserFactory.php
+++ b/utils/rector/tests/Fixtures/DummyModelFactoryExtendingUserFactory.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\Utils\Rector\Tests\Fixtures;
 
-use Zenstruck\Foundry\ModelFactory;
-
-class DummyObjectModelFactory extends ModelFactory
+final class DummyModelFactoryExtendingUserFactory extends DummyObjectModelFactory
 {
     protected function getDefaults(): array
     {


### PR DESCRIPTION
- [x] Proxy::forceGet() was mistakenly removed and rector should convert to _get()
- [x]  bc layer on sequences needs to be rolled-back
- [ ] Rector
  - [x] Don't replace extended factory if extending a user-defined factory
  - [x] Calls to parent::getDefaults() on factories that extend other user-defined factories