### PR TITLE
tests: ensure passing entity to many-to-one works correctly

### DIFF
--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -190,6 +190,7 @@ final class PersistenceManager
 
     public function isPersisted(object $object): bool
     {
+        // prevents doctrine to use its cache and think the object is persisted
         if ($this->strategyFor($object::class)->isScheduledForInsert($object)) {
             return false;
         }


### PR DESCRIPTION
this PR covers with tests the "small glitch" discovered [here](https://github.com/zenstruck/foundry/pull/778) is covered by tests