### PR TITLE
Default to false for 'embedded' and 'targetDocument' mappings

### DIFF
--- a/src/Bundle/Maker/Factory/ODMDefaultPropertiesGuesser.php
+++ b/src/Bundle/Maker/Factory/ODMDefaultPropertiesGuesser.php
@@ -30,8 +30,7 @@ class ODMDefaultPropertiesGuesser extends AbstractDoctrineDefaultPropertiesGuess
         }
 
         foreach ($metadata->associationMappings as $item) {
-            /** @phpstan-ignore-next-line */
-            if (!$item['embedded'] || !$item['targetDocument']) {
+            if (!($item['embedded'] ?? false) || !($item['targetDocument'] ?? false)) {
                 // foundry does not support ODM references
                 continue;
             }


### PR DESCRIPTION
When an ODM reference is configured, the 'embedded' key may not be present at all in the association mapping. The missing key should be treated as implicit false. Without this the make:factory command will crash.