### PR TITLE
fix: Ensure that nested factories can be created even if class already exists

### DIFF
--- a/src/Maker/Factory/FactoryGenerator.php
+++ b/src/Maker/Factory/FactoryGenerator.php
@@ -97,6 +97,9 @@ final class FactoryGenerator
             }
         }
 
+        // Should never do this if file/class already exists.
+        // A class_exists($factoryClass), return false, I don't know if it's not part of the autoloader, that the class is not found.
+        // I suspect that it's part of the problem.
         $generator->generateClass(
             $factoryClass,
             __DIR__.'/../../../skeleton/Factory.tpl.php',

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -129,10 +129,17 @@ final class MakeFactoryTest extends MakerTestCase
         }
 
         $tester = $this->makeFactoryCommandTester();
-        $tester->execute(['class' => Contact::class, '--test' => true]);
-        $tester->execute(['class' => Address::class, '--test' => true]);
+        
+        $tester->execute(['class' => Contact::class, '--test' => true]);    
+        
         $this->assertFileExists(self::tempFile('tests/Factory/ContactFactory.php'));
         $this->assertFileExists(self::tempFile('tests/Factory/AddressFactory.php'));
+        
+        // here, we're faking multiple calls to `bin/console make:factory`
+        // so it's perfectly acceptable to manually load the newly created class
+        require_once self::tempFile('tests/Factory/AddressFactory.php';
+        
+        $tester->execute(['class' => Address::class, '--test' => true]);
     }
 
     /**

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -129,16 +129,15 @@ final class MakeFactoryTest extends MakerTestCase
         }
 
         $tester = $this->makeFactoryCommandTester();
-        
-        $tester->execute(['class' => Contact::class, '--test' => true]);    
-        
+
+        $tester->execute(['class' => Contact::class, '--test' => true]);
+
         $this->assertFileExists(self::tempFile('tests/Factory/ContactFactory.php'));
         $this->assertFileExists(self::tempFile('tests/Factory/AddressFactory.php'));
         
         // here, we're faking multiple calls to `bin/console make:factory`
         // so it's perfectly acceptable to manually load the newly created class
-        require_once self::tempFile('tests/Factory/AddressFactory.php';
-        
+        require_once self::tempFile('tests/Factory/AddressFactory.php');
         $tester->execute(['class' => Address::class, '--test' => true]);
     }
 

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Zenstruck\Foundry\Maker\Factory\FactoryGenerator;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Document\WithEmbeddableDocument;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
@@ -116,6 +117,22 @@ final class MakeFactoryTest extends MakerTestCase
         $tester->execute(['class' => Category::class, '--test' => true]);
 
         $this->assertFileExists(self::tempFile('tests/Factory/CategoryFactory.php'));
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_factory_in_test_dir_with_nested_factory_already_created(): void
+    {
+        if (!\getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+
+        $tester = $this->makeFactoryCommandTester();
+        $tester->execute(['class' => Contact::class, '--test' => true]);
+        $tester->execute(['class' => Address::class, '--test' => true]);
+        $this->assertFileExists(self::tempFile('tests/Factory/ContactFactory.php'));
+        $this->assertFileExists(self::tempFile('tests/Factory/AddressFactory.php'));
     }
 
     /**


### PR DESCRIPTION
This is intended to resolve #786, which isn't the case yet. Right now it's only a test proving the problem described in the issue. 

As I don't know foundry that well, I have a little difficulties, with the naming as I don't know the terminology used in foundry. So inputs are welcome, but we get to a review state at some point anyway. :) 

Update: There is something not right in my test. There order should be different, and then it works. Back to the IDE.. 

