### PR TITLE
fix: fix _autoRefresh dynamic creation deprecation

### DIFF
--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -113,10 +113,15 @@ trait IsProxy
         return new ProxyRepositoryDecorator(parent::class);
     }
 
+    private function _isAutoRefresh(): bool
+    {
+        return $this->_autoRefresh ?? true;
+    }
+
     private function _autoRefresh(): void
     {
         // "??=" fixes in ProxyHelper where object gets created without any props initialized
-        if (!($this->_autoRefresh ??= true)) {
+        if (!$this->_isAutoRefresh()) {
             return;
         }
 


### PR DESCRIPTION
Using Symfony 7.1, PHPUnit 11.2 and Foundry 2.0, I got the following error:

> 1) /shared/httpd/ae-api/vendor/symfony/var-exporter/Internal/LazyObjectRegistry.php:94
> Creation of dynamic property AE\Calendar\CalendarPeriod\Infrastructure\Persistence\Entity\CalendarPeriod::$_autoRefresh is deprecated
>
> Triggered by:
>
> * AE\Tests\Functional\Calendar\CalendarPeriod\CalendarPeriodOccurrenceApiTest::iCanDeleteACalendarPeriodOccurrence
>   /shared/httpd/ae-api/tests/phpunit/Functional/Calendar/CalendarPeriod/CalendarPeriodOccurrenceApiTest.php:166

This is due to `IsProxy::_autoRefresh` affectation. I don't know exactly why this error occurred, but moving the `_autoRefresh` dynamic affectation in a dedicated method seems to solve this deprecation.

Reproducer: https://github.com/zenstruck/foundry/actions/runs/9481854069/job/26125482758