### PR TITLE
fix: handle contravariance problem when proxifying class with unserialize method

### DIFF
--- a/bin/tools/phpstan/composer.json
+++ b/bin/tools/phpstan/composer.json
@@ -4,7 +4,8 @@
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-symfony": "^1.2",
         "phpstan/extension-installer": "1.2",
-        "phpstan/phpstan-doctrine": "^1.3"
+        "phpstan/phpstan-doctrine": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.4"
     },
     "config": {
         "allow-plugins": {

--- a/bin/tools/phpstan/composer.lock
+++ b/bin/tools/phpstan/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b1db52830170e81543331f5296b2055",
+    "content-hash": "40a8977707f373834de0ae705ccfa2b9",
     "packages": [
         {
             "name": "ekino/phpstan-banned-code",
@@ -244,6 +244,58 @@
                 "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.4.1"
             },
             "time": "2024-05-28T15:37:29+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f3ea021866f4263f07ca3636bf22c64be9610c11",
+                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.0"
+            },
+            "time": "2024-04-20T06:39:00+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,10 @@ parameters:
 
         - message: '#Attribute class PHPUnit\\Framework\\Attributes\\(.*) does not exist.#'
 
+        # prevent PHPStan to force to type data providers
+        - identifier: missingType.iterableValue
+          path: tests/
+
     excludePaths:
         - tests/Fixture/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
         - tests/Fixture/Maker/expected/can_create_factory_interactively.php

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Persistence;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Persistence\ProxyGenerator;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class ProxyGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider classWithUnserializeMagicMethodProvider
+     */
+    public function it_can_generate_proxy_for_class_with_unserialize_magic_method(object $obj): void
+    {
+        $proxyfiedObj = ProxyGenerator::wrap($obj);
+        self::assertEquals(unserialize(serialize($proxyfiedObj))->_real(), $proxyfiedObj->_real());
+
+        // if this assertion fails, https://github.com/symfony/symfony/pull/57460 have been released
+        // so, the monkey patch around contravariance problem could be removed
+        self::assertFalse((new \ReflectionClass($proxyfiedObj))->hasMethod('__doUnserialize'));
+    }
+
+    public static function classWithUnserializeMagicMethodProvider(): iterable
+    {
+        yield 'not type hinted __unserialize method' => [new ClassWithNoTypeHintInUnserialize()];
+        yield 'type hinted __unserialize method' => [new ClassWithTypeHintedUnserialize()];
+    }
+}
+
+class ClassWithNoTypeHintInUnserialize
+{
+    public function __unserialize($array) // @phpstan-ignore missingType.parameter
+    {
+    }
+}
+
+class ClassWithTypeHintedUnserialize
+{
+    public function __unserialize(array $array)
+    {
+    }
+}


### PR DESCRIPTION
I'm monkey patching this in Foundry, since it is a blocker for several users.

fixes https://github.com/zenstruck/foundry/issues/639

see https://github.com/symfony/symfony/pull/57460
We'll remove this code when the PR in Symfony will be released (it targets 6.4, so it will be enough to remove completely this code)