### PR TITLE
use phpunit attributes

### DIFF
--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Test;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\ChainManagerRegistry;
 use Zenstruck\Foundry\Exception\FoundryBootException;
@@ -27,6 +29,7 @@ trait Factories
      * @internal
      * @before
      */
+    #[Before]
     public static function _setUpFactories(): void
     {
         if (!\is_subclass_of(static::class, KernelTestCase::class)) {
@@ -57,6 +60,7 @@ trait Factories
      * @internal
      * @after
      */
+    #[After]
     public static function _tearDownFactories(): void
     {
         try {

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -12,6 +12,8 @@
 namespace Zenstruck\Foundry\Test;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -28,6 +30,7 @@ trait ResetDatabase
      * @internal
      * @beforeClass
      */
+    #[BeforeClass]
     public static function _resetDatabase(): void
     {
         if (!\is_subclass_of(static::class, KernelTestCase::class)) {
@@ -65,6 +68,7 @@ trait ResetDatabase
      * @internal
      * @before
      */
+    #[Before]
     public static function _resetSchema(): void
     {
         if (!\is_subclass_of(static::class, KernelTestCase::class)) {


### PR DESCRIPTION
Starting in PHPUnit 11 - the use of metadata in doc-comments is _hard_ deprecated. Results in tests passing as expected but PHPUnit deprecation warnings everywhere...