### PR TITLE
fix(2.x): restore PHPUnit error handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "bamarni/composer-bin-plugin": "^1.8",
         "dama/doctrine-test-bundle": "^7.0|^8.0",
         "doctrine/common": "^3.2",
+        "doctrine/collections": "^1.7|^2.0",
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
         "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
@@ -43,7 +44,7 @@
     },
     "autoload": {
         "psr-4": { "Zenstruck\\Foundry\\": "src/" },
-        "files": ["src/functions.php", "src/Persistence/functions.php"]
+        "files": ["src/functions.php", "src/Persistence/functions.php", "src/phpunit_helper.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\Attributes\BeforeClass;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Persistence\PersistenceManager;
 
+use function Zenstruck\Foundry\restorePhpUnitErrorHandler;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -34,7 +36,10 @@ trait ResetDatabase
 
         PersistenceManager::resetDatabase(
             static fn() => static::bootKernel(),
-            static fn() => static::ensureKernelShutdown(),
+            static function (): void {
+                static::ensureKernelShutdown();
+                restorePhpUnitErrorHandler();
+            },
         );
     }
 
@@ -51,7 +56,10 @@ trait ResetDatabase
 
         PersistenceManager::resetSchema(
             static fn() => static::bootKernel(),
-            static fn() => static::ensureKernelShutdown(),
+            static function (): void {
+                static::ensureKernelShutdown();
+                restorePhpUnitErrorHandler();
+            },
         );
     }
 }

--- a/src/phpunit_helper.php
+++ b/src/phpunit_helper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry;
+
+/**
+ * When using ResetDatabase trait, we're booting the kernel,
+ * which registers the Symfony's error handler too soon.
+ * It is then impossible for PHPUnit to handle deprecations.
+ *
+ * This method tries to mitigate this problem by restoring the error handler.
+ *
+ * @see https://github.com/symfony/symfony/issues/53812
+ *
+ * @internal
+ */
+function restorePhpUnitErrorHandler(): void
+{
+    while (true) {
+        $previousHandler = set_error_handler(static fn() => null); // @phpstan-ignore-line
+        restore_error_handler();
+        $isPhpUnitErrorHandler = ($previousHandler instanceof \PHPUnit\Runner\ErrorHandler); // @phpstan-ignore-line
+        if ($previousHandler === null || $isPhpUnitErrorHandler) {
+            break;
+        }
+        restore_error_handler();
+    }
+}


### PR DESCRIPTION
this PR reproduces the behavior here: https://github.com/zenstruck/foundry/pull/577

At some point I'm wondering if we should not add in our tests permutations phpunit >= 10, WDYT?