### PR TITLE
fix(ci): change PHP version used by PHP CS-Fixer 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
     steps:
       - uses: zenstruck/.github/actions/php-cs-fixer@main
         with:
-          php: 8
+          php: 8.1
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 


### PR DESCRIPTION
because PHP 8 was used, PHP CS Fixer [was emitting an error:](https://github.com/zenstruck/foundry/actions/runs/12439861425/job/34734376699#step:2:205) 
> Files that were not fixed due to errors reported during linting before fixing" and could not work correctly
