### PR TITLE
feat: allow to configure migrations configuration files

### DIFF
--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -114,6 +114,28 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
                                     ->defaultValue(AbstractORMPersistenceStrategy::RESET_MODE_SCHEMA)
                                     ->values([AbstractORMPersistenceStrategy::RESET_MODE_SCHEMA, AbstractORMPersistenceStrategy::RESET_MODE_MIGRATE])
                                 ->end()
+                                ->arrayNode('migrations')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->arrayNode('configurations')
+                                            ->info('Migration configurations')
+                                            ->defaultValue([])
+                                            ->scalarPrototype()->end()
+                                            ->validate()
+                                                ->ifTrue(function(array $configurationFiles): bool {
+                                                    foreach ($configurationFiles as $configurationFile) {
+                                                        if (!\is_file($configurationFile)) {
+                                                            return true;
+                                                        }
+                                                    }
+
+                                                    return false;
+                                                })
+                                                ->thenInvalid('At least one migrations configuration file does not exist.')
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
This PR introduces a new `orm.reset.migrations.configurations` configuration node allowing a schema reset to run `doctrine:migrations:migrate` for each given configuration. This is useful because using `doctrine/migrations`, you can only target one single connection or entity manager per configuration file.

Fixes #685