### PR TITLE
Fix PHPUnit constraint requirement in FoundryExtension

### DIFF
--- a/src/PHPUnit/FoundryExtension.php
+++ b/src/PHPUnit/FoundryExtension.php
@@ -36,8 +36,8 @@ final class FoundryExtension implements Runner\Extension\Extension
 
         $subscribers = [new BuildStoryOnTestPrepared()];
 
-        if (ConstraintRequirement::from('11.4')->isSatisfiedBy(Runner\Version::id())) {
-            // those deal with data provider events which can be useful only if PHPUnit 11.4 is used
+        if (ConstraintRequirement::from('>=11.4')->isSatisfiedBy(Runner\Version::id())) {
+            // those deal with data provider events which can be useful only if PHPUnit >=11.4 is used
             $subscribers[] = new BootFoundryOnDataProviderMethodCalled();
             $subscribers[] = new ShutdownFoundryOnDataProviderMethodFinished();
         }


### PR DESCRIPTION
Fixes:

```
There was 1 PHPUnit test runner warning:

1) Bootstrapping of extension Zenstruck\Foundry\PHPUnit\FoundryExtension failed: Your PHPUnit version (11.5.0) is not compatible with the minimum version (11.4) needed to use this extension.
#0 /project/vendor/phpunit/phpunit/src/Runner/Extension/ExtensionBootstrapper.php(73): Zenstruck\Foundry\PHPUnit\FoundryExtension->bootstrap()
#1 /project/vendor/phpunit/phpunit/src/TextUI/Application.php(437): PHPUnit\Runner\Extension\ExtensionBootstrapper->bootstrap()
#2 /project/vendor/phpunit/phpunit/src/TextUI/Application.php(139): PHPUnit\TextUI\Application->bootstrapExtensions()
#3 /project/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run()
#4 /project/vendor/bin/phpunit(122): include('...')
#5 {main}
```