### PR TITLE
fix(1.x): only reset error handler in before class hook

### DIFF
--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -56,7 +56,7 @@ trait Factories
             ),
         );
 
-        KernelHelper::shutdownKernel($kernel);
+        $kernel->shutdown();
     }
 
     /**

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -80,7 +80,7 @@ trait ResetDatabase
 
         DatabaseResetter::resetSchema($kernel);
 
-        KernelHelper::shutdownKernel($kernel);
+        $kernel->shutdown();
     }
 
     private static function shouldReset(KernelInterface $kernel): bool


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/640