### PR TITLE
fix(2.x): add back second parameter for after persist callbacks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -562,14 +562,6 @@ they were added.
             // $object is the instantiated object
             // $attributes contains the attributes used to instantiate the object and any extras
         })
-        ->afterPersist(function(Proxy $proxy, array $attributes) {
-            /* @var Post $proxy */
-            // this event is only called if the object was persisted
-            // $proxy is a Proxy wrapping the persisted object
-            // $attributes contains the attributes used to instantiate the object and any extras
-        })
-
-        // if the first argument is type-hinted as the object, it will be passed to the closure (and not the proxy)
         ->afterPersist(function(Post $object, array $attributes) {
             // this event is only called if the object was persisted
             // $object is the persisted Post object

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -35,7 +35,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 {
     private bool $persist;
 
-    /** @var list<callable(T):void> */
+    /** @var list<callable(T, Parameters):void> */
     private array $afterPersist = [];
 
     /** @var list<callable(T):void> */
@@ -226,11 +226,13 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         $this->tempAfterPersist = [];
 
-        foreach ($this->afterPersist as $callback) {
-            $callback($object);
-        }
-
         if ($this->afterPersist) {
+            $attributes = $this->normalizeAttributes($attributes);
+
+            foreach ($this->afterPersist as $callback) {
+                $callback($object, $attributes);
+            }
+
             $configuration->persistence()->save($object);
         }
 
@@ -254,7 +256,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
     }
 
     /**
-     * @param callable(T):void $callback
+     * @param callable(T, Parameters):void $callback
      */
     final public function afterPersist(callable $callback): static
     {

--- a/src/Persistence/PersistentProxyObjectFactory.php
+++ b/src/Persistence/PersistentProxyObjectFactory.php
@@ -26,7 +26,7 @@ use Zenstruck\Foundry\FactoryCollection; // keep me!
  * @phpstan-type InstantiatorCallable = Instantiator|callable(Parameters,class-string<T>):T
  * @phpstan-import-type Parameters from Factory
  *
- * @phpstan-method static instantiateWith(InstantiatorCallable $instantiator)
+ * @phpstan-method $this instantiateWith(InstantiatorCallable $instantiator)
  *
  * @phpstan-method FactoryCollection<T&Proxy<T>> sequence(iterable<array<string, mixed>>|callable(): iterable<array<string, mixed>> $sequence)
  * @phpstan-method FactoryCollection<T&Proxy<T>> many(int $min, int|null $max = null)

--- a/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
@@ -14,7 +14,6 @@ namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\CascadeContact;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\CascadeAddressFactory;
-use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CascadeCategoryFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\Persistence;
 
+use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
@@ -262,6 +263,21 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
         $object->_delete();
 
         $this->assertSame('default1', $object->getProp1());
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_after_persist_with_attributes(): void
+    {
+        $object = $this->factory()
+            ->instantiateWith(Instantiator::withConstructor()->allowExtra('extra'))
+            ->afterPersist(function (GenericModel $object, array $attributes) {
+                $object->setProp1($attributes['extra']);
+            })
+            ->create(['extra' => $value = 'value set with after persist']);
+
+        $this->assertSame($value, $object->getProp1());
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/628

