### PR TITLE
fix: prevent refresh error with autorefresh

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
     mysql:
         image: mysql:5.7

--- a/src/Persistence/Exception/RefreshObjectFailed.php
+++ b/src/Persistence/Exception/RefreshObjectFailed.php
@@ -15,9 +15,14 @@ namespace Zenstruck\Foundry\Persistence\Exception;
 
 final class RefreshObjectFailed extends \RuntimeException
 {
+    private function __construct(string $message, private bool $objectWasDeleted = false)
+    {
+        parent::__construct($message);
+    }
+
     public static function objectNoLongExists(): static
     {
-        return new self('object no longer exists...');
+        return new self('object no longer exists...', objectWasDeleted: true);
     }
 
     /**
@@ -28,5 +33,10 @@ final class RefreshObjectFailed extends \RuntimeException
         return new self(
             "Cannot auto refresh \"{$objectClass}\" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details)."
         );
+    }
+
+    public function objectWasDeleted(): bool
+    {
+        return $this->objectWasDeleted;
     }
 }

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -254,6 +254,17 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
     }
 
     /**
+     * @test
+     */
+    public function can_delete_proxified_object_and_still_access_its_methods(): void
+    {
+        $object = $this->factory()->create();
+        $object->_delete();
+
+        $this->assertSame('default1', $object->getProp1());
+    }
+
+    /**
      * @return PersistentProxyObjectFactory<GenericModel>
      */
     abstract protected function factory(): PersistentProxyObjectFactory; // @phpstan-ignore-line


### PR DESCRIPTION
when an proxified object is deleted, we should be able to call its methods and access its properties...