### PR TITLE
fix: don't try to proxify objects that are not persistable

### DIFF
--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -362,6 +362,15 @@ final class PersistenceManager
         }
     }
 
+    public function hasPersistenceFor(object $object): bool
+    {
+        try {
+            return (bool) $this->strategyFor($object::class);
+        } catch (NoPersistenceStrategy) {
+            return false;
+        }
+    }
+
     private static function canSkipSchemaReset(): bool
     {
         return self::$ormOnly && self::isDAMADoctrineTestBundleEnabled();

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -19,7 +19,6 @@ use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\ObjectFactory;
-use Zenstruck\Foundry\Persistence\Exception\NoPersistenceStrategy;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
 use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 
@@ -320,9 +319,15 @@ abstract class PersistentObjectFactory extends ObjectFactory
             return $object;
         }
 
+        $configuration = Configuration::instance();
+
+        if (!$configuration->isPersistenceAvailable() || !$configuration->persistence()->hasPersistenceFor($object)) {
+            return $object;
+        }
+
         try {
             return proxy($object)->_refresh()->_real();
-        } catch (PersistenceNotAvailable|RefreshObjectFailed|NoPersistenceStrategy|VarExportLogicException) {
+        } catch (RefreshObjectFailed|VarExportLogicException) {
             return $object;
         }
     }

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -78,7 +78,7 @@ final class ProxyGenerator
     {
         /** @var class-string $class */
         $class = $object instanceof DoctrineProxy ? \get_parent_class($object) : $object::class;
-        $proxyClass = \str_replace('\\', '', $class).'Proxy';
+        $proxyClass = self::proxyClassNameFor($class);
 
         /** @var class-string<LazyObjectInterface&Proxy<T>&T> $proxyClass */
         if (\class_exists($proxyClass, autoload: false)) {
@@ -142,5 +142,13 @@ final class ProxyGenerator
         }
 
         return $proxyCode;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function proxyClassNameFor(string $class): string
+    {
+        return \str_replace('\\', '', $class).'Proxy';
     }
 }

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -16,6 +16,7 @@ use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\ProxyGenerator;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
@@ -528,6 +529,15 @@ abstract class GenericFactoryTestCase extends KernelTestCase
     {
         $object = $this->factory()->create(['date' => $date = new \DateTimeImmutable()]);
         self::assertSame($date->format(\DateTimeInterface::ATOM), $object->getDate()?->format(\DateTimeInterface::ATOM));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_create_proxy_for_not_persistable_objects(): void
+    {
+        $this->factory()->create(['date' => new \DateTimeImmutable()]);
+        self::assertFalse(class_exists(ProxyGenerator::proxyClassNameFor(\DateTimeImmutable::class)));
     }
 
     /**


### PR DESCRIPTION
this is kinda related to https://github.com/zenstruck/foundry/issues/639

this `PhoneNumber` object should have never been proxyfied...
