### PR TITLE
minor: use refresh for detached entities

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Persistence;
 
 use Doctrine\Persistence\ObjectRepository;
+use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
@@ -19,6 +20,8 @@ use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\ObjectFactory;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
+
+use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 
 use function Zenstruck\Foundry\set;
 
@@ -357,7 +360,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
             return $object;
         }
 
-        return $configuration->persistence()->findPersisted($object) ?? $object;
+        try {
+            return $configuration->persistence()->refresh($object, true);
+        } catch (RefreshObjectFailed|VarExportLogicException) {
+            return $object;
+        }
     }
 
     final protected function isPersisting(): bool


### PR DESCRIPTION
I discovered a small glitch because of [this PR](https://github.com/zenstruck/foundry/pull/773).

I'm rolling back, and prevent recomputing changeset if `$force = true` is passed to `PersistenceManager::refresh()`