### PR TITLE
docs: kernel must be shutdown sometimes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1170,6 +1170,7 @@ Let's look at an example:
         $this->assertCount(0, $post->getComments());
 
         // 2. "Act"
+        static::ensureKernelShutdown(); // Note kernel must be shutdown if you use factories before create client
         $client = static::createClient();
         $client->request('GET', '/posts/post-a'); // Note the slug from the arrange step
         $client->submitForm('Add', [


### PR DESCRIPTION
I begin to use Foundry on a new project.

Follow the docs to write a first tests and we can't create client after boot kernel (Kernel is boot by Trait [`Factories`](https://github.com/zenstruck/foundry/blob/2.x/src/Test/Factories.php)).

We need to ensure kernel is shutdown or create client before call factory.