### PR TITLE
test: add orphan removal premutation

### DIFF
--- a/tests/Fixture/DoctrineCascadeRelationship/ChangeCascadePersistOnLoadClassMetadataListener.php
+++ b/tests/Fixture/DoctrineCascadeRelationship/ChangeCascadePersistOnLoadClassMetadataListener.php
@@ -44,6 +44,10 @@ final class ChangeCascadePersistOnLoadClassMetadataListener
         foreach ($this->metadata as $metadatum) {
             if ($classMetadata->getName() === $metadatum->class) {
                 $classMetadata->getAssociationMapping($metadatum->field)['cascade'] = $metadatum->cascade ? ['persist'] : [];
+
+                if ($metadatum->orphanRemoval) {
+                    $classMetadata->getAssociationMapping($metadatum->field)['orphanRemoval'] = true;
+                }
             }
         }
     }

--- a/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
+++ b/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
@@ -112,9 +112,12 @@ trait ChangesEntityRelationshipCascadePersist
                     throw new \LogicException(\sprintf("Wrong parameters for attribute \"%s\". Association \"{$class}::\${$field}\" does not exist.", UsingRelationships::class));
                 }
 
-                $relationshipFields[] = ['class' => $association['sourceEntity'], 'field' => $association['fieldName']];
+                $relationshipFields[] = ['class' => $association['sourceEntity'], 'field' => $association['fieldName'], 'isOneToMany' => $association['type'] === ClassMetadata::ONE_TO_MANY];
                 if ($association['inversedBy'] ?? $association['mappedBy'] ?? null) {
-                    $relationshipFields[] = ['class' => $association['targetEntity'], 'field' => $association['inversedBy'] ?? $association['mappedBy']];
+                    /** @var ClassMetadata<object> $metadataTargetEntity */
+                    $metadataTargetEntity = $persistenceManager->metadataFor($association['targetEntity']); // @phpstan-ignore argument.templateType
+                    $associationTargetEntity = $metadataTargetEntity->getAssociationMapping($association['inversedBy'] ?? $association['mappedBy']);
+                    $relationshipFields[] = ['class' => $associationTargetEntity['sourceEntity'], 'field' => $associationTargetEntity['fieldName'], 'isOneToMany' => $associationTargetEntity['type'] === ClassMetadata::ONE_TO_MANY];
                 }
             }
         }


### PR DESCRIPTION
I noticed that in some case, `orphanRemoval` configuration of a relationship can change results. Then I've added one permutation with `orphanRemoval=true` for all `OneToMany` we're testing