### PR TITLE
feat: re-add Proxy assertions

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -246,10 +246,10 @@ This implies that calling `->object()` (or, now, `_real()`) everywhere to satisf
   - `enableAutoRefresh()` -> `_enableAutoRefresh()`
   - `disableAutoRefresh()` -> `_disableAutoRefresh()`
   - `withoutAutoRefresh()` -> `_withoutAutoRefresh()`
+  - `assertPersisted()` -> `_assertPersisted()` 
+  - `assertNotPersisted()` -> `_assertNotPersisted()`
   - `isPersisted()` is removed without any replacement
   - `forceSetAll()` is removed without any replacement
-  - `assertPersisted()` is removed without any replacement
-  - `assertNotPersisted()` is removed without any replacement
 - Everywhere you've type-hinted `Zenstruck\Foundry\FactoryCollection<T>` which was coming from a `PersistentProxyObjectFactory`, replace to `Zenstruck\Foundry\FactoryCollection<Proxy<T>>`
 
 ### Instantiator

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1467,11 +1467,15 @@ This library provides a *Repository Proxy* that wraps your object repositories t
 Assertions
 ~~~~~~~~~~
 
-Your object factory's have helpful PHPUnit assertions:
+Both object proxies and your Factory have helpful PHPUnit assertions:
 
 .. code-block:: php
 
     use App\Factory\PostFactory;
+
+    $post = PostFactory::createOne();
+    $post->_assertPersisted();
+    $post->_assertNotPersisted();
 
     PostFactory::assert()->empty();
     PostFactory::assert()->count(3);

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -45,6 +45,10 @@ interface Proxy
      */
     public function _real(): object;
 
+    public function _assertPersisted(string $message = '{entity} is not persisted.'): static;
+
+    public function _assertNotPersisted(string $message = '{entity} is persisted but it should not be.'): static;
+
     /**
      * @return ProxyRepositoryDecorator<T,ObjectRepository<T>>
      */


### PR DESCRIPTION
fixes #661

if we're OK about the new name of these methods, I'll create a PR on 1.x to introduce the new `Proxy::_assert(Not)Persisted` methods, and update deprecations