### PR TITLE
[Doc] Minor syntax fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1770,7 +1770,7 @@ Be sure your data provider returns only instances of ``Factory`` and you do not 
             )->asDataProvider();
         }
 
-    The ``FactoryCollection`` could also be passed directly to the test case in order to have several objects available in the same test:
+The ``FactoryCollection`` could also be passed directly to the test case in order to have several objects available in the same test:
 
 ::
 


### PR DESCRIPTION
This phrase should be rendered outside of the code example:

![](https://github.com/user-attachments/assets/b2e9dd79-7ca4-41be-b169-c628c781a3de)
