### PR TITLE
minor: introduce PerssitenceManager::isPersisted()

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -67,9 +67,14 @@ final class Configuration
         return (bool) $this->persistence;
     }
 
-    public function assertPersistanceEnabled(): void
+    public function isPersistenceEnabled(): bool
     {
-        if (!$this->isPersistenceAvailable() || !$this->persistence()->isEnabled()) {
+        return $this->isPersistenceAvailable() && $this->persistence()->isEnabled();
+    }
+
+    public function assertPersistenceEnabled(): void
+    {
+        if (!$this->isPersistenceEnabled()) {
             throw new PersistenceDisabled('Cannot get repository when persist is disabled.');
         }
     }

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -134,17 +134,10 @@ trait IsProxy // @phpstan-ignore trait.unused
 
     private function isPersisted(): bool
     {
-        try {
-            $this->_refresh();
+        $this->initializeLazyObject();
+        $object = $this->lazyObjectState->realInstance;
 
-            return true;
-        } catch (RefreshObjectFailed $e) {
-            if ($e->objectWasDeleted()) {
-                return false;
-            }
-
-            throw $e;
-        }
+        return Configuration::instance()->persistence()->isPersisted($object);
     }
 
     private function _autoRefresh(): void

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -175,6 +175,18 @@ final class PersistenceManager
         return $object;
     }
 
+    public function isPersisted(object $object): bool
+    {
+        if ($object instanceof Proxy) {
+            $object = unproxy($object);
+        }
+
+        $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
+        $id = $om->getClassMetadata($object::class)->getIdentifierValues($object);
+
+        return $id && $om->find($object::class, $id) !== null;
+    }
+
     /**
      * @template T of object
      *

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -166,7 +166,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public static function repository(): ObjectRepository
     {
-        Configuration::instance()->assertPersistanceEnabled();
+        Configuration::instance()->assertPersistenceEnabled();
 
         return new RepositoryDecorator(static::class()); // @phpstan-ignore return.type
     }
@@ -279,11 +279,12 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
                 // we create now the object to prevent "non-nullable" property errors,
                 // but we'll need to remove it once the current object is created
+
                 $inversedObject = unproxy($value->create());
                 $this->tempAfterPersist[] = static function(object $object) use ($value, $inverseField, $pm, $inversedObject) {
                     // we cannot use the already created $inversedObject:
                     // because we must also remove its potential newly created owner (here: "$oldObj")
-                    // but a cascade:["persist"] would remove too many things
+                    // but a cascade:["remove"] would remove too many things
                     $value->create([$inverseField => $object]);
                     $pm->refresh($object);
                     $oldObj = get($inversedObject, $inverseField);

--- a/src/Persistence/PersistentProxyObjectFactory.php
+++ b/src/Persistence/PersistentProxyObjectFactory.php
@@ -141,7 +141,7 @@ abstract class PersistentProxyObjectFactory extends PersistentObjectFactory
      */
     final public static function repository(): ObjectRepository
     {
-        Configuration::instance()->assertPersistanceEnabled();
+        Configuration::instance()->assertPersistenceEnabled();
 
         return new ProxyRepositoryDecorator(static::class()); // @phpstan-ignore argument.type, return.type
     }

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -167,7 +167,7 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
     #[Test]
     #[DataProvider('provideCascadeRelationshipsCombinations')]
     #[UsingRelationships(Address::class, ['contact'])]
-    #[UsingRelationships(Contact::class, ['address'])]
+    #[UsingRelationships(Contact::class, ['address', 'category'])]
     public function inversed_one_to_one(): void
     {
         $address = static::addressFactory()->create(['contact' => static::contactFactory()]);

--- a/tests/Integration/ORM/EntityRelationship/ProxyEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/EntityRelationship/ProxyEntityFactoryRelationshipTest.php
@@ -127,12 +127,11 @@ final class ProxyEntityFactoryRelationshipTest extends EntityFactoryRelationship
 
     /** @test */
     #[Test]
-    public function cannot_use_assert_persisted_when_entity_has_changes(): void
+    public function can_use_assert_persisted_when_entity_has_changes(): void
     {
         $contact = static::contactFactory()->create();
         $contact->setName('foo');
 
-        $this->expectException(RefreshObjectFailed::class);
         $contact->_assertPersisted();
     }
 


### PR DESCRIPTION
this change is needed before the fix about inversed one-to-one, otherwise calling `Proxy::isPersisted()` would break the tests, because of.... proxies :stuck_out_tongue_closed_eyes: 