### PR TITLE
feat: support `doctrine/orm` 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
         "doctrine/mongodb-odm": "^2.4",
         "doctrine/mongodb-odm-bundle": "^4.4.0|^5.0",
-        "doctrine/orm": "^2.11",
+        "doctrine/orm": "^2.11|^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1|^5.0",
         "phpunit/phpunit": "^9.5.0",
         "symfony/dotenv": "^5.4|^6.0|^7.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,10 @@ parameters:
     excludePaths:
         - ./src/Bundle/Resources
 
+        # phpstan runs with orm 3 - there are too many failures in these files which are compatible with orm 2
+        - ./src/Bundle/Maker/Factory/LegacyORMDefaultPropertiesGuesser.php
+        - ./src/Bundle/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
+
     ignoreErrors:
         -
             message: '#Unsafe usage of new static\(\).*#'

--- a/src/Bundle/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
@@ -12,7 +12,8 @@
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -56,12 +57,12 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
         $ids = $metadata->getIdentifierFieldNames();
 
         foreach ($metadata->fieldMappings as $property) {
-            if ($property['embedded'] ?? false) {
+            if (is_array($property) && ($property['embedded'] ?? false)) {
                 // skip ODM embedded
                 continue;
             }
 
-            $fieldName = $property['fieldName'];
+            $fieldName = $this->extractFieldMappingData($property, 'fieldName');
 
             if (\str_contains($fieldName, '.')) {
                 // this is a "subfield" of an ORM embeddable field.
@@ -69,19 +70,19 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
             }
 
             // ignore identifiers and nullable fields
-            if ((!$makeFactoryQuery->isAllFields() && ($property['nullable'] ?? false)) || \in_array($fieldName, $ids, true)) {
+            if ((!$makeFactoryQuery->isAllFields() && $this->extractFieldMappingData($property, 'nullable', false)) || \in_array($fieldName, $ids, true)) {
                 continue;
             }
 
-            $type = \mb_strtoupper($property['type']);
-            if (isset($property['enumType'])) {
-                $makeFactoryData->addEnumDefaultProperty($fieldName, $property['enumType']);
+            $type = \mb_strtoupper($this->extractFieldMappingData($property, 'type'));
+            if ($this->extractFieldMappingData($property, 'enumType')) {
+                $makeFactoryData->addEnumDefaultProperty($fieldName, $this->extractFieldMappingData($property, 'enumType'));
 
                 continue;
             }
 
             $value = "null, // TODO add {$type} type manually";
-            $length = $property['length'] ?? '';
+            $length = $this->extractFieldMappingData($property, 'length', '');
 
             if (\array_key_exists($type, self::DEFAULTS)) {
                 $value = self::DEFAULTS[$type];
@@ -94,5 +95,15 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
     public function supports(MakeFactoryData $makeFactoryData): bool
     {
         return $makeFactoryData->isPersisted();
+    }
+
+    // handles both ORM 3 & 4
+    private function extractFieldMappingData(FieldMapping|array $fieldMapping, string $field, mixed $default = null): mixed
+    {
+        if ($fieldMapping instanceof FieldMapping) {
+            return $fieldMapping->{$field};
+        } else {
+            return $fieldMapping[$field] ?? $default;
+        }
     }
 }

--- a/src/Bundle/Maker/Factory/FactoryCandidatesClassesExtractor.php
+++ b/src/Bundle/Maker/Factory/FactoryCandidatesClassesExtractor.php
@@ -11,7 +11,7 @@
 
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;

--- a/src/Bundle/Maker/Factory/FactoryGenerator.php
+++ b/src/Bundle/Maker/Factory/FactoryGenerator.php
@@ -12,7 +12,7 @@
 namespace Zenstruck\Foundry\Bundle\Maker\Factory;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Generator;

--- a/src/Bundle/Maker/Factory/ODMDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/ODMDefaultPropertiesGuesser.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type AssociationFieldMapping from ODMClassMetadata
  */
 class ODMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuesser
 {

--- a/src/Bundle/Resources/config/maker.xml
+++ b/src/Bundle/Resources/config/maker.xml
@@ -20,6 +20,13 @@
             <tag name="foundry.make_factory.default_properties_guesser" />
         </service>
 
+        <service id=".zenstruck_foundry.maker.factory.legacy_orm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\LegacyORMDefaultPropertiesGuesser">
+            <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />
+            <argument type="service" id=".zenstruck_foundry.maker.factory.generator" />
+            <tag name="foundry.make_factory.default_properties_guesser" />
+        </service>
+
         <service id=".zenstruck_foundry.maker.factory.odm_default_properties_guesser" class="Zenstruck\Foundry\Bundle\Maker\Factory\ODMDefaultPropertiesGuesser">
             <argument type="service" id=".zenstruck_foundry.chain_manager_registry" />
             <argument type="service" id=".zenstruck_foundry.maker.factory.factory_class_map" />

--- a/src/Persistence/DoctrineVersionGuesser.php
+++ b/src/Persistence/DoctrineVersionGuesser.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Persistence;
+
+use Doctrine\ORM\Mapping\FieldMapping;
+
+final class DoctrineVersionGuesser
+{
+    public static function isOrmV4(): bool
+    {
+        return class_exists(FieldMapping::class);
+    }
+}

--- a/src/Test/ORMDatabaseResetter.php
+++ b/src/Test/ORMDatabaseResetter.php
@@ -12,7 +12,7 @@
 namespace Zenstruck\Foundry\Test;
 
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
@@ -70,13 +70,7 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
         }
 
         foreach ($this->objectManagersToReset() as $manager) {
-            $this->runCommand(
-                $this->application,
-                'doctrine:schema:create',
-                [
-                    '--em' => $manager,
-                ],
-            );
+            $this->runCommand($this->application, 'doctrine:schema:create', ['--em' => $manager,]);
         }
     }
 
@@ -89,14 +83,7 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
         }
 
         foreach ($this->objectManagersToReset() as $manager) {
-            $this->runCommand(
-                $this->application,
-                'doctrine:schema:drop',
-                [
-                    '--em' => $manager,
-                    '--force' => true,
-                ],
-            );
+            $this->runCommand($this->application, 'doctrine:schema:drop', ['--em' => $manager, '--force' => true,]);
         }
     }
 
@@ -120,20 +107,17 @@ final class ORMDatabaseResetter extends AbstractSchemaResetter
 
             $dropParams = ['--connection' => $connection, '--force' => true];
 
-            if (!$databasePlatform instanceof SqlitePlatform) {
+            if (!$databasePlatform instanceof SQLitePlatform) {
                 // sqlite does not support "--if-exists" (ref: https://github.com/doctrine/dbal/pull/2402)
                 $dropParams['--if-exists'] = true;
             }
 
             $this->runCommand($this->application, 'doctrine:database:drop', $dropParams);
 
-            $this->runCommand(
-                $this->application,
-                'doctrine:database:create',
-                [
-                    '--connection' => $connection,
-                ],
-            );
+            if (!$databasePlatform instanceof SQLitePlatform) {
+                // d:d:create not supported on SQLite
+                $this->runCommand($this->application, 'doctrine:database:create', ['--connection' => $connection,]);
+            }
         }
     }
 

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -154,6 +154,7 @@ class Kernel extends BaseKernel
                     'dbal' => [
                         'url' => '%env(resolve:DATABASE_URL)%',
                         'use_savepoints' => true,
+                        'schema_filter' => '~^(?!(doctrine_migration_versions)$)~'
                     ],
                     'orm' => [
                         'auto_generate_proxy_classes' => true,

--- a/tests/Functional/ORMModelFactoryTest.php
+++ b/tests/Functional/ORMModelFactoryTest.php
@@ -597,7 +597,7 @@ final class ORMModelFactoryTest extends ModelFactoryTest
     public function can_find_or_create_from_object(): void
     {
         $user = UserFactory::createOne();
-        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user->object(), 'createdAt' => new \DateTimeImmutable('2023-01-01')]);
+        $comment = CommentFactory::findOrCreate($attributes = ['user' => $user->object(), 'createdAt' => new \DateTime('2023-01-01')]);
 
         self::assertSame($user->object(), $comment->getUser());
         CommentFactory::assert()->count(1);

--- a/tests/Functional/ORMRepositoryProxyTest.php
+++ b/tests/Functional/ORMRepositoryProxyTest.php
@@ -11,7 +11,8 @@
 
 namespace Zenstruck\Foundry\Tests\Functional;
 
-use Doctrine\Common\Proxy\Proxy as DoctrineProxy;
+use Doctrine\Common\Proxy\Proxy as LegacyDoctrineProxy;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Post;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
@@ -58,7 +59,12 @@ final class ORMRepositoryProxyTest extends RepositoryProxyTest
         $category = CategoryFactory::random()->object();
 
         // ensure the category is a "doctrine proxy" and a Category
-        $this->assertInstanceOf(DoctrineProxy::class, $category);
+        if (interface_exists(DoctrineProxy::class)) {
+            $this->assertInstanceOf(DoctrineProxy::class, $category);
+        } else {
+            $this->assertInstanceOf(LegacyDoctrineProxy::class, $category);
+        }
+
         $this->assertInstanceOf(Category::class, $category);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,10 @@ if (\getenv('DATABASE_URL') && \getenv('TEST_MIGRATIONS')) {
     $application = new Application($kernel);
     $application->setAutoExit(false);
 
-    $application->run(new StringInput('doctrine:database:create --if-not-exists --no-interaction'), new NullOutput());
+    if (!str_starts_with(\getenv('DATABASE_URL'), 'sqlite')) {
+        $application->run(new StringInput('doctrine:database:create --if-not-exists --no-interaction'), new NullOutput());
+    }
+
     $application->run(new StringInput('doctrine:schema:drop --force --no-interaction'), new NullOutput());
     $application->run(new StringInput('doctrine:migrations:diff --no-interaction'), new NullOutput());
 


### PR DESCRIPTION
had to create a new PR for this 

I'm wondering if somehow we should add more CI permutations using `doctrine/orm:^2.0`?
I think there is only one permutation remaining which uses 2.x: the one with `--lowest`

