### PR TITLE
Fix faker php urls

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -494,7 +494,7 @@ Sequences help to create different objects in one call:
 Faker
 ~~~~~
 
-This library provides a wrapper for `FakerPHP <https://fakerphp.github.io/>`_ to help with generating
+This library provides a wrapper for `FakerPHP <https://fakerphp.org/>`_ to help with generating
 random data for your factories:
 
 ::
@@ -505,8 +505,8 @@ random data for your factories:
 
 .. note::
 
-    You can customize Faker's `locale <https://fakerphp.github.io/#localization>`_ and random
-    `seed <https://fakerphp.github.io/#seeding-the-generator>`_:
+    You can customize Faker's `locale <https://fakerphp.org/#localization>`_ and random
+    `seed <https://fakerphp.org/#seeding-the-generator>`_:
 
     .. code-block:: yaml
 


### PR DESCRIPTION
Faker now lives on fakerphp.org instead of fakerphp.github.io.

The github domain also has a weird issue where it redirects to the http page of faker rather than https

See https://github.com/FakerPHP/fakerphp.github.io/issues/100