### PR TITLE
[Docs fix] Proxy::_save() instead of Proxy::save()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1051,7 +1051,7 @@ still wrapped in a ``Proxy`` to optionally save later.
 
     $post = PostFactory::new()->withoutPersisting()->create(); // returns Post|Proxy
     $post->setTitle('something else'); // do something with object
-    $post->save(); // persist the Post (save() is a method on Proxy)
+    $post->_save(); // persist the Post (save() is a method on Proxy)
 
     $post = PostFactory::new()->withoutPersisting()->create()->object(); // actual Post object
 


### PR DESCRIPTION
Changed an incorrect function name in the docs

$post->save(); // persist the Post 
to
$post->_save(); // persist the Post