### PR TITLE
fix: make proxy work with last symfony/var-exporter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/property-access": "^6.4|^7.0",
+        "symfony/var-exporter": "^6.4.9|~7.0.9|^7.1.2",
         "zenstruck/assert": "^1.4"
     },
     "require-dev": {

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -90,58 +90,15 @@ final class ProxyGenerator
             $proxyCode,
             [
                 'implements \Symfony\Component\VarExporter\LazyObjectInterface' => \sprintf('implements \%s, \Symfony\Component\VarExporter\LazyObjectInterface', Proxy::class),
-                'use \Symfony\Component\VarExporter\LazyProxyTrait;' => \sprintf("use \\%s;\n    use \\%s;", IsProxy::class, LazyProxyTrait::class),
+                'use \Symfony\Component\VarExporter\LazyProxyTrait' => \sprintf("use \\%s;\n    use \\%s", IsProxy::class, LazyProxyTrait::class),
                 'if (isset($this->lazyObjectState)) {' => "\$this->_autoRefresh();\n\n        if (isset(\$this->lazyObjectReal)) {",
                 '\func_get_args()' => '$this->unproxyArgs(\func_get_args())',
             ],
         );
 
-        $proxyCode = self::handleContravarianceInUnserializeMethod($reflectionClass, $proxyCode);
-
         eval($proxyCode); // @phpstan-ignore-line
 
         return $proxyClass;
-    }
-
-    /**
-     * @template T of object
-     *
-     * @param \ReflectionClass<T> $class
-     *
-     * Monkey patch for https://github.com/symfony/symfony/pull/57460, until the PR is released.
-     */
-    private static function handleContravarianceInUnserializeMethod(\ReflectionClass $class, string $proxyCode): string
-    {
-        if (
-            !str_contains($proxyCode, '__doUnserialize')
-            && $class->hasMethod('__unserialize')
-            && null !== ($unserializeParameter = $class->getMethod('__unserialize')->getParameters()[0] ?? null)
-            && null === $unserializeParameter->getType()
-        ) {
-            $proxyCode = str_replace(
-                'use \Symfony\Component\VarExporter\LazyProxyTrait;',
-                <<<EOPHP
-                use \Symfony\Component\VarExporter\LazyProxyTrait {
-                        __unserialize as private _doUnserialize;
-                    }
-                EOPHP,
-                $proxyCode
-            );
-
-            $unserializeMethod = <<<EOPHP
-
-                public function __unserialize(\$data): void
-                {
-                    \$this->_doUnserialize(\$data);
-                }
-
-            EOPHP;
-
-            $lastCurlyBraceOffset = strrpos($proxyCode, '}') ?: throw new \LogicException('Last curly brace offset not found.');
-            $proxyCode = substr_replace($proxyCode, $unserializeMethod."}", $lastCurlyBraceOffset, 1);
-        }
-
-        return $proxyCode;
     }
 
     /**

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -29,10 +29,6 @@ final class ProxyGeneratorTest extends TestCase
     {
         $proxyfiedObj = ProxyGenerator::wrap($obj);
         self::assertEquals(\unserialize(\serialize($proxyfiedObj))->_real(), $proxyfiedObj->_real());
-
-        // if this assertion fails, https://github.com/symfony/symfony/pull/57460 have been released
-        // so, the monkey patch around contravariance problem could be removed
-        self::assertFalse((new \ReflectionClass($proxyfiedObj))->hasMethod('__doUnserialize'));
     }
 
     public static function classWithUnserializeMagicMethodProvider(): iterable


### PR DESCRIPTION
oups... this "unserialize" stuff [introduced here](https://github.com/zenstruck/foundry/pull/644) does not work with the last version of `symfony/var-exporter`, because of a semicolon :sweat_smile: 

since symfony has released [my fix](https://github.com/symfony/symfony/pull/57460) I've removed the "monkey patch" and bumped the var exporter version

We should make a release after merging this PR
