### PR TITLE
feat: introduce "reuse()" method

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container): void {
             '%env(default:zenstruck_foundry.faker.seed:int:FOUNDRY_FAKER_SEED)%',
             param('.zenstruck_foundry.validation_enabled'),
             abstract_arg('validation_available'),
+            service('property_info'),
         ])
         ->public()
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -535,6 +535,10 @@ If you have a collection of values that you want to distribute over a collection
 
         ->create();
 
+.. versionadded::  2.4
+
+    The ``distribute()`` method was added in Foundry 2.4.
+
 Faker
 ~~~~~
 
@@ -944,6 +948,31 @@ The following assumes the ``Post`` entity has a many-to-many relationship with `
     // Example 5: create 3 Posts each with between 0 and 3 unique Tags
     PostFactory::createMany(3, ['tags' => TagFactory::new()->many(0, 3)]);
 
+Reuse Objects in Relationships
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When creating nested objects, sometimes it can be useful to tell Foundry to always use the same object for a given class.
+It can enforce coherence in your fixtures and avoid creating too many objects.
+
+In order to do this, you can use the ``reuse()`` method: it will force Foundry to use the object passed as parameter in
+all `ManyToOne` and `OneToOne` relationships using the class of this object:
+
+::
+
+    // let's say both Post and Comment classes have a ManyToOne field "author" of class User
+    $user = UserFactory::createOne();
+
+    PostFactory::new([
+        'comments' => CommentFactory::new()->many(5),
+    ])
+        // by calling reuse, the post and all its comments will have the same author
+        ->reuse($user)
+        ->create();
+
+.. versionadded::  2.4
+
+    The ``reuse()`` method was added in Foundry 2.4.
+
 Lazy Values
 ~~~~~~~~~~~
 
@@ -1234,6 +1263,10 @@ Validate your objects
 
 Foundry can validate your objects automatically after they are instantiated. This can be useful to
 ensure that your objects are in a valid state before they are used in your tests.
+
+.. versionadded::  2.4
+
+    Validation of the objects was added in Foundry 2.4.
 
 You can either enable validation globally:
 

--- a/tests/Unit/ReuseEntityTest.php
+++ b/tests/Unit/ReuseEntityTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
+
+final class ReuseEntityTest extends TestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_reuse_an_object(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($address)
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_throws_if_recycling_two_objects_of_same_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ContactFactory::new()
+            ->reuse(AddressFactory::createOne())
+            ->reuse(AddressFactory::createOne())
+            ->create();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_throws_if_recycling_a_factory(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ContactFactory::new()
+            ->reuse(AddressFactory::new())
+            ->create();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_does_nothing_if_reused_object_is_not_used(): void
+    {
+        ContactFactory::new()
+            ->reuse(new \stdClass())
+            ->create();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_call_reuse_multiple_times(): void
+    {
+        $address = AddressFactory::createOne();
+        $category = CategoryFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($address)
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
+        self::assertSame($category, $contact->getCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_reuse_the_same_object_multiple_times(): void
+    {
+        $category = CategoryFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($category, $contact->getCategory());
+        self::assertSame($category, $contact->getSecondaryCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_propagate_reused_objects(): void
+    {
+        $category = CategoryFactory::createOne();
+
+        $address = AddressFactory::new(['contact' => ContactFactory::new()])
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($category, $address->getContact()?->getCategory());
+        self::assertSame($category, $address->getContact()->getSecondaryCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function reused_object_in_sub_factory_has_priority(): void
+    {
+        $category = CategoryFactory::createOne();
+
+        $address = AddressFactory::new([
+                'contact' => ContactFactory::new()->reuse($category2 = CategoryFactory::createOne())
+            ])
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($category2, $address->getContact()?->getCategory());
+        self::assertSame($category2, $address->getContact()->getSecondaryCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function reused_object_dont_have_priority_over_states(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($address)
+            ->create(['address' => AddressFactory::new()]);
+
+        self::assertNotSame($address, $contact->getAddress());
+    }
+}


### PR DESCRIPTION
fixes #794 

For now, `reuse()` only takes one parameter. It cannot be passed multiple times an object of the same class nor a Factory 