### PR TITLE
chore: merge forward fixes in 2.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [v2.3.5](https://github.com/zenstruck/foundry/releases/tag/v2.3.5)
+
+February 24th, 2025 - [v2.3.4...v2.3.5](https://github.com/zenstruck/foundry/compare/v2.3.4...v2.3.5)
+
+* fbf0981 fix: actually disable persistence cascade (#817) by @nikophil
+* 2426f3e fix: trigger after persist callbacks for entities scheduled for insert (#822) by @nikophil
+
 ## [v2.3.4](https://github.com/zenstruck/foundry/releases/tag/v2.3.4)
 
 February 14th, 2025 - [v2.3.3...v2.3.4](https://github.com/zenstruck/foundry/compare/v2.3.3...v2.3.4)

--- a/bin/tools/phpstan/composer.lock
+++ b/bin/tools/phpstan/composer.lock
@@ -122,16 +122,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.0.3",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4"
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46b4d3529b12178112d9008337beda0cc2a1a6b4",
-                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +176,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-28T22:19:37+00:00"
+            "time": "2025-02-19T15:46:42+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -251,21 +251,21 @@
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475"
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
-                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d09e152f403c843998d7a52b5d87040c937525dd",
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.0.4"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -296,28 +296,28 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.1"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.4"
             },
-            "time": "2024-11-12T12:48:00+00:00"
+            "time": "2025-01-22T13:07:38+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "1ef4dce2baabd464c2dd3109d051bad94efa1e79"
+                "reference": "65f02c7e585f3c7372e42e14d3d87da034031553"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/1ef4dce2baabd464c2dd3109d051bad94efa1e79",
-                "reference": "1ef4dce2baabd464c2dd3109d051bad94efa1e79",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/65f02c7e585f3c7372e42e14d3d87da034031553",
+                "reference": "65f02c7e585f3c7372e42e14d3d87da034031553",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.1.2"
             },
             "conflict": {
                 "symfony/framework-bundle": "<3.0"
@@ -367,9 +367,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.0"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.2"
             },
-            "time": "2024-11-06T10:13:40+00:00"
+            "time": "2025-01-21T18:57:07+00:00"
         }
     ],
     "packages-dev": [],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,7 +38,6 @@ parameters:
         - identifier: property.readOnlyByPhpDocDefaultValue
           paths:
             - src/Object/Hydrator.php
-            - src/Factory.php
             - src/ObjectFactory.php
             - src/Persistence/PersistentObjectFactory.php
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,13 +25,6 @@ use Faker;
  */
 abstract class Factory
 {
-    /**
-     * Memoization of normalized parameters.
-     *
-     * @internal
-     * @var Parameters|null
-     */
-    protected ?array $normalizedParameters = null;
     /** @phpstan-var Attributes[] */
     private array $attributes;
 
@@ -208,7 +201,7 @@ abstract class Factory
      */
     protected function normalizeParameters(array $parameters): array
     {
-        return $this->normalizedParameters = \array_combine(
+        return \array_combine(
             \array_keys($parameters),
             \array_map($this->normalizeParameter(...), \array_keys($parameters), $parameters)
         );

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -97,12 +97,14 @@ trait IsProxy // @phpstan-ignore trait.unused
         return $this;
     }
 
-    public function _real(): object
+    public function _real(bool $withAutoRefresh = true): object
     {
-        try {
-            // we don't want the auto-refresh mechanism to break "real" object retrieval
-            $this->_autoRefresh();
-        } catch (\Throwable) {
+        if ($withAutoRefresh) {
+            try {
+                // we don't want the auto-refresh mechanism to break "real" object retrieval
+                $this->_autoRefresh();
+            } catch (\Throwable) {
+            }
         }
 
         return $this->initializeLazyObject();

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -91,7 +91,7 @@ final class PersistenceManager
     /**
      * @template T of object
      *
-     * @param T $object
+     * @param T                     $object
      * @param list<callable():void> $afterPersistCallbacks
      *
      * @return T

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -299,8 +299,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
                 // auto-refresh computes changeset and prevents the placeholder object to be cleanly
                 // forgotten fom the persistence manager
                 if ($inversedObject instanceof Proxy) {
-                    $inversedObject->_disableAutoRefresh();
-                    $inversedObject = $inversedObject->_real();
+                    $inversedObject = $inversedObject->_real(withAutoRefresh: false);
                 }
 
                 $this->tempAfterInstantiate[] = static function(object $object) use ($inversedObject, $inverseField, $pm, $placeholder) {
@@ -352,36 +351,26 @@ abstract class PersistentObjectFactory extends ObjectFactory
     }
 
     /**
+     * This method will try to find entities in database if they are detached.
+     *
      * @internal
      */
     protected function normalizeObject(object $object): object
     {
-        $reflectionClass = new \ReflectionClass($object::class);
-
-        if ($reflectionClass->isFinal()) {
-            return $object;
-        }
-
-        // readonly classes exist since php 8.2 and proxyHelper supports them since 8.3
-        if (80200 <= \PHP_VERSION_ID && \PHP_VERSION_ID < 80300 && $reflectionClass->isReadonly()) {
-            return $object;
-        }
-
         $configuration = Configuration::instance();
 
-        if (!$configuration->isPersistenceAvailable()) {
+        if (
+            !$this->isPersisting()
+            || !$configuration->isPersistenceAvailable()
+        ) {
             return $object;
+        }
+
+        if ($object instanceof Proxy) {
+            $object = $object->_real(withAutoRefresh: false);
         }
 
         $persistenceManager = $configuration->persistence();
-
-        if ($object instanceof Proxy) {
-            $proxy = $object;
-            $proxy->_disableAutoRefresh();
-            $object = $proxy->_real();
-            $proxy->_enableAutoRefresh();
-        }
-
         if (!$persistenceManager->hasPersistenceFor($object)) {
             return $object;
         }

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -69,7 +69,7 @@ interface Proxy
     /**
      * @return T
      */
-    public function _real(): object;
+    public function _real(bool $withAutoRefresh = true): object;
 
     /**
      * @psalm-return T&Proxy<T>

--- a/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
@@ -78,6 +78,7 @@ final class GenericEntityFactory extends PersistentProxyObjectFactory
     {
         return [
             'prop1' => self::faker()->text(),
+            'propInteger' => self::faker()->randomNumber(),
         ];
     }
 

--- a/tests/Fixture/Maker/expected/can_create_factory_with_all_fields.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_with_all_fields.php
@@ -43,6 +43,7 @@ final class GenericEntityFactory extends PersistentProxyObjectFactory
         return [
             'date' => \DateTimeImmutable::createFromMutable(self::faker()->dateTime()),
             'prop1' => self::faker()->text(),
+            'propInteger' => self::faker()->randomNumber(),
         ];
     }
 

--- a/tests/Fixture/Model/GenericModel.php
+++ b/tests/Fixture/Model/GenericModel.php
@@ -33,6 +33,10 @@ abstract class GenericModel
     #[MongoDB\Field(type: 'string')]
     private string $prop1;
 
+    #[ORM\Column]
+    #[MongoDB\Field(type: 'int')]
+    private int $propInteger = 0;
+
     #[ORM\Column(nullable: true)]
     #[MongoDB\Field(type: 'date_immutable', nullable: true)]
     private ?\DateTimeImmutable $date = null;
@@ -50,6 +54,16 @@ abstract class GenericModel
     public function setProp1(string $prop1): void
     {
         $this->prop1 = $prop1;
+    }
+
+    public function getPropInteger(): int
+    {
+        return $this->propInteger;
+    }
+
+    public function setPropInteger(int $propInteger): void
+    {
+        $this->propInteger = $propInteger;
     }
 
     public function getDate(): ?\DateTimeImmutable

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -400,6 +400,75 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         );
     }
 
+    /** @test */
+    public function it_uses_after_persist_with_many_to_many(): void
+    {
+        $contact = static::contactFactory()
+            ->with(
+                [
+                    'tags' => static::tagFactory()
+                        ->afterPersist(static function (Tag $tag) {$tag->setName('foobar');})
+                        ->many(1)
+                ]
+            )
+            ->create();
+
+        self::assertEquals('foobar', $contact->getTags()[0]?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_one_to_many(): void
+    {
+        $category = static::categoryFactory()
+            ->with([
+                'contacts' => static::contactFactory()
+                    ->afterPersist(static function (Contact $contact) {
+                        $contact->setName('foobar');
+                    })
+                    ->many(1)
+            ])->create();
+
+        self::assertEquals('foobar', $category->getContacts()[0]?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_many_to_one(): void
+    {
+        $contact = static::contactFactory()
+            ->with([
+                'category' => static::categoryFactory()
+                    ->afterPersist(static function (Category $category) {
+                        $category->setName('foobar');
+                    })
+            ])->create();
+
+        self::assertEquals('foobar', $contact->getCategory()?->getName());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_one_to_one(): void
+    {
+        $contact = static::contactFactory()
+            ->with([
+                'address' => static::addressFactory()
+                    ->afterPersist(static function (Address $address) {$address->setCity('foobar');})
+            ])->create();
+
+        self::assertEquals('foobar', $contact->getAddress()->getCity());
+    }
+
+    /** @test */
+    public function it_uses_after_persist_with_inversed_one_to_one(): void
+    {
+        $address = static::addressFactory()
+            ->with([
+                'contact' => static::contactFactory()
+                    ->afterPersist(static function (Contact $contact) {$contact->setName('foobar');})
+            ])->create();
+
+        self::assertEquals('foobar', $address->getContact()?->getName());
+    }
+
     /** @return PersistentObjectFactory<Contact> */
     protected static function contactFactoryWithoutCategory(): PersistentObjectFactory
     {

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -308,6 +308,9 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
             'category' => static::categoryFactory(),
         ]);
 
+        // ensure nothing was persisted in Doctrine by flushing
+        self::getContainer()->get(EntityManagerInterface::class)->flush(); // @phpstan-ignore method.notFound
+
         static::contactFactory()::assert()->empty();
         static::categoryFactory()::assert()->empty();
         static::tagFactory()::assert()->empty();

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -410,8 +410,8 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
             ->with(
                 [
                     'tags' => static::tagFactory()
-                        ->afterPersist(static function (Tag $tag) {$tag->setName('foobar');})
-                        ->many(1)
+                        ->afterPersist(static function(Tag $tag) {$tag->setName('foobar'); })
+                        ->many(1),
                 ]
             )
             ->create();
@@ -425,10 +425,10 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         $category = static::categoryFactory()
             ->with([
                 'contacts' => static::contactFactory()
-                    ->afterPersist(static function (Contact $contact) {
+                    ->afterPersist(static function(Contact $contact) {
                         $contact->setName('foobar');
                     })
-                    ->many(1)
+                    ->many(1),
             ])->create();
 
         self::assertEquals('foobar', $category->getContacts()[0]?->getName());
@@ -440,9 +440,9 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         $contact = static::contactFactory()
             ->with([
                 'category' => static::categoryFactory()
-                    ->afterPersist(static function (Category $category) {
+                    ->afterPersist(static function(Category $category) {
                         $category->setName('foobar');
-                    })
+                    }),
             ])->create();
 
         self::assertEquals('foobar', $contact->getCategory()?->getName());
@@ -454,7 +454,7 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         $contact = static::contactFactory()
             ->with([
                 'address' => static::addressFactory()
-                    ->afterPersist(static function (Address $address) {$address->setCity('foobar');})
+                    ->afterPersist(static function(Address $address) {$address->setCity('foobar'); }),
             ])->create();
 
         self::assertEquals('foobar', $contact->getAddress()->getCity());
@@ -466,7 +466,7 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         $address = static::addressFactory()
             ->with([
                 'contact' => static::contactFactory()
-                    ->afterPersist(static function (Contact $contact) {$contact->setName('foobar');})
+                    ->afterPersist(static function(Contact $contact) {$contact->setName('foobar'); }),
             ])->create();
 
         self::assertEquals('foobar', $address->getContact()?->getName());

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -270,21 +270,6 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
     /**
      * @test
      */
-    public function can_use_after_persist_with_attributes(): void
-    {
-        $object = static::factory()
-            ->instantiateWith(Instantiator::withConstructor()->allowExtra('extra'))
-            ->afterPersist(function(GenericModel $object, array $attributes) {
-                $object->setProp1($attributes['extra']);
-            })
-            ->create(['extra' => $value = 'value set with after persist']);
-
-        $this->assertSame($value, $object->getProp1());
-    }
-
-    /**
-     * @test
-     */
     public function can_use_after_persist_with_attributes_added_in_before_instantiate(): void
     {
         $value = 'value set with before instantiate';


### PR DESCRIPTION
This needed a conflict resolution, hence the MR

- **fix: trigger after persist callbacks for entities scheduled for insert (#822)**
- **fix: actually disable persistence cascade (#817)**
