### PR TITLE
[Doc] Fix CategoryStory codeblock

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1957,7 +1957,7 @@ Later, you can access the story's state when creating other fixtures:
     Unlike factories, stories are not tied to a specific type, and then they cannot be generic, but you can leverage
     the magic method and PHPDoc to improve autocompletion and fix static analysis issues with stories:
 
-::
+    ::
 
         // src/Story/CategoryStory.php
         namespace App\Story;


### PR DESCRIPTION
Codeblock was not nested in the tip and was badly rendered