### PR TITLE
fix: reset database for sqlite and windows 

### DIFF
--- a/src/ORM/ResetDatabase/BaseOrmResetter.php
+++ b/src/ORM/ResetDatabase/BaseOrmResetter.php
@@ -60,9 +60,8 @@ abstract class BaseOrmResetter implements OrmResetter
                 // let's only drop the .db file
 
                 $dbPath = $connection->getParams()['path'] ?? null;
-                $fs = new Filesystem();
-                if (DoctrineOrmVersionGuesser::isOrmV3() && $dbPath && $fs->exists($dbPath)) {
-                    (new Filesystem())->remove($dbPath);
+                if (DoctrineOrmVersionGuesser::isOrmV3() && $dbPath && (new Filesystem())->exists($dbPath)) {
+                    file_put_contents($dbPath, '');
                 }
 
                 continue;


### PR DESCRIPTION
fixes #746 

I found the fix thanks to https://github.com/laravel/framework/pull/21720

At start, I wanted to add a unique CI permutation with windows, but it is incompatible with [this](https://github.com/zenstruck/foundry/blob/2.x/.github/workflows/ci.yml#L61-L64), we're getting an error "[Container operations are only supported on Linux runners](https://github.com/zenstruck/foundry/actions/runs/12329822803/job/34414589515?pr=747#step:2:1)". 

The only solution would be to add yet another job, which I'm reluctant to do. But the [tests actually passed with a window runner](https://github.com/zenstruck/foundry/actions/runs/12330413858/job/34415854677?pr=747). Let's say we'll add this new job if a new bug with windows occurs