### PR TITLE
fix: detect if relation is oneToOne

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -272,7 +272,10 @@ abstract class PersistentObjectFactory extends ObjectFactory
             $relationshipMetadata = $pm->relationshipMetadata($value::class(), static::class(), $field);
 
             // handle inversed OneToOne
-            if ($relationshipMetadata && !$relationshipMetadata->isCollection && $inverseField = $relationshipMetadata->inverseField) {
+            if ($relationshipMetadata
+                && $relationshipMetadata->isOneToOne
+                && !$relationshipMetadata->isCollection
+                && $inverseField = $relationshipMetadata->inverseField) {
                 // we create now the object to prevent "non-nullable" property errors,
                 // but we'll need to remove it once the current object is created
                 $inversedObject = unproxy($value->create());

--- a/src/Persistence/RelationshipMetadata.php
+++ b/src/Persistence/RelationshipMetadata.php
@@ -22,6 +22,7 @@ final class RelationshipMetadata
         public readonly bool $isCascadePersist,
         public readonly ?string $inverseField,
         public readonly bool $isCollection,
+        public readonly bool $isOneToOne,
     ) {
     }
 }

--- a/tests/Fixture/Entity/EdgeCases/InversedOneToOneWithNonNullableOwning/InverseSide.php
+++ b/tests/Fixture/Entity/EdgeCases/InversedOneToOneWithNonNullableOwning/InverseSide.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
 #[ORM\Entity]
+#[ORM\Table('inversed_one_to_one_with_non_nullable_owning_inverse_side')]
 class InverseSide
 {
     #[ORM\Id]

--- a/tests/Fixture/Entity/EdgeCases/InversedOneToOneWithNonNullableOwning/OwningSide.php
+++ b/tests/Fixture/Entity/EdgeCases/InversedOneToOneWithNonNullableOwning/OwningSide.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
 #[ORM\Entity]
+#[ORM\Table('inversed_one_to_one_with_non_nullable_owning_owning_side')]
 class OwningSide
 {
     #[ORM\Id]

--- a/tests/Fixture/Entity/EdgeCases/ManyToOneToSelfReferencing/OwningSide.php
+++ b/tests/Fixture/Entity/EdgeCases/ManyToOneToSelfReferencing/OwningSide.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\ManyToOneToSelfReferencing;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('many_to_one_to_self_referencing_owning_side')]
+class OwningSide
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'owningSide')]
+    public ?SelfReferencingInverseSide $inverseSide = null;
+}

--- a/tests/Fixture/Entity/EdgeCases/ManyToOneToSelfReferencing/SelfReferencingInverseSide.php
+++ b/tests/Fixture/Entity/EdgeCases/ManyToOneToSelfReferencing/SelfReferencingInverseSide.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\ManyToOneToSelfReferencing;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('many_to_one_to_self_referencing_inverse_side')]
+class SelfReferencingInverseSide
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\ManyToOne()]
+    public ?SelfReferencingInverseSide $inverseSide = null;
+
+    #[ORM\OneToOne(mappedBy: 'inverseSide')]
+    public ?OwningSide $owningSide = null;
+}

--- a/tests/Integration/ORM/EdgeCasesRelationshipTest.php
+++ b/tests/Integration/ORM/EdgeCasesRelationshipTest.php
@@ -19,6 +19,7 @@ use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\InversedOneToOneWithNonNullableOwning;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\ManyToOneToSelfReferencing;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RelationshipWithGlobalEntity;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GlobalEntity;
@@ -121,6 +122,20 @@ final class EdgeCasesRelationshipTest extends KernelTestCase
         $inverseSideFactory::assert()->count(1);
 
         self::assertSame($inverseSide, $inverseSide->owningSide->inverseSide);
+    }
+
+    /**
+     * @test
+     */
+    public function many_to_many_to_self_referencing_inverse_side(): void
+    {
+        $owningSideFactory = persistent_factory(ManyToOneToSelfReferencing\OwningSide::class);
+        $inverseSideFactory = persistent_factory(ManyToOneToSelfReferencing\SelfReferencingInverseSide::class);
+
+        $owningSideFactory->create(['inverseSide' => $inverseSideFactory]);
+
+        $owningSideFactory::assert()->count(1);
+        $inverseSideFactory::assert()->count(1);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a last bug before we can release 2.3: some edge case was buggy, when the a many to one was referencing a "self referencing" class