### PR TITLE
fix: Attributes added in `beforeInstantiate` are not passed to `afterPersist`

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,11 +28,18 @@ abstract class Factory
     /** @var Attributes[] */
     private array $attributes;
 
+    /**
+     * Memoization of normalized parameters
+     *
+     * @internal
+     * @var Parameters|null
+     */
+    protected array|null $normalizedParameters = null;
+
     // keep an empty constructor for BC
     public function __construct()
     {
     }
-
 
     /**
      * @param Attributes $attributes
@@ -145,6 +152,16 @@ abstract class Factory
     }
 
     /**
+     * Override to adjust default attributes & config.
+     *
+     * @return static
+     */
+    protected function initialize(): static
+    {
+        return $this;
+    }
+
+    /**
      * @internal
      *
      * @param Attributes $attributes
@@ -171,16 +188,6 @@ abstract class Factory
     }
 
     /**
-     * Override to adjust default attributes & config.
-     *
-     * @return static
-     */
-    protected function initialize(): static
-    {
-        return $this;
-    }
-
-    /**
      * @internal
      *
      * @param Parameters $parameters
@@ -189,7 +196,7 @@ abstract class Factory
      */
     protected function normalizeParameters(array $parameters): array
     {
-        return array_combine(
+        return $this->normalizedParameters = array_combine(
             array_keys($parameters),
             \array_map($this->normalizeParameter(...), array_keys($parameters), $parameters)
         );

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -226,7 +226,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
         $this->tempAfterPersist = [];
 
         if ($this->afterPersist) {
-            $attributes = $this->normalizeAttributes($attributes);
+            $attributes = $this->normalizedParameters ?? throw new \LogicException('Factory::$normalizedParameters has not been initialized.');
 
             foreach ($this->afterPersist as $callback) {
                 $callback($object, $attributes);

--- a/tests/Integration/ObjectFactoryTest.php
+++ b/tests/Integration/ObjectFactoryTest.php
@@ -44,4 +44,20 @@ final class ObjectFactoryTest extends KernelTestCase
 
         $this->assertSame('router-constructor', $object->object->getProp1());
     }
+
+    /**
+     * @test
+     */
+    public function can_create_different_objects_based_on_same_factory(): void
+    {
+        $factory = Object1Factory::new(['prop1' => 'first object']);
+        $object1 = $factory->create();
+        self::assertSame('first object-constructor', $object1->getProp1());
+
+        $object2 = $factory->create(['prop1' => 'second object']);
+        self::assertSame('second object-constructor', $object2->getProp1());
+
+        $object3 = $factory->with(['prop1' => 'third object'])->create();
+        self::assertSame('third object-constructor', $object3->getProp1());
+    }
 }

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -281,6 +281,27 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
     }
 
     /**
+     * @test
+     */
+    public function can_use_after_persist_with_attributes_added_in_before_instantiate(): void
+    {
+        $value = 'value set with before instantiate';
+        $object = $this->factory()
+            ->instantiateWith(Instantiator::withConstructor()->allowExtra('extra'))
+            ->beforeInstantiate(function (array $attributes) use ($value) {
+                $attributes['extra'] = $value;
+
+                return $attributes;
+            })
+            ->afterPersist(function (GenericModel $object, array $attributes) {
+                $object->setProp1($attributes['extra']);
+            })
+            ->create();
+
+        $this->assertSame($value, $object->getProp1());
+    }
+
+    /**
      * @return PersistentProxyObjectFactory<GenericModel>
      */
     abstract protected function factory(): PersistentProxyObjectFactory; // @phpstan-ignore-line


### PR DESCRIPTION
Followup to quick fix in #631 that demonstrates an edge case it didn't fix.