### PR TITLE
feat(sequence): sequence attributes should be compatible with 1.x

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -21,6 +21,7 @@ use Faker;
  * @template T
  * @phpstan-type Parameters = array<string,mixed>
  * @phpstan-type Attributes = Parameters|callable(int):Parameters
+ * @phpstan-type Sequence = iterable<Parameters>|callable(): iterable<Parameters>
  */
 abstract class Factory
 {
@@ -82,14 +83,13 @@ abstract class Factory
     }
 
     /**
-     * @param iterable<Attributes> $items
-     * @param Attributes           $attributes
+     * @param Sequence $sequence
      *
      * @return T[]
      */
-    final public static function createSequence(iterable $items, array|callable $attributes = []): array
+    final public static function createSequence(iterable|callable $sequence): array
     {
-        return static::new()->sequence($items)->create($attributes);
+        return static::new()->sequence($sequence)->create();
     }
 
     /**
@@ -116,12 +116,16 @@ abstract class Factory
     }
 
     /**
-     * @param  iterable<Attributes> $items
+     * @param  Sequence $sequence
      * @return FactoryCollection<T>
      */
-    final public function sequence(iterable $items): FactoryCollection
+    final public function sequence(iterable|callable $sequence): FactoryCollection
     {
-        return FactoryCollection::sequence($this, $items);
+        if (\is_callable($sequence)) {
+            $sequence = $sequence();
+        }
+
+        return FactoryCollection::sequence($this, $sequence);
     }
 
     /**

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -497,6 +497,18 @@ abstract class GenericFactoryTestCase extends KernelTestCase
 
     /**
      * @test
+     */
+    public function can_persist_object_with_sequence(): void
+    {
+        $this->factory()->sequence([['prop1' => 'foo'], ['prop1' => 'bar']])->create();
+
+        $this->factory()::assert()->count(2);
+        $this->factory()::assert()->exists(['prop1' => 'foo']);
+        $this->factory()::assert()->exists(['prop1' => 'bar']);
+    }
+
+    /**
+     * @test
      * @depends cannot_access_repository_method_when_persist_disabled
      */
     public function assert_persist_is_re_enabled_automatically(): void

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Object1Factory;
@@ -25,6 +26,8 @@ use function Zenstruck\Foundry\set;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @phpstan-import-type Sequence from Factory
  */
 final class ObjectFactoryTest extends TestCase
 {
@@ -332,11 +335,58 @@ final class ObjectFactoryTest extends TestCase
     }
 
     /**
+     * @dataProvider sequenceDataProvider
+     *
+     * @param Sequence $sequence
+     *
      * @test
      */
-    public function sequences(): void
+    public function can_create_sequence(iterable|callable $sequence): void
     {
-        $this->markTestIncomplete();
+        self::assertEquals(
+            [
+                new Object1('foo1', 'bar1'),
+                new Object1('foo2', 'bar2'),
+            ],
+            Object1Factory::createSequence($sequence),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{Sequence}>
+     */
+    public static function sequenceDataProvider(): iterable
+    {
+        yield 'sequence as array' => [
+            [
+                [
+                    'prop1' => 'foo1',
+                    'prop2' => 'bar1',
+                ],
+                [
+                    'prop1' => 'foo2',
+                    'prop2' => 'bar2',
+                ],
+            ],
+        ];
+
+        yield 'sequence as iterable which returns array' => [
+            static fn() => array_map(
+                static fn(int $i) => ['prop1' => "foo{$i}", 'prop2' => "bar{$i}"],
+                range(1, 2)
+            )
+        ];
+
+        yield 'sequence as iterable which returns generator' => [
+            static function () {
+                foreach (range(1, 2) as $i) {
+                    yield [
+                        'prop1' => "foo{$i}",
+                        'prop2' => "bar{$i}",
+                    ];
+                }
+            }
+        ];
     }
 
     /**


### PR DESCRIPTION
Sequence methods should have not changed their prototypes in foundry 2

FTR: https://symfony-devs.slack.com/archives/D011WDCE8MD/p1704902778401289?thread_ts=1704899786.641179&cid=D011WDCE8MD