### PR TITLE
fix: trigger after persist callbacks for entities scheduled for insert

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,7 +38,6 @@ parameters:
         - identifier: property.readOnlyByPhpDocDefaultValue
           paths:
             - src/Object/Hydrator.php
-            - src/Factory.php
             - src/ObjectFactory.php
             - src/Persistence/PersistentObjectFactory.php
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,13 +25,6 @@ use Faker;
  */
 abstract class Factory
 {
-    /**
-     * Memoization of normalized parameters.
-     *
-     * @internal
-     * @var Parameters|null
-     */
-    protected ?array $normalizedParameters = null;
     /** @phpstan-var Attributes[] */
     private array $attributes;
 
@@ -208,7 +201,7 @@ abstract class Factory
      */
     protected function normalizeParameters(array $parameters): array
     {
-        return $this->normalizedParameters = \array_combine(
+        return \array_combine(
             \array_keys($parameters),
             \array_map($this->normalizeParameter(...), \array_keys($parameters), $parameters)
         );

--- a/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
@@ -78,6 +78,7 @@ final class GenericEntityFactory extends PersistentProxyObjectFactory
     {
         return [
             'prop1' => self::faker()->text(),
+            'propInteger' => self::faker()->randomNumber(),
         ];
     }
 

--- a/tests/Fixture/Maker/expected/can_create_factory_with_all_fields.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_with_all_fields.php
@@ -43,6 +43,7 @@ final class GenericEntityFactory extends PersistentProxyObjectFactory
         return [
             'date' => \DateTimeImmutable::createFromMutable(self::faker()->dateTime()),
             'prop1' => self::faker()->text(),
+            'propInteger' => self::faker()->randomNumber(),
         ];
     }
 

--- a/tests/Fixture/Model/GenericModel.php
+++ b/tests/Fixture/Model/GenericModel.php
@@ -33,6 +33,10 @@ abstract class GenericModel
     #[MongoDB\Field(type: 'string')]
     private string $prop1;
 
+    #[ORM\Column]
+    #[MongoDB\Field(type: 'int')]
+    private int $propInteger = 0;
+
     #[ORM\Column(nullable: true)]
     #[MongoDB\Field(type: 'date_immutable', nullable: true)]
     private ?\DateTimeImmutable $date = null;
@@ -50,6 +54,16 @@ abstract class GenericModel
     public function setProp1(string $prop1): void
     {
         $this->prop1 = $prop1;
+    }
+
+    public function getPropInteger(): int
+    {
+        return $this->propInteger;
+    }
+
+    public function setPropInteger(int $propInteger): void
+    {
+        $this->propInteger = $propInteger;
     }
 
     public function getDate(): ?\DateTimeImmutable

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -400,6 +400,75 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         );
     }
 
+    /** @test */
+    public function it_uses_after_persist_with_many_to_many(): void
+    {
+        $contact = static::contactFactory()
+            ->with(
+                [
+                    'tags' => static::tagFactory()
+                        ->afterPersist(static function (Tag $tag) {$tag->setName('foobar');})
+                        ->many(1)
+                ]
+            )
+            ->create();
+
+        self::assertEquals('foobar', $contact->getTags()[0]?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_one_to_many(): void
+    {
+        $category = static::categoryFactory()
+            ->with([
+                'contacts' => static::contactFactory()
+                    ->afterPersist(static function (Contact $contact) {
+                        $contact->setName('foobar');
+                    })
+                    ->many(1)
+            ])->create();
+
+        self::assertEquals('foobar', $category->getContacts()[0]?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_many_to_one(): void
+    {
+        $contact = static::contactFactory()
+            ->with([
+                'category' => static::categoryFactory()
+                    ->afterPersist(static function (Category $category) {
+                        $category->setName('foobar');
+                    })
+            ])->create();
+
+        self::assertEquals('foobar', $contact->getCategory()?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_one_to_one(): void
+    {
+        $contact = static::contactFactory()
+            ->with([
+                'address' => static::addressFactory()
+                    ->afterPersist(static function (Address $address) {$address->setCity('foobar');})
+            ])->create();
+
+        self::assertEquals('foobar', $contact->getAddress()->getCity());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_inversed_one_to_one(): void
+    {
+        $address = static::addressFactory()
+            ->with([
+                'contact' => static::contactFactory()
+                    ->afterPersist(static function (Contact $contact) {$contact->setName('foobar');})
+            ])->create();
+
+        self::assertEquals('foobar', $address->getContact()?->getName());
+    }
+
     /** @return PersistentObjectFactory<Contact> */
     protected static function contactFactoryWithoutCategory(): PersistentObjectFactory
     {

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -270,21 +270,6 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
     /**
      * @test
      */
-    public function can_use_after_persist_with_attributes(): void
-    {
-        $object = static::factory()
-            ->instantiateWith(Instantiator::withConstructor()->allowExtra('extra'))
-            ->afterPersist(function(GenericModel $object, array $attributes) {
-                $object->setProp1($attributes['extra']);
-            })
-            ->create(['extra' => $value = 'value set with after persist']);
-
-        $this->assertSame($value, $object->getProp1());
-    }
-
-    /**
-     * @test
-     */
     public function can_use_after_persist_with_attributes_added_in_before_instantiate(): void
     {
         $value = 'value set with before instantiate';


### PR DESCRIPTION
Because we're now "scheduling for insert" some entities, and not directly saving them, we should take care of their after persist callbacks differently. The proposal of this PR is to give this responsibility to `PersistenceManager` 

fixes #821