### PR TITLE
ci: add sf 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,15 @@ jobs:
       matrix:
         php: [ 8.1, 8.2, 8.3 ]
         deps: [ highest ]
-        symfony: [ 6.4.*, 7.0.* ]
+        symfony: [ 6.4.*, 7.0.*, 7.1.* ]
         database: [ mysql, mongo ]
         use-dama: [ 1 ]
         use-migrate: [ 0 ]
         exclude:
           - php: 8.1
             symfony: 7.0.*
+          - php: 8.1
+            symfony: 7.1.*
         include:
           - php: 8.3
             deps: highest


### PR DESCRIPTION
our proxy system does not work with `symfony/var-exporter` 7.1:

```
TypeError: Value of type null returned from ZenstruckFoundryTestsFixtureDocumentGenericDocumentProxy::__get() must be compatible with unset property ZenstruckFoundryTestsFixtureDocumentGenericDocumentProxy::$_autoRefresh of type bool

/home/runner/work/foundry/foundry/src/Persistence/IsProxy.php:118
```
or
```
TypeError: Cannot assign null to property AppDomainProgrammingProxy::$_autoRefresh of type bool

/app/opa-v4/vendor/zenstruck/foundry/src/Persistence/IsProxy.php:48
```

I don't understand why it fails now, because everything is fine in `7.0.8` and nothing big was release since then https://github.com/symfony/var-exporter/releases

Here is how a proxy class generated with [`ProxyGenerator`](https://github.com/zenstruck/foundry/blob/2.x/src/Persistence/ProxyGenerator.php) looks like:
```php
<?php

class ZenstruckFoundryTestsFixtureEntityGenericEntityProxy extends \Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity implements \Zenstruck\Foundry\Persistence\Proxy, \Symfony\Component\VarExporter\LazyObjectInterface
{
    use \Zenstruck\Foundry\Persistence\IsProxy, \Symfony\Component\VarExporter\LazyProxyTrait;

    private const LAZY_OBJECT_PROPERTY_SCOPES = [
        "\0".'Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel'."\0".'date' => ['Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel', 'date', null],
        "\0".'Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel'."\0".'prop1' => ['Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel', 'prop1', null],
        'date' => ['Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel', 'date', null],
        'id' => [parent::class, 'id', null],
        'prop1' => ['Zenstruck\\Foundry\\Tests\\Fixture\\Model\\GenericModel', 'prop1', null],
    ];

    public function getProp1(): string
    {
        $this->_autoRefresh();

        if (isset($this->lazyObjectReal)) {
            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getProp1(...\func_get_args());
        }

        return parent::getProp1(...\func_get_args());
    }

    public function setProp1(string $prop1): void
    {
        $this->_autoRefresh();

        if (isset($this->lazyObjectReal)) {
            ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setProp1(...\func_get_args());
        } else {
            parent::setProp1(...\func_get_args());
        }
    }

    public function getDate(): ?\DateTimeImmutable
    {
        $this->_autoRefresh();

        if (isset($this->lazyObjectReal)) {
            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->getDate(...\func_get_args());
        }

        return parent::getDate(...\func_get_args());
    }

    public function setDate(?\DateTimeImmutable $date): void
    {
        $this->_autoRefresh();

        if (isset($this->lazyObjectReal)) {
            ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->setDate(...\func_get_args());
        } else {
            parent::setDate(...\func_get_args());
        }
    }
}

// Help opcache.preload discover always-needed symbols
class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
```