### PR TITLE
fix: after_flush() can use objects created in global state

### DIFF
--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -205,9 +205,9 @@ final class PersistenceManager
      *
      * @return T
      */
-    public function refresh(object &$object): object
+    public function refresh(object &$object, bool $force = false): object
     {
-        if (!$this->flush) {
+        if (!$this->flush && !$force) {
             return $object;
         }
 

--- a/src/Story.php
+++ b/src/Story.php
@@ -11,6 +11,10 @@
 
 namespace Zenstruck\Foundry;
 
+use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
+use Zenstruck\Foundry\Persistence\Exception\NoPersistenceStrategy;
+use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -127,7 +131,11 @@ abstract class Story
             throw new \InvalidArgumentException(\sprintf('"%s" was not registered. Did you forget to call "%s::addState()"?', $name, static::class));
         }
 
-        return $this->state[$name];
+        try {
+            return Configuration::instance()->persistence()->refresh($this->state[$name], force: true); // @phpstan-ignore argument.templateType
+        } catch (PersistenceNotAvailable|NoPersistenceStrategy|RefreshObjectFailed) {
+            return $this->state[$name];
+        }
     }
 
     final protected function addToPool(string $pool, mixed $value): self

--- a/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/CascadeRelationshipWithGlobalEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/CascadeRelationshipWithGlobalEntity.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity;
+
+use Zenstruck\Foundry\Tests\Fixture\Entity\GlobalEntity;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+class CascadeRelationshipWithGlobalEntity extends RelationshipWithGlobalEntity
+{
+    #[ORM\ManyToOne(targetEntity: GlobalEntity::class, cascade: ['persist'])]
+    protected ?GlobalEntity $globalEntity = null;
+}

--- a/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/RelationshipWithGlobalEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/RelationshipWithGlobalEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Entity\GlobalEntity;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\MappedSuperclass]
+abstract class RelationshipWithGlobalEntity
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    protected ?GlobalEntity $globalEntity = null;
+
+    public function setGlobalEntity(?GlobalEntity $globalEntity): void
+    {
+        $this->globalEntity = $globalEntity;
+    }
+
+    public function getGlobalEntity(): ?GlobalEntity
+    {
+        return $this->globalEntity;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/StandardRelationshipWithGlobalEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/RelationshipWithGlobalEntity/StandardRelationshipWithGlobalEntity.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Entity\GlobalEntity;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+class StandardRelationshipWithGlobalEntity extends RelationshipWithGlobalEntity
+{
+    #[ORM\ManyToOne(targetEntity: GlobalEntity::class)]
+    protected ?GlobalEntity $globalEntity = null;
+}

--- a/tests/Fixture/Stories/GlobalStory.php
+++ b/tests/Fixture/Stories/GlobalStory.php
@@ -19,13 +19,15 @@ use function Zenstruck\Foundry\Persistence\persist;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
+ * @method static GlobalEntity globalEntity()
  */
 final class GlobalStory extends Story
 {
     public function build(): void
     {
         if (\getenv('DATABASE_URL')) {
-            persist(GlobalEntity::class);
+            $globalEntity = persist(GlobalEntity::class);
+            $this->addState('globalEntity', $globalEntity);
         }
 
         if (\getenv('MONGO_URL')) {

--- a/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
@@ -12,15 +12,17 @@
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity\CascadeRelationshipWithGlobalEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\CascadeAddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CascadeCategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\CascadeContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\CascadeTagFactory;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationshipTest
+final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationshipTestCase
 {
     /**
      * @test
@@ -112,5 +114,10 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
     protected function addressFactory(): PersistentObjectFactory
     {
         return CascadeAddressFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function relationshipWithGlobalEntityFactory(): PersistentObjectFactory
+    {
+        return persistent_factory(CascadeRelationshipWithGlobalEntity::class); // @phpstan-ignore-line
     }
 }

--- a/tests/Integration/ORM/PolymorphicEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/PolymorphicEntityFactoryRelationshipTest.php
@@ -17,7 +17,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ChildContactFactory
 /**
  * tests behavior with inheritance.
  */
-class PolymorphicEntityFactoryRelationshipTest extends EntityFactoryRelationshipTest
+class PolymorphicEntityFactoryRelationshipTest extends StandardEntityFactoryRelationshipTest
 {
     protected function contactFactory(): PersistentObjectFactory
     {

--- a/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
@@ -12,10 +12,12 @@
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity\CascadeRelationshipWithGlobalEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyCascadeAddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\ProxyCascadeCategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyCascadeContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyCascadeTagFactory;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -40,5 +42,10 @@ final class ProxyCascadeEntityFactoryRelationshipTest extends ProxyEntityFactory
     protected function addressFactory(): PersistentObjectFactory
     {
         return ProxyCascadeAddressFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function relationshipWithGlobalEntityFactory(): PersistentObjectFactory
+    {
+        return proxy_factory(CascadeRelationshipWithGlobalEntity::class); // @phpstan-ignore-line
     }
 }

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
@@ -12,10 +12,12 @@
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity\StandardRelationshipWithGlobalEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyAddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\ProxyCategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyTagFactory;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -40,5 +42,10 @@ final class ProxyEntityFactoryRelationshipTest extends ProxyEntityFactoryRelatio
     protected function addressFactory(): PersistentObjectFactory
     {
         return ProxyAddressFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function relationshipWithGlobalEntityFactory(): PersistentObjectFactory
+    {
+        return proxy_factory(StandardRelationshipWithGlobalEntity::class); // @phpstan-ignore-line
     }
 }

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
@@ -18,6 +18,7 @@ use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity\RelationshipWithGlobalEntity;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 
 /**
@@ -27,8 +28,9 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
  * @method PersistentProxyObjectFactory<Category> categoryFactory()
  * @method PersistentProxyObjectFactory<Tag>      tagFactory()
  * @method PersistentProxyObjectFactory<Address>  addressFactory()
+ * @method PersistentProxyObjectFactory<RelationshipWithGlobalEntity>  relationshipWithGlobalEntityFactory()
  */
-abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelationshipTest
+abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelationshipTestCase
 {
     /**
      * @see https://github.com/zenstruck/foundry/issues/42

--- a/tests/Integration/ORM/StandardEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/StandardEntityFactoryRelationshipTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity\StandardRelationshipWithGlobalEntity;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\StandardAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\StandardCategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\StandardContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\RichDomainMandatoryRelationship;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\StandardTagFactory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\GlobalStory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+use function Zenstruck\Foundry\Persistence\flush_after;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+use function Zenstruck\Foundry\Persistence\unproxy;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+class StandardEntityFactoryRelationshipTest extends EntityFactoryRelationshipTestCase
+{
+    protected function contactFactory(): PersistentObjectFactory
+    {
+        return StandardContactFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function categoryFactory(): PersistentObjectFactory
+    {
+        return StandardCategoryFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function tagFactory(): PersistentObjectFactory
+    {
+        return StandardTagFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function addressFactory(): PersistentObjectFactory
+    {
+        return StandardAddressFactory::new(); // @phpstan-ignore-line
+    }
+
+    protected function relationshipWithGlobalEntityFactory(): PersistentObjectFactory
+    {
+        return persistent_factory(StandardRelationshipWithGlobalEntity::class); // @phpstan-ignore-line
+    }
+}


### PR DESCRIPTION
fixes #649