### PR TITLE
test: assert updates are implicitly persisted

### DIFF
--- a/src/ORM/AbstractORMPersistenceStrategy.php
+++ b/src/ORM/AbstractORMPersistenceStrategy.php
@@ -41,10 +41,13 @@ abstract class AbstractORMPersistenceStrategy extends PersistenceStrategy
             return false;
         }
 
-        // cannot use UOW::recomputeSingleEntityChangeSet() here as it wrongly computes embedded objects as changed
-        $em->getUnitOfWork()->computeChangeSet($em->getClassMetadata($object::class), $object);
+        // we're cloning the UOW because computing change set has side effect
+        $unitOfWork = clone $em->getUnitOfWork();
 
-        return (bool) $em->getUnitOfWork()->getEntityChangeSet($object);
+        // cannot use UOW::recomputeSingleEntityChangeSet() here as it wrongly computes embedded objects as changed
+        $unitOfWork->computeChangeSet($em->getClassMetadata($object::class), $object);
+
+        return (bool) $unitOfWork->getEntityChangeSet($object);
     }
 
     final public function truncate(string $class): void

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -155,10 +155,8 @@ final class PersistenceManager
 
         $strategy = $this->strategyFor($object::class);
 
-        if (!$force) {
-            if ($strategy->hasChanges($object)) {
-                throw RefreshObjectFailed::objectHasUnsavedChanges($object::class);
-            }
+        if ($strategy->hasChanges($object)) {
+            throw RefreshObjectFailed::objectHasUnsavedChanges($object::class);
         }
 
         $om = $strategy->objectManagerFor($object::class);

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -389,7 +389,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
         }
 
         try {
-            return $persistenceManager->refresh($object, force: true);
+            return $configuration->persistence()->refresh($object);
         } catch (RefreshObjectFailed|VarExportLogicException) {
             return $object;
         }

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -31,6 +31,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 
+use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\unproxy;
 
 /**
@@ -359,6 +360,22 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         foreach ($category->getContacts() as $contact) {
             $this->assertNotNull($contact->id);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function assert_updates_are_implicitly_persisted(): void
+    {
+        $category = static::categoryFactory()->create();
+        $address = static::addressFactory()->create();
+
+        $category->setName('new name');
+
+        static::contactFactory()->create(['category' => $category, 'address' => $address]);
+
+        refresh($category);
+        self::assertSame('new name', $category->getName());
     }
 
     /** @test */


### PR DESCRIPTION
fix of a subtle bug introduced by https://github.com/zenstruck/foundry/pull/773
