### PR TITLE
Remove @internal from db resetter interfaces

### DIFF
--- a/src/Persistence/ResetDatabase/BeforeEachTestResetter.php
+++ b/src/Persistence/ResetDatabase/BeforeEachTestResetter.php
@@ -16,7 +16,6 @@ namespace Zenstruck\Foundry\Persistence\ResetDatabase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
 interface BeforeEachTestResetter

--- a/src/Persistence/ResetDatabase/BeforeFirstTestResetter.php
+++ b/src/Persistence/ResetDatabase/BeforeFirstTestResetter.php
@@ -16,7 +16,6 @@ namespace Zenstruck\Foundry\Persistence\ResetDatabase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
 interface BeforeFirstTestResetter


### PR DESCRIPTION
The problem with these interfaces being internal is that Psalm complains about using their methods:

```
ERROR: InternalMethod
at /app/src/Test/CustomDatabaseResetter.php:31:27
The method Zenstruck\Foundry\Persistence\ResetDatabase\BeforeFirstTestResetter::resetBeforeFirstTest is internal to Zenstruck but called from App\Test\CustomDatabaseResetter::resetBeforeFirstTest (see https://psalm.dev/175)
        $this->decorated->resetBeforeFirstTest($kernel);


ERROR: InternalMethod
at /app/src/Test/CustomDatabaseResetter.php:42:27
The method Zenstruck\Foundry\Persistence\ResetDatabase\BeforeEachTestResetter::resetBeforeEachTest is internal to Zenstruck but called from App\Test\CustomDatabaseResetter::resetBeforeEachTest (see https://psalm.dev/175)
        $this->decorated->resetBeforeEachTest($kernel);
```

I'm not sure if there's a way to get this to pass without removing the `@internal` tags.