### PR TITLE
fix: unproxy args in proxy objects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -231,21 +231,21 @@ This command will generate a ``PostFactory`` class that looks like this:
          * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
          * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
          *
-         * @phpstan-method Proxy<Post> create(array|callable $attributes = [])
-         * @phpstan-method static Proxy<Post> createOne(array $attributes = [])
-         * @phpstan-method static Proxy<Post> find(object|array|mixed $criteria)
-         * @phpstan-method static Proxy<Post> findOrCreate(array $attributes)
-         * @phpstan-method static Proxy<Post> first(string $sortedField = 'id')
-         * @phpstan-method static Proxy<Post> last(string $sortedField = 'id')
-         * @phpstan-method static Proxy<Post> random(array $attributes = [])
-         * @phpstan-method static Proxy<Post> randomOrCreate(array $attributes = [])
-         * @phpstan-method static list<Proxy<Post>> all()
-         * @phpstan-method static list<Proxy<Post>> createMany(int $number, array|callable $attributes = [])
-         * @phpstan-method static list<Proxy<Post>> createSequence(array|callable $sequence)
-         * @phpstan-method static list<Proxy<Post>> findBy(array $attributes)
-         * @phpstan-method static list<Proxy<Post>> randomRange(int $min, int $max, array $attributes = [])
-         * @phpstan-method static list<Proxy<Post>> randomSet(int $number, array $attributes = [])
-         * @phpstan-method static RepositoryProxy<Post> repository()
+         * @phpstan-method Proxy<Post>&Post create(array|callable $attributes = [])
+         * @phpstan-method static Proxy<Post>&Post createOne(array $attributes = [])
+         * @phpstan-method static Proxy<Post>&Post find(object|array|mixed $criteria)
+         * @phpstan-method static Proxy<Post>&Post findOrCreate(array $attributes)
+         * @phpstan-method static Proxy<Post>&Post first(string $sortedField = 'id')
+         * @phpstan-method static Proxy<Post>&Post last(string $sortedField = 'id')
+         * @phpstan-method static Proxy<Post>&Post random(array $attributes = [])
+         * @phpstan-method static Proxy<Post>&Post randomOrCreate(array $attributes = [])
+         * @phpstan-method static list<Proxy<Post>&Post> all()
+         * @phpstan-method static list<Proxy<Post>&Post> createMany(int $number, array|callable $attributes = [])
+         * @phpstan-method static list<Proxy<Post>&Post> createSequence(array|callable $sequence)
+         * @phpstan-method static list<Proxy<Post>&Post> findBy(array $attributes)
+         * @phpstan-method static list<Proxy<Post>&Post> randomRange(int $min, int $max, array $attributes = [])
+         * @phpstan-method static list<Proxy<Post>&Post> randomSet(int $number, array $attributes = [])
+         * @phpstan-method static RepositoryProxy<Post>&Post repository()
          */
         final class PostFactory extends PersistentProxyObjectFactory
         {
@@ -1392,6 +1392,21 @@ Without auto-refreshing enabled, the above call to ``$post->getTitle()`` would r
             $post->setBody('New Body');
         });
         $post->_save();
+
+Proxy objects pitfalls
+......................
+
+Proxified objects may have some pitfalls when dealing with Doctrine's entity manager. You may encounter this error:
+
+> Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship
+'App\Entity\Post#category' that was not configured to cascade persist operations for entity: AppEntityCategoryProxy@3082.
+To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist
+this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity
+causes the problem implement 'App\Entity\Category#__toString()' to get a clue.
+
+The problem will occur if a proxy has been passed to ``EntityManager::persist()``. To fix this, you should pass the "real"
+object, by calling ``$proxyfiedObject->_real()``.
+
 
 Factory without proxy
 .....................

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -144,4 +144,10 @@ trait IsProxy
 
         static::$_autoRefresh[\spl_object_id($real)] = $autoRefresh;
     }
+
+    // used in ProxyGenerator
+    private function unproxyArgs(array $args): array
+    {
+        return \array_map(unproxy(...), $args);
+    }
 }

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -85,18 +85,14 @@ final class ProxyGenerator
         }
 
         $proxyCode = 'class '.$proxyClass.ProxyHelper::generateLazyProxy(new \ReflectionClass($class));
-        $proxyCode = \str_replace(
+        $proxyCode = \strtr(
+            $proxyCode,
             [
-                'implements \Symfony\Component\VarExporter\LazyObjectInterface',
-                'use \Symfony\Component\VarExporter\LazyProxyTrait;',
-                'if (isset($this->lazyObjectState)) {',
+                'implements \Symfony\Component\VarExporter\LazyObjectInterface' => \sprintf('implements \%s, \Symfony\Component\VarExporter\LazyObjectInterface', Proxy::class),
+                'use \Symfony\Component\VarExporter\LazyProxyTrait;' => \sprintf('use \\%s, \\Symfony\\Component\\VarExporter\\LazyProxyTrait;', IsProxy::class),
+                'if (isset($this->lazyObjectState)) {' => "\$this->_autoRefresh();\n\n        if (isset(\$this->lazyObjectReal)) {",
+                '\func_get_args()' => '$this->unproxyArgs(\func_get_args())',
             ],
-            [
-                \sprintf('implements \%s, \Symfony\Component\VarExporter\LazyObjectInterface', Proxy::class),
-                \sprintf('use \\%s, \\Symfony\\Component\\VarExporter\\LazyProxyTrait;', IsProxy::class),
-                "\$this->_autoRefresh();\n\n        if (isset(\$this->lazyObjectReal)) {",
-            ],
-            $proxyCode
         );
 
         eval($proxyCode); // @phpstan-ignore-line

--- a/tests/Fixture/Entity/Address.php
+++ b/tests/Fixture/Entity/Address.php
@@ -33,10 +33,8 @@ abstract class Address extends Base
         return $this->city;
     }
 
-    public function setCity(string $city): static
+    public function setCity(string $city): void
     {
         $this->city = $city;
-
-        return $this;
     }
 }

--- a/tests/Fixture/Entity/Contact.php
+++ b/tests/Fixture/Entity/Contact.php
@@ -50,11 +50,9 @@ abstract class Contact extends Base
         return $this->name;
     }
 
-    public function setName(string $name): static
+    public function setName(string $name): void
     {
         $this->name = $name;
-
-        return $this;
     }
 
     public function getCategory(): ?Category
@@ -62,11 +60,9 @@ abstract class Contact extends Base
         return $this->category;
     }
 
-    public function setCategory(?Category $category): static
+    public function setCategory(?Category $category): void
     {
         $this->category = $category;
-
-        return $this;
     }
 
     public function getSecondaryCategory(): ?Category
@@ -87,20 +83,16 @@ abstract class Contact extends Base
         return $this->tags;
     }
 
-    public function addTag(Tag $tag): static
+    public function addTag(Tag $tag): void
     {
         if (!$this->tags->contains($tag)) {
             $this->tags->add($tag);
         }
-
-        return $this;
     }
 
-    public function removeTag(Tag $tag): static
+    public function removeTag(Tag $tag): void
     {
         $this->tags->removeElement($tag);
-
-        return $this;
     }
 
     /**
@@ -130,10 +122,8 @@ abstract class Contact extends Base
         return $this->address;
     }
 
-    public function setAddress(Address $address): static
+    public function setAddress(Address $address): void
     {
         $this->address = $address;
-
-        return $this;
     }
 }

--- a/tests/Fixture/Entity/Tag/CascadeTag.php
+++ b/tests/Fixture/Entity/Tag/CascadeTag.php
@@ -22,7 +22,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 #[ORM\Entity]
 class CascadeTag extends Tag
 {
-    #[ORM\ManyToMany(targetEntity: CascadeContact::class, mappedBy: 'tags', cascade: ['persist', 'remove'])]
+    #[ORM\ManyToMany(targetEntity: CascadeContact::class, mappedBy: 'tags', cascade: ['persist', 'remove'], fetch: 'EAGER')]
     protected Collection $contacts;
 
     #[ORM\ManyToMany(targetEntity: CascadeContact::class, mappedBy: 'secondaryTags', cascade: ['persist', 'remove'])]

--- a/tests/Fixture/Entity/Tag/StandardTag.php
+++ b/tests/Fixture/Entity/Tag/StandardTag.php
@@ -22,7 +22,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 #[ORM\Entity]
 class StandardTag extends Tag
 {
-    #[ORM\ManyToMany(targetEntity: StandardContact::class, mappedBy: 'tags')]
+    #[ORM\ManyToMany(targetEntity: StandardContact::class, mappedBy: 'tags', fetch: 'EAGER')]
     protected Collection $contacts;
 
     #[ORM\ManyToMany(targetEntity: StandardContact::class, mappedBy: 'secondaryTags')]

--- a/tests/Fixture/Factories/Entity/Address/ProxyCascadeAddressFactory.php
+++ b/tests/Fixture/Factories/Entity/Address/ProxyCascadeAddressFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address;
+
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Address\CascadeAddress;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @extends PersistentProxyObjectFactory<CascadeAddress>
+ */
+final class ProxyCascadeAddressFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return CascadeAddress::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'city' => self::faker()->city(),
+        ];
+    }
+}

--- a/tests/Fixture/Factories/Entity/Category/ProxyCascadeCategoryFactory.php
+++ b/tests/Fixture/Factories/Entity/Category/ProxyCascadeCategoryFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category;
+
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category\CascadeCategory;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @extends PersistentProxyObjectFactory<CascadeCategory>
+ */
+final class ProxyCascadeCategoryFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return CascadeCategory::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+}

--- a/tests/Fixture/Factories/Entity/Contact/ProxyCascadeContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/ProxyCascadeContactFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact;
+
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\CascadeContact;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyCascadeAddressFactory;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @extends PersistentProxyObjectFactory<CascadeContact>
+ */
+final class ProxyCascadeContactFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return CascadeContact::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'name' => self::faker()->word(),
+            //            'category' => ProxyCategoryFactory::new(),
+            'address' => ProxyCascadeAddressFactory::new(),
+        ];
+    }
+}

--- a/tests/Fixture/Factories/Entity/Tag/ProxyCascadeTagFactory.php
+++ b/tests/Fixture/Factories/Entity/Tag/ProxyCascadeTagFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag;
+
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Tag\CascadeTag;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @extends PersistentProxyObjectFactory<CascadeTag>
+ */
+final class ProxyCascadeTagFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return CascadeTag::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+}

--- a/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyCascadeAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\ProxyCascadeCategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyCascadeContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyCascadeTagFactory;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class ProxyCascadeEntityFactoryRelationshipTest extends ProxyEntityFactoryRelationshipTestCase
+{
+    protected function contactFactory(): PersistentObjectFactory
+    {
+        return ProxyCascadeContactFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function categoryFactory(): PersistentObjectFactory
+    {
+        return ProxyCascadeCategoryFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function tagFactory(): PersistentObjectFactory
+    {
+        return ProxyCascadeTagFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function addressFactory(): PersistentObjectFactory
+    {
+        return ProxyCascadeAddressFactory::new(); // @phpstan-ignore-line
+    }
+}

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
@@ -11,11 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
-use Zenstruck\Foundry\Persistence\Proxy;
-use Zenstruck\Foundry\Tests\Fixture\Entity\Category\StandardCategory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyAddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\ProxyCategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyContactFactory;
@@ -24,32 +20,8 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyTagFactory;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class EntityProxyFactoryRelationshipTest extends EntityFactoryRelationshipTest
+final class ProxyEntityFactoryRelationshipTest extends ProxyEntityFactoryRelationshipTestCase
 {
-    /**
-     * @see https://github.com/zenstruck/foundry/issues/42
-     *
-     * @test
-     */
-    public function doctrine_proxies_are_converted_to_foundry_proxies(): void
-    {
-        $this->contactFactory()->create(['category' => $this->categoryFactory()]);
-
-        // clear the em so nothing is tracked
-        self::getContainer()->get(EntityManagerInterface::class)->clear(); // @phpstan-ignore-line
-
-        // load a random Contact which causes the em to track a "doctrine proxy" for category
-        $this->contactFactory()::random();
-
-        // load a random Category which should be a "doctrine proxy"
-        $category = $this->categoryFactory()::random();
-
-        // ensure the category is a "doctrine proxy" and a Category
-        $this->assertInstanceOf(Proxy::class, $category);
-        $this->assertInstanceOf(DoctrineProxy::class, $category->_real());
-        $this->assertInstanceOf(StandardCategory::class, $category);
-    }
-
     protected function contactFactory(): PersistentObjectFactory
     {
         return ProxyContactFactory::new(); // @phpstan-ignore-line

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @method PersistentProxyObjectFactory<Contact> contactFactory()
+ * @method PersistentProxyObjectFactory<Category> categoryFactory()
+ * @method PersistentProxyObjectFactory<Tag> tagFactory()
+ * @method PersistentProxyObjectFactory<Address> addressFactory()
+ */
+abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelationshipTest
+{
+    /**
+     * @see https://github.com/zenstruck/foundry/issues/42
+     *
+     * @test
+     */
+    public function doctrine_proxies_are_converted_to_foundry_proxies(): void
+    {
+        $this->contactFactory()->create(['category' => $this->categoryFactory()]);
+
+        // clear the em so nothing is tracked
+        self::getContainer()->get(EntityManagerInterface::class)->clear(); // @phpstan-ignore-line
+
+        // load a random Contact which causes the em to track a "doctrine proxy" for category
+        $this->contactFactory()::random();
+
+        // load a random Category which should be a "doctrine proxy"
+        $category = $this->categoryFactory()::random();
+
+        // ensure the category is a "doctrine proxy" and a Category
+        $this->assertInstanceOf(Proxy::class, $category);
+        $this->assertInstanceOf(DoctrineProxy::class, $category->_real());
+        $this->assertInstanceOf($this->categoryFactory()::class(), $category);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_proxy_to_many_to_one(): void
+    {
+        $contact = $this->contactFactory()->create();
+
+        $contact->setCategory($category = $this->categoryFactory()->create());
+        $contact->_save();
+
+        $this->contactFactory()::assert()->count(1);
+        $this->contactFactory()::assert()->exists(['category' => $category]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_proxy_to_one_to_many(): void
+    {
+        $contact = $this->contactFactory()->create();
+
+        $contact->addTag($this->tagFactory()->create());
+        $contact->_save();
+
+        $this->contactFactory()::assert()->count(1);
+        $tag = $this->tagFactory()::first();
+        self::assertContains($contact->_real(), $tag->getContacts());
+    }
+}

--- a/tests/Integration/ORM/ProxyGenericEntityRepositoryDecoratorTest.php
+++ b/tests/Integration/ORM/ProxyGenericEntityRepositoryDecoratorTest.php
@@ -17,7 +17,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\GenericRepositoryDecoratorTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
-final class GenericProxyEntityRepositoryDecoratorTest extends GenericRepositoryDecoratorTestCase
+final class ProxyGenericEntityRepositoryDecoratorTest extends GenericRepositoryDecoratorTestCase
 {
     use RequiresORM;
 


### PR DESCRIPTION
Here is a first attempt to mitigate the problem when proxy objects are passed to entity manager.

I also tried to explain the problem in the docs.