### PR TITLE
fix: isPersisted() must work when id is predictable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "brianium/paratest": "^6|^7",
         "dama/doctrine-test-bundle": "^7.0|^8.0",
         "doctrine/collections": "^1.7|^2.0",
-        "doctrine/common": "^3.2",
+        "doctrine/common": "^2|^3",
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
         "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
@@ -42,6 +42,7 @@
         "symfony/phpunit-bridge": "^6.4|^7.0",
         "symfony/runtime": "^6.4|^7.0",
         "symfony/translation-contracts": "^3.4",
+        "symfony/uid": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0"
     },

--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -88,4 +88,11 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
     {
         return $this->objectManagerFor($object::class)->getClassMetadata($object::class)->isEmbeddedDocument;
     }
+
+    final function isScheduledForInsert(object $object): bool
+    {
+        $uow = $this->objectManagerFor($object::class)->getUnitOfWork();
+
+        return $uow->isScheduledForInsert($object) || $uow->isScheduledForUpsert($object);
+    }
 }

--- a/src/ORM/AbstractORMPersistenceStrategy.php
+++ b/src/ORM/AbstractORMPersistenceStrategy.php
@@ -78,6 +78,11 @@ abstract class AbstractORMPersistenceStrategy extends PersistenceStrategy
         return $this->objectManagerFor($object::class)->getClassMetadata($object::class)->isEmbeddedClass;
     }
 
+    final function isScheduledForInsert(object $object): bool
+    {
+        return $this->objectManagerFor($object::class)->getUnitOfWork()->isScheduledForInsert($object);
+    }
+
     final public function managedNamespaces(): array
     {
         $namespaces = [];

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -211,7 +211,7 @@ final class PersistenceManager
 
     public function isPersisted(object $object): bool
     {
-        return (bool) $this->findPersisted($object);
+        return !$this->strategyFor($object::class)->isScheduledForInsert($object) && $this->findPersisted($object);
     }
 
     /**

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -99,4 +99,6 @@ abstract class PersistenceStrategy
     abstract public function embeddablePropertiesFor(object $object, string $owner): ?array;
 
     abstract public function isEmbeddable(object $object): bool;
+
+    abstract public function isScheduledForInsert(object $object): bool;
 }

--- a/tests/Fixture/Document/DocumentWithUid.php
+++ b/tests/Fixture/Document/DocumentWithUid.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[MongoDB\Document]
+class DocumentWithUid
+{
+    #[MongoDB\Id(type: 'bin_uuid', strategy: 'NONE')]
+    public string $id;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v7()->toBinary();
+    }
+}

--- a/tests/Fixture/Entity/EntityWithUid.php
+++ b/tests/Fixture/Entity/EntityWithUid.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Uid\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+class EntityWithUid
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    public Uuid $id;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v7();
+    }
+}

--- a/tests/Integration/Mongo/PersistenceManagerTest.php
+++ b/tests/Integration/Mongo/PersistenceManagerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\Mongo;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\ObjectManager;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithUid;
+use Zenstruck\Foundry\Tests\Integration\Persistence\PersistenceManagerTestCase;
+use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
+
+final class PersistenceManagerTest extends PersistenceManagerTestCase
+{
+    use RequiresMongo;
+
+    protected static function createObject(): object
+    {
+        return new DocumentWithUid();
+    }
+
+    protected static function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(DocumentManager::class); // @phpstan-ignore return.type
+    }
+}

--- a/tests/Integration/ORM/PersistenceManagerTest.php
+++ b/tests/Integration/ORM/PersistenceManagerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
+use Zenstruck\Foundry\Tests\Integration\Persistence\PersistenceManagerTestCase;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithUid;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+final class PersistenceManagerTest extends PersistenceManagerTestCase
+{
+    use RequiresORM;
+
+    protected static function createObject(): object
+    {
+        return new EntityWithUid();
+    }
+
+    protected static function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
+    }
+}

--- a/tests/Integration/Persistence/PersistenceManagerTestCase.php
+++ b/tests/Integration/Persistence/PersistenceManagerTestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\Persistence;
+
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Test\Factories;
+
+abstract class PersistenceManagerTestCase extends KernelTestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    public function it_can_test_if_object_with_uuid_is_persisted(): void
+    {
+        $object = $this->createObject();
+
+        $this->objectManager()->persist($object);
+
+        self::assertFalse(
+            Configuration::instance()->persistence()->isPersisted($object)
+        );
+    }
+
+    abstract protected static function createObject(): object;
+
+    abstract protected static function objectManager(): ObjectManager;
+}


### PR DESCRIPTION
I discovered a small glitch, when using uuid as column id (and its value is known in advance)