### PR TITLE
refactor: deprecate $orderBy argument in RepositoryDecorator::findOneBy()

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -401,6 +401,10 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
      */
     public function findOneBy(array $criteria, ?array $orderBy = null): ?Proxy
     {
+        if (null !== $orderBy) {
+            trigger_deprecation('zenstruck\foundry', '1.37.0', 'Argument "$orderBy" of method "%s()" is deprecated and will be removed in Foundry 2.0. Use "%s::findBy()" instead if you need an order.', __METHOD__, __CLASS__);
+        }
+
         if (\is_array($orderBy)) {
             $wrappedParams = (new \ReflectionClass($this->repository))->getMethod('findOneBy')->getParameters();
 

--- a/tests/Functional/ORMRepositoryDecoratorTest.php
+++ b/tests/Functional/ORMRepositoryDecoratorTest.php
@@ -64,6 +64,7 @@ final class ORMRepositoryDecoratorTest extends RepositoryDecoratorTest
 
     /**
      * @test
+     * @group legacy
      */
     public function proxy_wrapping_orm_entity_manager_can_order_by_in_find_one_by(): void
     {

--- a/tests/Unit/RepositoryDecoratorTest.php
+++ b/tests/Unit/RepositoryDecoratorTest.php
@@ -22,6 +22,7 @@ final class RepositoryDecoratorTest extends TestCase
 {
     /**
      * @test
+     * @group legacy
      * @dataProvider objectRepositoryWithoutFindOneByOrderBy
      */
     public function calling_find_one_by_with_order_by_when_wrapped_repo_does_not_have_throws_exception(ObjectRepository $inner): void


### PR DESCRIPTION
in 2.x, `RepositoryDecorator` implements `\Doctrine\Persistence\ObjectRepository` so we need to comply to its methods prototypes