### PR TITLE
fix: only run maker test on php > 8.0

### DIFF
--- a/tests/Functional/Bundle/Maker/MakeFactoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeFactoryTest.php
@@ -40,6 +40,8 @@ use Zenstruck\Foundry\Tests\Fixtures\PHP81\EntityWithEnum;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ * @group maker
+ * @requires PHP 8.1
  */
 final class MakeFactoryTest extends MakerTestCase
 {

--- a/tests/Functional/Bundle/Maker/MakeStoryTest.php
+++ b/tests/Functional/Bundle/Maker/MakeStoryTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ * @group maker
+ * @requires PHP 8.1
  */
 final class MakeStoryTest extends MakerTestCase
 {

--- a/tests/Functional/Bundle/Maker/MakerTestCase.php
+++ b/tests/Functional/Bundle/Maker/MakerTestCase.php
@@ -17,6 +17,8 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ * @group maker
+ * @requires PHP 8.1
  */
 abstract class MakerTestCase extends KernelTestCase
 {


### PR DESCRIPTION
`symfony/maker-bundle` ships its own phpcs-fixer version. The one we need, which accepts our config is `v3.49.0` which is shiiped from [maker bundle 1.55.0](https://github.com/symfony/maker-bundle/releases/tag/v1.55.0)

but this version is incompatible with our lowest CI permutation.

This PR skips maker tests on CI with `--prefer-lowest` option and php 8.0

The problem will be fixed in Foundry 2.0, where we bump php 8.1