### PR TITLE
fix: only restore error handler for PHPUnit 10 or superior

### DIFF
--- a/src/Test/KernelHelper.php
+++ b/src/Test/KernelHelper.php
@@ -33,6 +33,10 @@ final class KernelHelper
     {
         $kernel->shutdown();
 
+        if (!class_exists(\PHPUnit\Runner\ErrorHandler::class)) {
+            return;
+        }
+
         while (true) {
             $previousHandler = \set_error_handler(static fn() => null);
             \restore_error_handler();


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/667