### PR TITLE
[Docs fix] Factory::_real() instead Factory::object()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -720,7 +720,7 @@ The following assumes the ``Comment`` entity has a many-to-one relationship with
     $post = PostFactory::createOne(); // instance of Proxy
 
     CommentFactory::createOne(['post' => $post]);
-    CommentFactory::createOne(['post' => $post->object()]); // functionally the same as above
+    CommentFactory::createOne(['post' => $post->_real()]); // functionally the same as above
 
     // Example 2: pre-create Posts and choose a random one
     PostFactory::createMany(5); // create 5 Posts


### PR DESCRIPTION
Relying on docs I was trying to call such a method as "Factory::object()" but there was no this method.

Maybe the "Factory::_real()" was ment