### PR TITLE
Fix `Instantiator::allowExtra` example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -642,7 +642,7 @@ You can customize the instantiator in several ways:
         ->instantiateWith(Instantiator::withoutConstructor())
 
         // "foo" and "bar" attributes are ignored when instantiating
-        ->instantiateWith(Instantiator::withConstructor()->allowExtra(['foo', 'bar']))
+        ->instantiateWith(Instantiator::withConstructor()->allowExtra('foo', 'bar'))
 
         // all extra attributes are ignored when instantiating
         ->instantiateWith(Instantiator::withConstructor()->allowExtra())


### PR DESCRIPTION
Fixes an example which leads to `Expected parameter of type 'string', 'string[]' provided`