### PR TITLE
doc: Fix range call instead of many

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -781,7 +781,7 @@ The following assumes the ``Post`` entity has a one-to-many relationship with ``
     PostFactory::createMany(6, ['comments' => CommentFactory::new()->many(4)]);
 
     // Example 3: Create 6 Posts each with between 0 and 10 Comments
-    PostFactory::createMany(6, ['comments' => CommentFactory::new()->many(0, 10)]);
+    PostFactory::createMany(6, ['comments' => CommentFactory::new()->range(0, 10)]);
 
 Many-to-Many
 ............
@@ -1131,7 +1131,7 @@ You can simply use your factories and stories right within your fixture files:
                     'tags' => TagFactory::randomRange(0, 6),
 
                     // each Post will have between 0 and 10 Comment's that are created new
-                    'comments' => CommentFactory::new()->many(0, 10),
+                    'comments' => CommentFactory::new()->range(0, 10),
                 ];
             });
         }


### PR DESCRIPTION
`many()` seems to have only one parameter, see https://github.com/zenstruck/foundry/blob/2.x/src/Factory.php#L107 and https://github.com/zenstruck/foundry/blob/2.x/src/FactoryCollection.php#L39

So, if we want "between 0 and 10 comments", `range()` seems to be the good one: https://github.com/zenstruck/foundry/blob/2.x/src/FactoryCollection.php#L53
