### PR TITLE
Fix Psalm TooManyTemplateParams

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -36,10 +36,8 @@ abstract class Factory
 
     /**
      * @param Attributes $attributes
-     *
-     * @return static<T>
      */
-    final public static function new(array|callable $attributes = []): static // @phpstan-ignore return.phpDocType
+    final public static function new(array|callable $attributes = []): static
     {
         if (Configuration::isBooted()) {
             $factory = Configuration::instance()->factories->get(static::class);
@@ -132,10 +130,8 @@ abstract class Factory
 
     /**
      * @param Attributes $attributes
-     *
-     * @return static<T>
      */
-    final public function with(array|callable $attributes = []): static // @phpstan-ignore return.phpDocType
+    final public function with(array|callable $attributes = []): static
     {
         $clone = clone $this;
         $clone->attributes[] = $attributes;
@@ -176,12 +172,8 @@ abstract class Factory
 
     /**
      * Override to adjust default attributes & config.
-     *
-     * @return static
-     *
-     * @return static<T>
      */
-    protected function initialize(): static // @phpstan-ignore return.phpDocType
+    protected function initialize(): static
     {
         return $this;
     }


### PR DESCRIPTION
Since Foundry 2.0.8, due to https://github.com/zenstruck/foundry/pull/675/files#diff-f1158fbec0bb446d87dbd5346fba683c58ccec1a98b1787511ec7786585e8c31R40,
Psalm throws:

```
ERROR: TooManyTemplateParams - MyFactory.php - TimeslotFactory<Timeslot> has too many template params, expecting 0 (see https://psalm.dev/184)
            'timeslot' => TimeslotFactory::new(),
```
