### PR TITLE
feat: skip resetDatabase when migrations are up-to-date

### DIFF
--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -26,20 +26,21 @@ use Zenstruck\Foundry\Factory;
 final class DatabaseResetter
 {
     private static bool $hasBeenReset = false;
+    private static bool $isDAMADoctrineTestBundleEnabled = false;
 
     public static function hasBeenReset(): bool
     {
         return self::$hasBeenReset;
     }
 
-    public static function isDAMADoctrineTestBundleAvailable(): bool
+    public static function isDAMADoctrineTestBundleEnabled(bool $cached = false): bool
     {
-        return \class_exists(StaticDriver::class);
-    }
+        if($cached) {
+            return self::$isDAMADoctrineTestBundleEnabled;
+        }
 
-    public static function isDAMADoctrineTestBundleEnabled(): bool
-    {
-        return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
+        self::$isDAMADoctrineTestBundleEnabled = \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
+        return self::$isDAMADoctrineTestBundleEnabled;
     }
 
     public static function resetDatabase(KernelInterface $kernel, bool $damaIsEnabled): void

--- a/src/Test/DatabaseResetter.php
+++ b/src/Test/DatabaseResetter.php
@@ -32,6 +32,11 @@ final class DatabaseResetter
         return self::$hasBeenReset;
     }
 
+    public static function isDAMADoctrineTestBundleAvailable(): bool
+    {
+        return \class_exists(StaticDriver::class);
+    }
+
     public static function isDAMADoctrineTestBundleEnabled(): bool
     {
         return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -46,6 +46,15 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
 
     public function resetDatabase(): void
     {
+        if (DatabaseResetter::isDAMADoctrineTestBundleAvailable() && $this->isResetUsingMigrations()) {
+            try{
+                $this->runCommand($this->application, 'doctrine:migrations:up-to-date', ['--fail-on-unregistered' => true]);
+                // not required as the database schema is already up-to-date
+                return;
+            }catch(\RuntimeException $e){
+            }
+        }
+
         $this->dropAndResetDatabase();
         $this->createSchema();
     }


### PR DESCRIPTION
I use the DamaDoctrineTestBundle in combination with `database_resetter.orm.reset_mode: migrate`.

Everytime the test suite is run, when there is a TestCase using the `ResetDatabase` trait, the database is reset.

This change skips the step when there are no new migrations and no unregistered migrations in the database.

This eliminates about 10s of initialization time to 0s for every test suit run in my case.


This assumes, that when DamaDoctrineTestBundle is installed, it is also used and correctly configured.

I use ddev for my projects, so I haven't locally tested the changes as I don't have php locally installed.