### PR TITLE
fix(2.x): only reset error handler in before class hook

### DIFF
--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -56,10 +56,7 @@ trait ResetDatabase
 
         PersistenceManager::resetSchema(
             static fn() => static::bootKernel(),
-            static function(): void {
-                static::ensureKernelShutdown();
-                restorePhpUnitErrorHandler();
-            },
+            static fn() => static::ensureKernelShutdown(),
         );
     }
 }


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/640