### PR TITLE
feat: add `#[WithStory]` attribute

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -43,8 +43,8 @@ fi
 DAMA_EXTENSION="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"
 FOUNDRY_EXTENSION="Zenstruck\Foundry\PHPUnit\FoundryExtension"
 
-if [ "${USE_FOUNDRY_PHPUNIT_EXTENSION:-0}" = "1" ] && [ "${PHPUNIT_VERSION}" != "11" ]; then
-  echo "❌ USE_FOUNDRY_PHPUNIT_EXTENSION could only be used with PHPUNIT_VERSION=11";
+if [ "${USE_FOUNDRY_PHPUNIT_EXTENSION:-0}" = "1" ] && [ "${PHPUNIT_VERSION}" = "9" ]; then
+  echo "❌ USE_FOUNDRY_PHPUNIT_EXTENSION cannot be used with PHPUNIT_VERSION=10";
   exit 1;
 fi
 

--- a/src/Attribute/WithStory.php
+++ b/src/Attribute/WithStory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Attribute;
+
+use Zenstruck\Foundry\Story;
+
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+final class WithStory
+{
+    public function __construct(
+        /** @var class-string<Story> $story */
+        public readonly string $story
+    )
+    {
+        if (!\is_subclass_of($story, Story::class)) {
+            throw new \InvalidArgumentException(\sprintf('"%s" is not a valid story class.', $story));
+        }
+    }
+}

--- a/src/PHPUnit/BootFoundryOnDataProviderMethodCalled.php
+++ b/src/PHPUnit/BootFoundryOnDataProviderMethodCalled.php
@@ -24,7 +24,7 @@ final class BootFoundryOnDataProviderMethodCalled implements Event\Test\DataProv
     public function notify(Event\Test\DataProviderMethodCalled $event): void
     {
         if (\method_exists($event->testMethod()->className(), '_bootForDataProvider')) {
-            \call_user_func([$event->testMethod()->className(), '_bootForDataProvider']);
+            $event->testMethod()->className()::_bootForDataProvider();
         }
     }
 }

--- a/src/PHPUnit/BuildStoryOnTestPrepared.php
+++ b/src/PHPUnit/BuildStoryOnTestPrepared.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\PHPUnit;
 
 use PHPUnit\Event;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
 
 /**
@@ -32,17 +33,44 @@ final class BuildStoryOnTestPrepared implements Event\Test\PreparedSubscriber
 
         /** @var Event\Code\TestMethod $test */
 
+        $reflectionClass = new \ReflectionClass($test->className());
         $withStoryAttributes = [
-           ...(new \ReflectionClass($test->className()))->getAttributes(WithStory::class),
-           ...(new \ReflectionMethod($test->className(), $test->methodName()))->getAttributes(WithStory::class),
+            ...$this->collectWithStoryAttributesFromClassAndParents($reflectionClass),
+            ...$reflectionClass->getMethod($test->methodName())->getAttributes(WithStory::class),
         ];
 
         if (!$withStoryAttributes) {
             return;
         }
 
+        if (!is_subclass_of($test->className(), KernelTestCase::class)) {
+            throw new \InvalidArgumentException(
+                \sprintf(
+                    'The test class "%s" must extend "%s" to use the "%s" attribute.',
+                    $test->className(),
+                    KernelTestCase::class,
+                    WithStory::class
+                )
+            );
+        }
+
         foreach ($withStoryAttributes as $withStoryAttribute) {
             $withStoryAttribute->newInstance()->story::load();
         }
+    }
+
+    /**
+     * @return list<\ReflectionAttribute<WithStory>>
+     */
+    private function collectWithStoryAttributesFromClassAndParents(\ReflectionClass $class): array // @phpstan-ignore missingType.generics
+    {
+        return [
+            ...$class->getAttributes(WithStory::class),
+            ...(
+            $class->getParentClass()
+                ? $this->collectWithStoryAttributesFromClassAndParents($class->getParentClass())
+                : []
+            )
+        ];
     }
 }

--- a/src/PHPUnit/BuildStoryOnTestPrepared.php
+++ b/src/PHPUnit/BuildStoryOnTestPrepared.php
@@ -29,18 +29,20 @@ final class BuildStoryOnTestPrepared implements Event\Test\PreparedSubscriber
         if (!$test->isTestMethod()) {
             return;
         }
+
         /** @var Event\Code\TestMethod $test */
 
-        $method = (new \ReflectionMethod($test->className(), $test->methodName()));
-        $withStoryReflectionAttributes = $method->getAttributes(WithStory::class);
+        $withStoryAttributes = [
+           ...(new \ReflectionClass($test->className()))->getAttributes(WithStory::class),
+           ...(new \ReflectionMethod($test->className(), $test->methodName()))->getAttributes(WithStory::class),
+        ];
 
-        if (!$withStoryReflectionAttributes) {
+        if (!$withStoryAttributes) {
             return;
         }
 
-        $withStoryAttributes = array_map(static fn(\ReflectionAttribute $a): WithStory => $a->newInstance(), $withStoryReflectionAttributes);
         foreach ($withStoryAttributes as $withStoryAttribute) {
-            $withStoryAttribute->story::load();
+            $withStoryAttribute->newInstance()->story::load();
         }
     }
 }

--- a/src/PHPUnit/BuildStoryOnTestPrepared.php
+++ b/src/PHPUnit/BuildStoryOnTestPrepared.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\PHPUnit;
+
+use PHPUnit\Event;
+use Zenstruck\Foundry\Attribute\WithStory;
+
+/**
+ * @internal
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class BuildStoryOnTestPrepared implements Event\Test\PreparedSubscriber
+{
+    public function notify(Event\Test\Prepared $event): void
+    {
+        $test = $event->test();
+
+        if (!$test->isTestMethod()) {
+            return;
+        }
+        /** @var Event\Code\TestMethod $test */
+
+        $method = (new \ReflectionMethod($test->className(), $test->methodName()));
+        $withStoryReflectionAttributes = $method->getAttributes(WithStory::class);
+
+        if (!$withStoryReflectionAttributes) {
+            return;
+        }
+
+        $withStoryAttributes = array_map(static fn(\ReflectionAttribute $a): WithStory => $a->newInstance(), $withStoryReflectionAttributes);
+        foreach ($withStoryAttributes as $withStoryAttribute) {
+            $withStoryAttribute->story::load();
+        }
+    }
+}

--- a/src/PHPUnit/FoundryExtension.php
+++ b/src/PHPUnit/FoundryExtension.php
@@ -43,6 +43,7 @@ final class FoundryExtension implements Runner\Extension\Extension
         $facade->registerSubscribers(
             new BootFoundryOnDataProviderMethodCalled(),
             new ShutdownFoundryOnDataProviderMethodFinished(),
+            new BuildStoryOnTestPrepared(),
         );
     }
 }

--- a/src/PHPUnit/FoundryExtension.php
+++ b/src/PHPUnit/FoundryExtension.php
@@ -24,26 +24,24 @@ use Zenstruck\Foundry\Configuration;
  */
 final class FoundryExtension implements Runner\Extension\Extension
 {
-    public const MIN_PHPUNIT_VERSION = '11.4';
-
     public function bootstrap(
         TextUI\Configuration\Configuration $configuration,
         Runner\Extension\Facade $facade,
         Runner\Extension\ParameterCollection $parameters,
     ): void {
-        if (!ConstraintRequirement::from(self::MIN_PHPUNIT_VERSION)->isSatisfiedBy(Runner\Version::id())) {
-            throw new \LogicException(\sprintf('Your PHPUnit version (%s) is not compatible with the minimum version (%s) needed to use this extension.', Runner\Version::id(), self::MIN_PHPUNIT_VERSION));
-        }
-
         // shutdown Foundry if for some reason it has been booted before
         if (Configuration::isBooted()) {
             Configuration::shutdown();
         }
 
-        $facade->registerSubscribers(
-            new BootFoundryOnDataProviderMethodCalled(),
-            new ShutdownFoundryOnDataProviderMethodFinished(),
-            new BuildStoryOnTestPrepared(),
-        );
+        $subscribers = [new BuildStoryOnTestPrepared()];
+
+        if (ConstraintRequirement::from('11.4')->isSatisfiedBy(Runner\Version::id())) {
+            // those deal with data provider events which can be useful only if PHPUnit 11.4 is used
+            $subscribers[] = new BootFoundryOnDataProviderMethodCalled();
+            $subscribers[] = new ShutdownFoundryOnDataProviderMethodFinished();
+        }
+
+        $facade->registerSubscribers(...$subscribers);
     }
 }

--- a/src/PHPUnit/ShutdownFoundryOnDataProviderMethodFinished.php
+++ b/src/PHPUnit/ShutdownFoundryOnDataProviderMethodFinished.php
@@ -24,7 +24,7 @@ final class ShutdownFoundryOnDataProviderMethodFinished implements Event\Test\Da
     public function notify(Event\Test\DataProviderMethodFinished $event): void
     {
         if (\method_exists($event->testMethod()->className(), '_shutdownAfterDataProvider')) {
-            \call_user_func([$event->testMethod()->className(), '_shutdownAfterDataProvider']);
+            $event->testMethod()->className()::_shutdownAfterDataProvider();
         }
     }
 }

--- a/tests/Fixture/Stories/ServiceStory.php
+++ b/tests/Fixture/Stories/ServiceStory.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Stories;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+    final class ServiceStory extends Story
+{
+    public function __construct(
+        private readonly RouterInterface $router
+    ) {
+    }
+
+    public function build(): void
+    {
+        $this->addState(
+            'foo',
+            GenericEntityFactory::createOne(['prop1' => $this->router->getContext()->getHost()])
+        );
+    }
+}

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -28,6 +28,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\ArrayFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Object1Factory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\GlobalInvokableService;
 use Zenstruck\Foundry\Tests\Fixture\Stories\GlobalStory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\ServiceStory;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
 /**
@@ -162,6 +163,7 @@ final class TestKernel extends Kernel
         $c->register(GlobalInvokableService::class);
         $c->register(ArrayFactory::class)->setAutowired(true)->setAutoconfigured(true);
         $c->register(Object1Factory::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(ServiceStory::class)->setAutowired(true)->setAutoconfigured(true);
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void

--- a/tests/Integration/Attribute/WithStory/ParentClassWithStoryAttributeTestCase.php
+++ b/tests/Integration/Attribute/WithStory/ParentClassWithStoryAttributeTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\Attribute\WithStory;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[WithStory(EntityStory::class)]
+abstract class ParentClassWithStoryAttributeTestCase extends KernelTestCase
+{
+    use Factories, ResetDatabase, RequiresORM;
+}

--- a/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
@@ -18,9 +18,9 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
- * @requires PHPUnit 11.4
+ * @requires PHPUnit 11
  */
-#[RequiresPhpunit('11.4')]
+#[RequiresPhpunit('11')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[WithStory(EntityStory::class)]
 final class WithStoryOnClassTest extends KernelTestCase

--- a/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\Attribute\WithStory;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+
+#[WithStory(EntityStory::class)]
+final class WithStoryOnClassTest extends KernelTestCase
+{
+    use Factories, ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function can_use_story_in_attribute(): void
+    {
+        GenericEntityFactory::assert()->count(2);
+
+        // ensure state is accessible
+        $this->assertSame('foo', EntityStory::get('foo')->getProp1());
+    }
+
+    /**
+     * @test
+     */
+    #[WithStory(EntityStory::class)]
+    public function can_use_story_in_attribute_multiple_times(): void
+    {
+        GenericEntityFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    #[WithStory(EntityPoolStory::class)]
+    public function can_use_another_story_at_level_class(): void
+    {
+        GenericEntityFactory::assert()->count(5);
+    }
+}

--- a/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
@@ -2,20 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Integration\Attribute\WithStory;
+namespace Zenstruck\Foundry\Tests\Integration\Attribute\WithStory;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit 11.4
+ */
+#[RequiresPhpunit('11.4')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
 #[WithStory(EntityStory::class)]
 final class WithStoryOnClassTest extends KernelTestCase
 {
-    use Factories, ResetDatabase;
+    use Factories, ResetDatabase, RequiresORM;
 
     /**
      * @test

--- a/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
@@ -2,19 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Integration\Attribute\WithStory;
+namespace Zenstruck\Foundry\Tests\Integration\Attribute\WithStory;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit 11.4
+ */
+#[RequiresPhpunit('11.4')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
 final class WithStoryOnMethodTest extends KernelTestCase
 {
-    use Factories, ResetDatabase;
+    use Factories, ResetDatabase, RequiresORM;
 
     /**
      * @test

--- a/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\Attribute\WithStory;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+
+final class WithStoryOnMethodTest extends KernelTestCase
+{
+    use Factories, ResetDatabase;
+
+    /**
+     * @test
+     */
+    #[WithStory(EntityStory::class)]
+    public function can_use_story_in_attribute(): void
+    {
+        GenericEntityFactory::assert()->count(2);
+
+        // ensure state is accessible
+        $this->assertSame('foo', EntityStory::get('foo')->getProp1());
+    }
+
+    /**
+     * @test
+     */
+    #[WithStory(EntityStory::class)]
+    #[WithStory(EntityPoolStory::class)]
+    public function can_use_multiple_story_in_attribute(): void
+    {
+        GenericEntityFactory::assert()->count(5);
+    }
+}

--- a/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
@@ -14,13 +14,14 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\ServiceStory;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
- * @requires PHPUnit 11.4
+ * @requires PHPUnit 11
  */
-#[RequiresPhpunit('11.4')]
+#[RequiresPhpunit('11')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class WithStoryOnMethodTest extends KernelTestCase
 {
@@ -46,5 +47,14 @@ final class WithStoryOnMethodTest extends KernelTestCase
     public function can_use_multiple_story_in_attribute(): void
     {
         GenericEntityFactory::assert()->count(5);
+    }
+
+    /**
+     * @test
+     */
+    #[WithStory(ServiceStory::class)]
+    public function can_use_service_story(): void
+    {
+        $this->assertSame('localhost', ServiceStory::get('foo')->getProp1());
     }
 }

--- a/tests/Integration/Attribute/WithStory/WithStoryOnParentClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnParentClassTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\Attribute\WithStory;
+
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use Zenstruck\Foundry\Attribute\WithStory;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit 11.4
+ */
+#[RequiresPhpunit('11.4')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
+#[WithStory(EntityPoolStory::class)]
+final class WithStoryOnParentClassTest extends ParentClassWithStoryAttributeTestCase
+{
+    /**
+     * @test
+     */
+    public function can_use_story_in_attribute_from_parent_class(): void
+    {
+        GenericEntityFactory::assert()->count(5);
+    }
+}

--- a/tests/Integration/Attribute/WithStory/WithStoryOnParentClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnParentClassTest.php
@@ -13,9 +13,9 @@ use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
- * @requires PHPUnit 11.4
+ * @requires PHPUnit 11
  */
-#[RequiresPhpunit('11.4')]
+#[RequiresPhpunit('11')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[WithStory(EntityPoolStory::class)]
 final class WithStoryOnParentClassTest extends ParentClassWithStoryAttributeTestCase


### PR DESCRIPTION
fixes #430

- **feat: introduce WithStory attribute**
- **feat: apply WithStory attribute at class level**
- **feat: allow WithStory attribute on parent class**

I think that only an attribute related to stories is useful, I don't see any practical usage of an attribute related to factories

TODO:
- [x] story service should work
- [x] ~only load story once if it is added to a class? Maybe this will be conditioned by a boolean~ won't be made