### PR TITLE
fix: simplify reset database extension

### DIFF
--- a/config/mongo.php
+++ b/config/mongo.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Zenstruck\Foundry\Mongo\MongoPersistenceStrategy;
+use Zenstruck\Foundry\Mongo\MongoResetter;
 use Zenstruck\Foundry\Mongo\MongoSchemaResetter;
 
 return static function (ContainerConfigurator $container): void {
@@ -13,7 +14,8 @@ return static function (ContainerConfigurator $container): void {
                 abstract_arg('config'),
             ])
             ->tag('.foundry.persistence_strategy')
-        ->set('.zenstruck_foundry.persistence.schema_resetter.mongo', MongoSchemaResetter::class)
+
+        ->set(MongoResetter::class, MongoSchemaResetter::class)
             ->args([
                 abstract_arg('managers'),
             ])

--- a/config/orm.php
+++ b/config/orm.php
@@ -8,8 +8,7 @@ use Zenstruck\Foundry\ORM\OrmV2PersistenceStrategy;
 use Zenstruck\Foundry\ORM\OrmV3PersistenceStrategy;
 use Zenstruck\Foundry\ORM\ResetDatabase\BaseOrmResetter;
 use Zenstruck\Foundry\ORM\ResetDatabase\DamaDatabaseResetter;
-use Zenstruck\Foundry\ORM\ResetDatabase\SchemaDatabaseResetter;
-use Zenstruck\Foundry\ORM\ResetDatabase\MigrateDatabaseResetter;
+use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
@@ -26,13 +25,7 @@ return static function (ContainerConfigurator $container): void {
             ->arg('$connections', service('connections'))
             ->abstract()
 
-        ->set('.zenstruck_foundry.persistence.database_resetter.orm.schema', SchemaDatabaseResetter::class)
-            ->parent('.zenstruck_foundry.persistence.database_resetter.orm.abstract')
-            ->tag('.foundry.persistence.database_resetter')
-            ->tag('.foundry.persistence.schema_resetter')
-
-        ->set('.zenstruck_foundry.persistence.database_resetter.orm.migrate', MigrateDatabaseResetter::class)
-            ->arg('$configurations', abstract_arg('configurations'))
+        ->set(OrmResetter::class, /* class to be defined thanks to the configuration */)
             ->parent('.zenstruck_foundry.persistence.database_resetter.orm.abstract')
             ->tag('.foundry.persistence.database_resetter')
             ->tag('.foundry.persistence.schema_resetter')
@@ -40,13 +33,8 @@ return static function (ContainerConfigurator $container): void {
 
     if (\class_exists(StaticDriver::class)) {
         $container->services()
-            ->set('.zenstruck_foundry.persistence.database_resetter.orm.schema.dama', DamaDatabaseResetter::class)
-                ->decorate('.zenstruck_foundry.persistence.database_resetter.orm.schema')
-                ->args([
-                    service('.inner'),
-                ])
-            ->set('.zenstruck_foundry.persistence.database_resetter.orm.migrate.dama', DamaDatabaseResetter::class)
-                ->decorate('.zenstruck_foundry.persistence.database_resetter.orm.migrate')
+            ->set('.zenstruck_foundry.persistence.database_resetter.orm.dama', DamaDatabaseResetter::class)
+                ->decorate(OrmResetter::class, priority: 10)
                 ->args([
                     service('.inner'),
                 ])

--- a/tests/Fixture/ResetDatabase/MongoResetterDecorator.php
+++ b/tests/Fixture/ResetDatabase/MongoResetterDecorator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\ResetDatabase;
+
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\Mongo\MongoResetter;
+
+#[AsDecorator(MongoResetter::class)]
+final class MongoResetterDecorator implements MongoResetter
+{
+    public static bool $calledBeforeEachTest = false;
+
+    public function __construct(
+        private MongoResetter $decorated
+    ) {
+    }
+
+    public function resetBeforeEachTest(KernelInterface $kernel): void
+    {
+        self::$calledBeforeEachTest = true;
+
+        $this->decorated->resetBeforeEachTest($kernel);
+    }
+}

--- a/tests/Fixture/ResetDatabase/OrmResetterDecorator.php
+++ b/tests/Fixture/ResetDatabase/OrmResetterDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\ResetDatabase;
+
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
+
+#[AsDecorator(OrmResetter::class)]
+final class OrmResetterDecorator implements OrmResetter
+{
+    public static bool $calledBeforeFirstTest = false;
+    public static bool $calledBeforeEachTest = false;
+
+    public function __construct(
+        private OrmResetter $decorated
+    ) {}
+
+    public function resetBeforeFirstTest(KernelInterface $kernel): void
+    {
+        self::$calledBeforeFirstTest = true;
+
+        $this->decorated->resetBeforeFirstTest($kernel);
+    }
+
+    public function resetBeforeEachTest(KernelInterface $kernel): void
+    {
+        self::$calledBeforeEachTest = true;
+
+        $this->decorated->resetBeforeEachTest($kernel);
+    }
+
+    public static function reset(): void
+    {
+        self::$calledBeforeFirstTest = false;
+        self::$calledBeforeEachTest = false;
+    }
+}

--- a/tests/Fixture/ResetDatabase/ResetDatabaseTestKernel.php
+++ b/tests/Fixture/ResetDatabase/ResetDatabaseTestKernel.php
@@ -63,5 +63,13 @@ final class ResetDatabaseTestKernel extends FoundryTestKernel
         }
 
         $c->register(GlobalInvokableService::class);
+
+        if (self::hasORM()) {
+            $c->register(OrmResetterDecorator::class)->setAutowired(true)->setAutoconfigured(true);
+        }
+
+        if (self::hasMongo()) {
+            $c->register(MongoResetterDecorator::class)->setAutowired(true)->setAutoconfigured(true);
+        }
     }
 }


### PR DESCRIPTION
:warning: this PR is build on top of #763  which needs to be reviewed/merged before this one

fixes #770 
fixes #771 (I guess :sweat_smile:)

At first, I used private services names for the resetters, and added a public alias (`OrmResetter`) which purpose was to be used to decorate the resetters ([see docs](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#extending-reset-mechanism)). But this was clumsy, because when an alias is decorated, the decorator does not inherit the tags from the decorated. Which made the whole extension system complex.

Now, the resetter service name is directly the name of the service which needs to be decorated, as stated in the docs. No more alias.
I've also added some tests so we know it just work

ping @Nyholm @javiereguiluz this is going to land in the next release :)