### PR TITLE
minor: add platform config to mysql docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
     mysql:
+        platform: linux/x86_64
         image: mysql:5.7
         ports:
             - "3307:3306"


### PR DESCRIPTION
This is needed for the mysql container to start properly on macos.