### PR TITLE
fix: remove APP_ENV from .env

### DIFF
--- a/.env
+++ b/.env
@@ -10,4 +10,3 @@ MONGO_URL="mongodb://127.0.0.1:27018/dbName?compressors=disabled&amp;gssapiServi
 USE_DAMA_DOCTRINE_TEST_BUNDLE="0"
 USE_FOUNDRY_PHPUNIT_EXTENSION="0"
 PHPUNIT_VERSION="9" # allowed values: 9, 10, 11
-APP_ENV=test

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -36,7 +36,7 @@ final class TestKernel extends FoundryTestKernel
     {
         parent::configureContainer($c, $loader);
 
-        if ('test' !== $this->getEnvironment()) {
+        if ('dev' !== $this->getEnvironment()) {
             $loader->load(\sprintf('%s/config/%s.yaml', __DIR__, $this->getEnvironment()));
         }
 

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -439,7 +439,7 @@ final class MakeFactoryTest extends MakerTestCase
      */
     public function does_force_initialization_of_non_settable_with_always_force(): void
     {
-        $tester = $this->makeFactoryCommandTester('always_force');
+        $tester = $this->makeFactoryCommandTester(['environment' => 'always_force']);
 
         $tester->execute(['class' => ObjectWithNonWriteable::class, '--no-persistence' => true]);
 
@@ -452,10 +452,8 @@ final class MakeFactoryTest extends MakerTestCase
         \touch($scaToolFilePath);
     }
 
-    private function makeFactoryCommandTester(string $appEnv = 'test'): CommandTester
+    private function makeFactoryCommandTester(array $options = []): CommandTester
     {
-        return new CommandTester((new Application(self::bootKernel([
-            'environment' => $appEnv,
-        ])))->find('make:factory'));
+        return new CommandTester((new Application(self::bootKernel($options)))->find('make:factory'));
     }
 }


### PR DESCRIPTION
this was introduced in [this PR](https://github.com/zenstruck/foundry/pull/798). I don't know why dama does not work locally with the environment in the `.env` :thinking: let's roll with `dev` until we find why