### PR TITLE
docs:fix code blocks not showing up

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1620,11 +1620,11 @@ You can install it by modifying you ``phpunit.xml.dist``:
 
     .. code-block:: xml
     
-    <phpunit>
-      <extensions>
-        <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension"/>
-      </extensions>
-    </phpunit>
+        <phpunit>
+          <extensions>
+            <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension"/>
+          </extensions>
+        </phpunit>
     
 .. warning::
 
@@ -1825,7 +1825,7 @@ This can dramatically improve test speed. The following considerations need to b
 
    .. code-block:: yaml
 
-   # config/packages/doctrine.yaml
+       # config/packages/doctrine.yaml
        when@test:
            doctrine:
                dbal:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1621,9 +1621,9 @@ You can install it by modifying you ``phpunit.xml.dist``:
     .. code-block:: xml
     
         <phpunit>
-          <extensions>
-            <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension"/>
-          </extensions>
+            <extensions>
+                <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension"/>
+            </extensions>
         </phpunit>
     
 .. warning::


### PR DESCRIPTION
Hi,

some of the code-blocks are not rendered on 

https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html

Probably due to missing indentations.

Not sure if those are all relevant blocks but those two I noticed missing.