### PR TITLE
Fix invalid offset access on relationship without `inversedBy` and `mappedBy`

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -457,10 +457,12 @@ class Factory
             return null;
         }
 
+        $metaDataField = $relationshipMetadata['inversedBy'] ?? $relationshipMetadata['mappedBy'] ?? null;
+
         return [
             'cascade' => $relationshipMetadata['isCascadePersist'],
-            'inversedField' => $relationshipMetadata['inversedBy'] ?? $relationshipMetadata['mappedBy'] ?? null,
-            'inverseIsCollection' => $entityManager->getClassMetadata($relationshipMetadata['targetEntity'])->isCollectionValuedAssociation($relationshipMetadata['inversedBy'] ?? $relationshipMetadata['mappedBy']),
+            'inversedField' => $metaDataField,
+            'inverseIsCollection' => $metaDataField && $entityManager->getClassMetadata($relationshipMetadata['targetEntity'])->isCollectionValuedAssociation($metaDataField),
             'isOwningSide' => $relationshipMetadata['isOwningSide'],
         ];
     }


### PR DESCRIPTION
When dealing with unilateral one-to-one relation like this:

```php
class User
{
    #[OneToOne]
    public Address $adress
}
```

We have this error popping:

```
In AssociationMapping.php line 243:

   [OutOfRangeException]
   Unknown property "mappedBy" on class Doctrine\ORM\Mapping\OneToOneOwningSideMapping


 Exception trace:
   at /private/var/www/backoffice-api/vendor/doctrine/orm/src/Mapping/AssociationMapping.php:243
  Doctrine\ORM\Mapping\AssociationMapping->offsetGet() at
 /private/var/www/backoffice-api/vendor/zenstruck/foundry/src/Factory.php:463
  Zenstruck\Foundry\Factory::getRelationshipMetadata() at
 /private/var/www/backoffice-api/vendor/zenstruck/foundry/src/Factory.php:411
  Zenstruck\Foundry\Factory->normalizeAttribute() at
 /private/var/www/backoffice-api/vendor/zenstruck/foundry/src/Factory.php:111
  Zenstruck\Foundry\Factory->create() at
 /private/var/www/backoffice-api/src/DataFixtures/Story/User/UserStory.php:29
  App\DataFixtures\Story\Kitchen\KitchenBlockStory->build() at
 /private/var/www/backoffice-api/vendor/zenstruck/foundry/src/StoryManager.php:52
```

It happened when trying to upgrade to DBAL4/ORM3. I think this fix can help support latest Doctrine's versions 🙂 