### PR TITLE
fix: bug with one to many

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -202,13 +202,6 @@ abstract class Factory
      */
     protected function normalizeParameter(string $field, mixed $value): mixed
     {
-        if (\is_array($value)) {
-            return array_combine(
-                array_keys($value),
-                \array_map($this->normalizeParameter(...), array_fill(0, count($value), $field), $value)
-            );
-        }
-
         if ($value instanceof LazyValue) {
             $value = $value();
         }
@@ -217,8 +210,19 @@ abstract class Factory
             $value = $value->create();
         }
 
+        if (FactoryCollection::accepts($value)) {
+            $value = FactoryCollection::fromFactoriesList($value);
+        }
+
         if ($value instanceof FactoryCollection) {
             $value = $this->normalizeCollection($field, $value);
+        }
+
+        if (\is_array($value)) {
+            return array_combine(
+                array_keys($value),
+                \array_map($this->normalizeParameter(...), array_fill(0, count($value), $field), $value)
+            );
         }
 
         return \is_object($value) ? $this->normalizeObject($value) : $value;

--- a/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\CascadeContact;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\CascadeAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CascadeCategoryFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -31,7 +32,7 @@ final class CascadeContactFactory extends PersistentObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            //            'category' => CascadeCategoryFactory::new(),
+            'category' => CascadeCategoryFactory::new(),
             'address' => CascadeAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/Contact/ProxyCascadeContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/ProxyCascadeContactFactory.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\CascadeContact;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyCascadeAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\ProxyCascadeCategoryFactory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -31,7 +32,7 @@ final class ProxyCascadeContactFactory extends PersistentProxyObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            //            'category' => ProxyCategoryFactory::new(),
+            'category' => ProxyCascadeCategoryFactory::new(),
             'address' => ProxyCascadeAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/Contact/ProxyContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/ProxyContactFactory.php
@@ -32,7 +32,7 @@ final class ProxyContactFactory extends PersistentProxyObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            //            'category' => ProxyCategoryFactory::new(),
+            'category' => ProxyCategoryFactory::new(),
             'address' => ProxyAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/Contact/StandardContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/StandardContactFactory.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\StandardContact;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\StandardAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\StandardCategoryFactory;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -32,6 +33,7 @@ class StandardContactFactory extends PersistentObjectFactory
         return [
             'name' => self::faker()->word(),
             'address' => StandardAddressFactory::new(),
+            'category' => StandardCategoryFactory::new(),
         ];
     }
 }

--- a/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
@@ -27,15 +27,15 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
      */
     public function ensure_to_one_cascade_relations_are_not_pre_persisted(): void
     {
-        $contact = $this->contactFactory()
+        $contact = self::contactFactory()
             ->afterInstantiate(function() {
-                $this->categoryFactory()::repository()->assert()->empty();
-                $this->addressFactory()::repository()->assert()->empty();
-                $this->tagFactory()::repository()->assert()->empty();
+                self::categoryFactory()::repository()->assert()->empty();
+                self::addressFactory()::repository()->assert()->empty();
+                self::tagFactory()::repository()->assert()->empty();
             })
             ->create([
-                'tags' => $this->tagFactory()->many(3),
-                'category' => $this->categoryFactory(),
+                'tags' => self::tagFactory()->many(3),
+                'category' => self::categoryFactory(),
             ])
         ;
 
@@ -53,14 +53,14 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
      */
     public function ensure_many_to_many_cascade_relations_are_not_pre_persisted(): void
     {
-        $tag = $this->tagFactory()
+        $tag = self::tagFactory()
             ->afterInstantiate(function() {
-                $this->categoryFactory()::repository()->assert()->empty();
-                $this->addressFactory()::repository()->assert()->empty();
-                $this->contactFactory()::repository()->assert()->empty();
+                self::categoryFactory()::repository()->assert()->empty();
+                self::addressFactory()::repository()->assert()->empty();
+                self::contactFactory()::repository()->assert()->empty();
             })
             ->create([
-                'contacts' => $this->contactFactory()->many(3),
+                'contacts' => self::contactFactory()->many(3),
             ])
         ;
 
@@ -76,14 +76,14 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
      */
     public function ensure_one_to_many_cascade_relations_are_not_pre_persisted(): void
     {
-        $category = $this->categoryFactory()
+        $category = self::categoryFactory()
             ->afterInstantiate(function() {
-                $this->contactFactory()::repository()->assert()->empty();
-                $this->addressFactory()::repository()->assert()->empty();
-                $this->tagFactory()::repository()->assert()->empty();
+                self::contactFactory()::repository()->assert()->empty();
+                self::addressFactory()::repository()->assert()->empty();
+                self::tagFactory()::repository()->assert()->empty();
             })
             ->create([
-                'contacts' => $this->contactFactory()->many(3),
+                'contacts' => self::contactFactory()->many(3),
             ])
         ;
 
@@ -94,22 +94,22 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
         }
     }
 
-    protected function contactFactory(): PersistentObjectFactory
+    protected static function contactFactory(): PersistentObjectFactory
     {
         return CascadeContactFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function categoryFactory(): PersistentObjectFactory
+    protected static function categoryFactory(): PersistentObjectFactory
     {
         return CascadeCategoryFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function tagFactory(): PersistentObjectFactory
+    protected static function tagFactory(): PersistentObjectFactory
     {
         return CascadeTagFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function addressFactory(): PersistentObjectFactory
+    protected static function addressFactory(): PersistentObjectFactory
     {
         return CascadeAddressFactory::new(); // @phpstan-ignore return.type
     }

--- a/tests/Integration/ORM/PolymorphicEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/PolymorphicEntityFactoryRelationshipTest.php
@@ -19,7 +19,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ChildContactFactory
  */
 class PolymorphicEntityFactoryRelationshipTest extends StandardEntityFactoryRelationshipTest
 {
-    protected function contactFactory(): PersistentObjectFactory
+    protected static function contactFactory(): PersistentObjectFactory
     {
         return ChildContactFactory::new(); // @phpstan-ignore return.type
     }

--- a/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyCascadeEntityFactoryRelationshipTest.php
@@ -22,22 +22,22 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyCascadeTagFactory;
  */
 final class ProxyCascadeEntityFactoryRelationshipTest extends ProxyEntityFactoryRelationshipTestCase
 {
-    protected function contactFactory(): PersistentObjectFactory
+    protected static function contactFactory(): PersistentObjectFactory
     {
         return ProxyCascadeContactFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function categoryFactory(): PersistentObjectFactory
+    protected static function categoryFactory(): PersistentObjectFactory
     {
         return ProxyCascadeCategoryFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function tagFactory(): PersistentObjectFactory
+    protected static function tagFactory(): PersistentObjectFactory
     {
         return ProxyCascadeTagFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function addressFactory(): PersistentObjectFactory
+    protected static function addressFactory(): PersistentObjectFactory
     {
         return ProxyCascadeAddressFactory::new(); // @phpstan-ignore return.type
     }

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTest.php
@@ -22,22 +22,22 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\ProxyTagFactory;
  */
 final class ProxyEntityFactoryRelationshipTest extends ProxyEntityFactoryRelationshipTestCase
 {
-    protected function contactFactory(): PersistentObjectFactory
+    protected static function contactFactory(): PersistentObjectFactory
     {
         return ProxyContactFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function categoryFactory(): PersistentObjectFactory
+    protected static function categoryFactory(): PersistentObjectFactory
     {
         return ProxyCategoryFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function tagFactory(): PersistentObjectFactory
+    protected static function tagFactory(): PersistentObjectFactory
     {
         return ProxyTagFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function addressFactory(): PersistentObjectFactory
+    protected static function addressFactory(): PersistentObjectFactory
     {
         return ProxyAddressFactory::new(); // @phpstan-ignore return.type
     }

--- a/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/ProxyEntityFactoryRelationshipTestCase.php
@@ -40,21 +40,21 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function doctrine_proxies_are_converted_to_foundry_proxies(): void
     {
-        $this->contactFactory()->create(['category' => $this->categoryFactory()]);
+        static::contactFactory()->create(['category' => static::categoryFactory()]);
 
         // clear the em so nothing is tracked
         self::getContainer()->get(EntityManagerInterface::class)->clear(); // @phpstan-ignore method.nonObject
 
         // load a random Contact which causes the em to track a "doctrine proxy" for category
-        $this->contactFactory()::random();
+        static::contactFactory()::random();
 
         // load a random Category which should be a "doctrine proxy"
-        $category = $this->categoryFactory()::random();
+        $category = static::categoryFactory()::random();
 
         // ensure the category is a "doctrine proxy" and a Category
         $this->assertInstanceOf(Proxy::class, $category);
         $this->assertInstanceOf(DoctrineProxy::class, $category->_real());
-        $this->assertInstanceOf($this->categoryFactory()::class(), $category);
+        $this->assertInstanceOf(static::categoryFactory()::class(), $category);
     }
 
     /**
@@ -62,13 +62,13 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function it_can_add_proxy_to_many_to_one(): void
     {
-        $contact = $this->contactFactory()->create();
+        $contact = static::contactFactory()->create();
 
-        $contact->setCategory($category = $this->categoryFactory()->create());
+        $contact->setCategory($category = static::categoryFactory()->create());
         $contact->_save();
 
-        $this->contactFactory()::assert()->count(1);
-        $this->contactFactory()::assert()->exists(['category' => $category]);
+        static::contactFactory()::assert()->count(1);
+        static::contactFactory()::assert()->exists(['category' => $category]);
     }
 
     /**
@@ -76,13 +76,13 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function it_can_add_proxy_to_one_to_many(): void
     {
-        $contact = $this->contactFactory()->create();
+        $contact = static::contactFactory()->create();
 
-        $contact->addTag($this->tagFactory()->create());
+        $contact->addTag(static::tagFactory()->create());
         $contact->_save();
 
-        $this->contactFactory()::assert()->count(1);
-        $tag = $this->tagFactory()::first();
+        static::contactFactory()::assert()->count(1);
+        $tag = static::tagFactory()::first();
         self::assertContains($contact->_real(), $tag->getContacts());
     }
 
@@ -91,10 +91,10 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function can_assert_persisted(): void
     {
-        $this->contactFactory()->create()->_assertPersisted();
+        static::contactFactory()->create()->_assertPersisted();
 
-        Assert::that(function(): void { $this->contactFactory()->withoutPersisting()->create()->_assertPersisted(); })
-            ->throws(AssertionFailedError::class, \sprintf('%s is not persisted.', $this->contactFactory()::class()))
+        Assert::that(function(): void { static::contactFactory()->withoutPersisting()->create()->_assertPersisted(); })
+            ->throws(AssertionFailedError::class, \sprintf('%s is not persisted.', static::contactFactory()::class()))
         ;
     }
 
@@ -103,10 +103,10 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function can_assert_not_persisted(): void
     {
-        $this->contactFactory()->withoutPersisting()->create()->_assertNotPersisted();
+        static::contactFactory()->withoutPersisting()->create()->_assertNotPersisted();
 
-        Assert::that(function(): void { $this->contactFactory()->create()->_assertNotPersisted(); })
-            ->throws(AssertionFailedError::class, \sprintf('%s is persisted but it should not be.', $this->contactFactory()::class()))
+        Assert::that(function(): void { static::contactFactory()->create()->_assertNotPersisted(); })
+            ->throws(AssertionFailedError::class, \sprintf('%s is persisted but it should not be.', static::contactFactory()::class()))
         ;
     }
 
@@ -115,7 +115,7 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function can_remove_and_assert_not_persisted(): void
     {
-        $this->contactFactory()
+        static::contactFactory()
             ->create()
             ->_assertPersisted()
             ->_delete()
@@ -128,7 +128,7 @@ abstract class ProxyEntityFactoryRelationshipTestCase extends EntityFactoryRelat
      */
     public function cannot_use_assert_persisted_when_entity_has_changes(): void
     {
-        $contact = $this->contactFactory()->create();
+        $contact = static::contactFactory()->create();
         $contact->setName('foo');
 
         $this->expectException(RefreshObjectFailed::class);

--- a/tests/Integration/ORM/StandardEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/StandardEntityFactoryRelationshipTest.php
@@ -22,22 +22,22 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\StandardTagFactory;
  */
 class StandardEntityFactoryRelationshipTest extends EntityFactoryRelationshipTestCase
 {
-    protected function contactFactory(): PersistentObjectFactory
+    protected static function contactFactory(): PersistentObjectFactory
     {
         return StandardContactFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function categoryFactory(): PersistentObjectFactory
+    protected static function categoryFactory(): PersistentObjectFactory
     {
         return StandardCategoryFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function tagFactory(): PersistentObjectFactory
+    protected static function tagFactory(): PersistentObjectFactory
     {
         return StandardTagFactory::new(); // @phpstan-ignore return.type
     }
 
-    protected function addressFactory(): PersistentObjectFactory
+    protected static function addressFactory(): PersistentObjectFactory
     {
         return StandardAddressFactory::new(); // @phpstan-ignore return.type
     }


### PR DESCRIPTION
Fixes a bug where using "inversed one-to-many" was creating too many entites in the inverse side of the association:

this was failing, because 3 categories were created (only when using "non-cascade-entities")
```php
    public function one_to_many(FactoryCollection|array $contacts): void
    {
        $category = $this->categoryFactory()::createOne([
            'contacts' => [
                $this->contactFactory(),
                $this->contactFactory()
            ],
        ]);

        $this->categoryFactory()::repository()->assert()->count(1);        
    }
```