### PR TITLE
feat: skip readonly properties on entities when generating factories

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,4 @@ MONGO_URL="mongodb://127.0.0.1:27018/dbName?compressors=disabled&amp;gssapiServi
 USE_DAMA_DOCTRINE_TEST_BUNDLE="0"
 USE_FOUNDRY_PHPUNIT_EXTENSION="0"
 PHPUNIT_VERSION="9" # allowed values: 9, 10, 11
+APP_ENV=test

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/property-access": "^6.4|^7.0",
+        "symfony/property-info": "^6.4|^7.0",
         "symfony/var-exporter": "^6.4.9|~7.0.9|^7.1.2",
         "zenstruck/assert": "^1.4"
     },

--- a/src/Maker/Factory/FactoryGenerator.php
+++ b/src/Maker/Factory/FactoryGenerator.php
@@ -32,9 +32,6 @@ final class FactoryGenerator
     public const PHPSTAN_PATH = '/vendor/phpstan/phpstan/phpstan';
     public const PSALM_PATH = '/vendor/vimeo/psalm/psalm';
 
-    /** @var string[]|true */
-    private array|bool $forceProperties = [];
-
     /** @param \Traversable<int, DefaultPropertiesGuesser> $defaultPropertiesGuessers */
     public function __construct(
         private ?PersistenceManager $persistenceManager,
@@ -42,6 +39,7 @@ final class FactoryGenerator
         private \Traversable $defaultPropertiesGuessers,
         private FactoryClassMap $factoryClassMap,
         private NamespaceGuesser $namespaceGuesser,
+        private bool $forceProperties = false
     ) {
     }
 
@@ -164,13 +162,5 @@ final class FactoryGenerator
             \file_exists($this->kernel->getProjectDir().self::PSALM_PATH) => MakeFactoryData::STATIC_ANALYSIS_TOOL_PSALM,
             default => MakeFactoryData::STATIC_ANALYSIS_TOOL_NONE,
         };
-    }
-
-    public function alwaysForce(string ...$properties): self
-    {
-        $clone = clone $this;
-        $clone->forceProperties = $properties ?: true;
-
-        return $clone;
     }
 }

--- a/src/Maker/Factory/FactoryGenerator.php
+++ b/src/Maker/Factory/FactoryGenerator.php
@@ -32,6 +32,9 @@ final class FactoryGenerator
     public const PHPSTAN_PATH = '/vendor/phpstan/phpstan/phpstan';
     public const PSALM_PATH = '/vendor/vimeo/psalm/psalm';
 
+    /** @var string[]|true */
+    private array|bool $forceProperties = [];
+
     /** @param \Traversable<int, DefaultPropertiesGuesser> $defaultPropertiesGuessers */
     public function __construct(
         private ?PersistenceManager $persistenceManager,
@@ -150,6 +153,7 @@ final class FactoryGenerator
             $this->staticAnalysisTool(),
             $persisted ?? false,
             $makeFactoryQuery->addPhpDoc(),
+            $this->forceProperties
         );
     }
 
@@ -160,5 +164,13 @@ final class FactoryGenerator
             \file_exists($this->kernel->getProjectDir().self::PSALM_PATH) => MakeFactoryData::STATIC_ANALYSIS_TOOL_PSALM,
             default => MakeFactoryData::STATIC_ANALYSIS_TOOL_NONE,
         };
+    }
+
+    public function alwaysForce(string ...$properties): self
+    {
+        $clone = clone $this;
+        $clone->forceProperties = $properties ?: true;
+
+        return $clone;
     }
 }

--- a/src/Maker/Factory/MakeFactoryData.php
+++ b/src/Maker/Factory/MakeFactoryData.php
@@ -158,7 +158,7 @@ final class MakeFactoryData
     public function getDefaultProperties(): array
     {
         $defaultProperties = $this->defaultProperties;
-        $clazz = $this->object->getName();
+        $class = $this->object->getName();
 
         /**
          * If forceProperties is not set we filter out properties that can not be set because they're either readonly or have no setter.
@@ -166,12 +166,12 @@ final class MakeFactoryData
          *
          * We do this here because we need to get the class of the Entity which only seems to be accessible here.
          */
-        $defaultProperties = array_filter($defaultProperties, function (string $propertyName) use ($clazz): bool {
+        $defaultProperties = array_filter($defaultProperties, function (string $propertyName) use ($class): bool {
             if (true === $this->forceProperties) {
                 return true;
             }
 
-            return self::propertyInfo()->isWritable($clazz, $propertyName) || self::propertyInfo()->isInitializable($clazz, $propertyName);
+            return self::propertyInfo()->isWritable($class, $propertyName) || self::propertyInfo()->isInitializable($class, $propertyName);
         }, ARRAY_FILTER_USE_KEY);
 
         \ksort($defaultProperties);

--- a/src/Maker/Factory/MakeFactoryData.php
+++ b/src/Maker/Factory/MakeFactoryData.php
@@ -16,8 +16,6 @@ use Doctrine\ORM\EntityRepository;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
-use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
-use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Zenstruck\Foundry\ObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy;
@@ -32,10 +30,7 @@ final class MakeFactoryData
     public const STATIC_ANALYSIS_TOOL_PHPSTAN = 'phpstan';
     public const STATIC_ANALYSIS_TOOL_PSALM = 'psalm';
 
-    /**
-     * @var null|PropertyAccessExtractorInterface&PropertyInitializableExtractorInterface
-     */
-    private static mixed $propertyInfo = null;
+    private static ReflectionExtractor|null $propertyInfo = null;
 
     /** @var list<string> */
     private array $uses;
@@ -53,6 +48,7 @@ final class MakeFactoryData
         private string $staticAnalysisTool,
         private bool $persisted,
         bool $withPhpDoc,
+        /** @var string[]|true $forceProperties */
         array|bool $forceProperties
     ) {
         $this->uses = [
@@ -216,7 +212,7 @@ final class MakeFactoryData
         );
     }
 
-    private static function propertyInfo(): PropertyAccessExtractorInterface&PropertyInitializableExtractorInterface
+    private static function propertyInfo(): ReflectionExtractor
     {
         return self::$propertyInfo ??= new ReflectionExtractor();
     }

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -341,6 +341,9 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
             $container->getDefinition('.zenstruck_foundry.instantiator')
                 ->addMethodCall('alwaysForce', returnsClone: true)
             ;
+            $container->getDefinition('.zenstruck_foundry.maker.factory.generator')
+                ->addMethodCall('alwaysForce', returnsClone: true)
+            ;
         }
     }
 

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -231,6 +231,9 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
             if (!isset($bundles['DoctrineBundle']) && !isset($bundles['DoctrineMongoDBBundle'])) {
                 $container->removeDefinition('.zenstruck_foundry.maker.factory.doctrine_scalar_fields_default_properties_guesser');
             }
+
+            $container->getDefinition('.zenstruck_foundry.maker.factory.generator')
+                ->setArgument('$forceProperties', $config['instantiator']['always_force_properties'] ?? false);
         } else {
             $configurator->import('../config/command_stubs.php');
         }
@@ -339,9 +342,6 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
 
         if ($config['always_force_properties']) {
             $container->getDefinition('.zenstruck_foundry.instantiator')
-                ->addMethodCall('alwaysForce', returnsClone: true)
-            ;
-            $container->getDefinition('.zenstruck_foundry.maker.factory.generator')
                 ->addMethodCall('alwaysForce', returnsClone: true)
             ;
         }

--- a/tests/Fixture/Maker/expected/does_force_initialization_of_non_settable_with_always_force.php
+++ b/tests/Fixture/Maker/expected/does_force_initialization_of_non_settable_with_always_force.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Factory;
+
+use Zenstruck\Foundry\ObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\ObjectWithNonWriteable;
+
+/**
+ * @extends ObjectFactory<ObjectWithNonWriteable>
+ */
+final class ObjectWithNonWriteableFactory extends ObjectFactory
+{
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
+     *
+     * @todo inject services if required
+     */
+    public function __construct()
+    {
+    }
+
+    public static function class(): string
+    {
+        return ObjectWithNonWriteable::class;
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     *
+     * @todo add your default values here
+     */
+    protected function defaults(): array|callable
+    {
+        return [
+            'baz' => self::faker()->sentence(),
+            'bar' => self::faker()->sentence(),
+            'foo' => self::faker()->sentence(),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this
+            // ->afterInstantiate(function(ObjectWithNonWriteable $objectWithNonWriteable): void {})
+        ;
+    }
+}

--- a/tests/Fixture/Maker/expected/does_force_initialization_of_non_settable_with_always_force.php
+++ b/tests/Fixture/Maker/expected/does_force_initialization_of_non_settable_with_always_force.php
@@ -41,8 +41,8 @@ final class ObjectWithNonWriteableFactory extends ObjectFactory
     protected function defaults(): array|callable
     {
         return [
-            'baz' => self::faker()->sentence(),
             'bar' => self::faker()->sentence(),
+            'baz' => self::faker()->sentence(),
             'foo' => self::faker()->sentence(),
         ];
     }

--- a/tests/Fixture/Maker/expected/does_not_initialize_non_settable.php
+++ b/tests/Fixture/Maker/expected/does_not_initialize_non_settable.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Factory;
+
+use Zenstruck\Foundry\ObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\ObjectWithNonWriteable;
+
+/**
+ * @extends ObjectFactory<ObjectWithNonWriteable>
+ */
+final class ObjectWithNonWriteableFactory extends ObjectFactory
+{
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
+     *
+     * @todo inject services if required
+     */
+    public function __construct()
+    {
+    }
+
+    public static function class(): string
+    {
+        return ObjectWithNonWriteable::class;
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     *
+     * @todo add your default values here
+     */
+    protected function defaults(): array|callable
+    {
+        return [
+            'baz' => self::faker()->sentence(),
+            'foo' => self::faker()->sentence(),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this
+            // ->afterInstantiate(function(ObjectWithNonWriteable $objectWithNonWriteable): void {})
+        ;
+    }
+}

--- a/tests/Fixture/ObjectWithNonWriteable.php
+++ b/tests/Fixture/ObjectWithNonWriteable.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture;
+
+final class ObjectWithNonWriteable
+{
+    private string $bar;
+    // @phpstan-ignore-next-line We do not want assign a default value to this so the factory sets one
+    private string $baz;
+
+    public function __construct(
+        public readonly string $foo
+    ) {
+        $this->bar = 'bar';
+    }
+
+    public function getBaz(): string
+    {
+        return $this->baz;
+    }
+
+    public function setBaz(string $baz): ObjectWithNonWriteable
+    {
+        $this->baz = $baz;
+        return $this;
+    }
+
+    public function getBar(): string
+    {
+        return $this->bar;
+    }
+}

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -35,6 +35,10 @@ final class TestKernel extends FoundryTestKernel
     {
         parent::configureContainer($c, $loader);
 
+        if ($this->getEnvironment() !== 'test') {
+            $loader->load(\sprintf('%s/config/%s.yaml', __DIR__, $this->getEnvironment()));
+        }
+
         $c->loadFromExtension('zenstruck_foundry', [
             'orm' => [
                 'reset' => [

--- a/tests/Fixture/config/always_force.yaml
+++ b/tests/Fixture/config/always_force.yaml
@@ -1,0 +1,3 @@
+zenstruck_foundry:
+    instantiator:
+        always_force_properties: true # always "force set" properties

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -23,6 +23,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Entity\WithEmbeddableEntity;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
 use Zenstruck\Foundry\Tests\Fixture\ObjectWithEnum;
+use Zenstruck\Foundry\Tests\Fixture\ObjectWithNonWriteable;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -419,6 +420,18 @@ final class MakeFactoryTest extends MakerTestCase
         $tester->execute(['class' => ObjectWithEnum::class, '--no-persistence' => true]);
 
         $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/ObjectWithEnumFactory.php'));
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_initialize_non_settable(): void
+    {
+        $tester = $this->makeFactoryCommandTester();
+
+        $tester->execute(['class' => ObjectWithNonWriteable::class, '--no-persistence' => true]);
+
+        $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/ObjectWithNonWriteableFactory.php'));
     }
 
     private function emulateSCAToolEnabled(string $scaToolFilePath): void

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -439,7 +439,7 @@ final class MakeFactoryTest extends MakerTestCase
      */
     public function does_force_initialization_of_non_settable_with_always_force(): void
     {
-        $tester = $this->makeFactoryCommandTester();
+        $tester = $this->makeFactoryCommandTester('always_force');
 
         $tester->execute(['class' => ObjectWithNonWriteable::class, '--no-persistence' => true]);
 
@@ -452,8 +452,10 @@ final class MakeFactoryTest extends MakerTestCase
         \touch($scaToolFilePath);
     }
 
-    private function makeFactoryCommandTester(): CommandTester
+    private function makeFactoryCommandTester(string $appEnv = 'test'): CommandTester
     {
-        return new CommandTester((new Application(self::bootKernel()))->find('make:factory'));
+        return new CommandTester((new Application(self::bootKernel([
+            'environment' => $appEnv,
+        ])))->find('make:factory'));
     }
 }

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -434,6 +434,18 @@ final class MakeFactoryTest extends MakerTestCase
         $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/ObjectWithNonWriteableFactory.php'));
     }
 
+    /**
+     * @test
+     */
+    public function does_force_initialization_of_non_settable_with_always_force(): void
+    {
+        $tester = $this->makeFactoryCommandTester();
+
+        $tester->execute(['class' => ObjectWithNonWriteable::class, '--no-persistence' => true]);
+
+        $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/ObjectWithNonWriteableFactory.php'));
+    }
+
     private function emulateSCAToolEnabled(string $scaToolFilePath): void
     {
         \mkdir(\dirname($scaToolFilePath), 0777, true);


### PR DESCRIPTION
Fixes #769 by checking if the property is writable or settable via constructor 

Things that are missing:

- [x] Test cases (as soon as I figure out how those maker tests work)
- [x] `always_force_property` (I guess that needs to be injected there since it's only present in Hydrator and Instantiator)

If you got some pointers for those two points, I'd gladly take those