### PR TITLE
fix: Change `RepositoryDecorator::inner()` visibility to public

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -229,7 +229,7 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
     /**
      * @return ObjectRepository<T>
      */
-    private function inner(): ObjectRepository
+    public function inner(): ObjectRepository
     {
         return Configuration::instance()->persistence()->repositoryFor($this->class);
     }


### PR DESCRIPTION
Fixes https://github.com/zenstruck/foundry/issues/713

`RepositoryDecorator::inner()` is documented as public in the documentation, but its visibility changed during the release of Foundry 2.