### PR TITLE
tests: validate PSR-4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,9 @@ jobs:
         with:
           composer-options: --prefer-dist
 
+      - name: Validate PSR-4
+        run: composer dump-autoload --optimize --strict-psr --strict-ambiguous
+
       - name: Install PHPStan
         run: composer bin phpstan install
 

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
             "Zenstruck\\Foundry\\Tests\\": ["tests/"],
             "App\\": "tests/Fixture/Maker/tmp/src",
             "App\\Tests\\": "tests/Fixture/Maker/tmp/tests"
-        }
+        },
+        "exclude-from-classmap": ["tests/Fixture/Maker/expected"]
     },
     "config": {
         "preferred-install": "dist",

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Unit\Persistence;
+namespace Zenstruck\Foundry\Tests\Unit\Persistence;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;


### PR DESCRIPTION
It's been several times that I detect and fix few classes that does not respect psr 4 in the `tests` directory.
Moreover, PHPStorm seems to be a little be buggy here... so I'm adding a check in the CI.