### PR TITLE
[1.x] fix using stories with simple objects

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -59,6 +59,8 @@ class Factory
     /** @var callable[] */
     private array $afterPersist = [];
 
+    private bool $shouldPersist = true;
+
     /**
      * @param class-string<TObject> $class
      */
@@ -156,10 +158,10 @@ class Factory
         }
 
         if (!$this->isPersisting(calledInternally: true)) {
-            return $noProxy ? $object : new ProxyObject($object);
+            return $noProxy ? $object : new ProxyObject($object, $this->shouldPersist);
         }
 
-        $proxy = new ProxyObject($object);
+        $proxy = new ProxyObject($object, $this->shouldPersist);
 
         if ($this->cascadePersist && !$postPersistCallbacks) {
             return $proxy;
@@ -228,6 +230,7 @@ class Factory
 
         $cloned = clone $this;
         $cloned->persist = false;
+        $cloned->shouldPersist = false;
 
         return $cloned;
     }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -50,6 +50,8 @@ final class Proxy implements \Stringable, ProxyBase
     public function __construct(
         /** @param TProxiedObject $object */
         private object $object,
+
+        private bool $shouldPersist = true,
     ) {
         if ((new \ReflectionClass($object::class))->isFinal()) {
             trigger_deprecation(
@@ -174,6 +176,10 @@ final class Proxy implements \Stringable, ProxyBase
 
     public function _save(): static
     {
+        if (!$this->shouldPersist) {
+            return $this;
+        }
+
         $this->objectManager()->persist($this->object);
 
         if (Factory::configuration()->isFlushingEnabled()) {

--- a/tests/Fixtures/Factories/LegacyObjectFactory.php
+++ b/tests/Fixtures/Factories/LegacyObjectFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Factories;
+
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+class LegacyObjectFactory extends ModelFactory
+{
+    protected static function getClass(): string
+    {
+        return SomeObject::class;
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'propertyWithoutType' => self::faker()->word(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->withoutPersisting();
+    }
+}

--- a/tests/Fixtures/Stories/LegacyObjectStory.php
+++ b/tests/Fixtures/Stories/LegacyObjectStory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixtures\Stories;
+
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\Tests\Fixtures\Factories\LegacyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @method static SomeObject simpleObject()
+ */
+class LegacyObjectStory extends Story
+{
+    public function build(): void
+    {
+        $this->addState('simpleObject', LegacyObjectFactory::createOne());
+    }
+}

--- a/tests/Functional/StoryTest.php
+++ b/tests/Functional/StoryTest.php
@@ -19,8 +19,10 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixtures\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixtures\Factories\PostFactory;
+use Zenstruck\Foundry\Tests\Fixtures\Object\SomeObject;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\CategoryPoolStory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\CategoryStory;
+use Zenstruck\Foundry\Tests\Fixtures\Stories\LegacyObjectStory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\PostStory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\ServiceStory;
 use Zenstruck\Foundry\Tests\Fixtures\Stories\StoryWhichReadsItsOwnPool;
@@ -236,5 +238,15 @@ final class StoryTest extends KernelTestCase
         self::assertInstanceOf(Category::class, $item->_real());
 
         self::assertContains($item->_real()->getName(), ['php', 'symfony']);
+    }
+
+    /**
+     * @test
+     */
+    public function story_does_not_persist_legacy_object(): void
+    {
+        LegacyObjectStory::load();
+
+        self::assertInstanceOf(Proxy::class, LegacyObjectStory::simpleObject());
     }
 }


### PR DESCRIPTION
 - fix using stories with objects that can't be persisted

Current behavior:
![image](https://github.com/zenstruck/foundry/assets/40327885/3e27a024-6ee8-4ebd-8dfd-748abb76ecd6)

This is intended to be legacy code that shouldn't be merged / released in 2.x.

fixes: #573