### PR TITLE
fix: prevent infinite loop when ->create() is called in after persist callback

### DIFF
--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -76,11 +76,12 @@ final class PersistenceManager
         $this->flush($om);
 
         if ($this->afterPersistCallbacks) {
-            foreach ($this->afterPersistCallbacks as $afterPersistCallback) {
+            $afterPersistCallbacks = $this->afterPersistCallbacks;
+            $this->afterPersistCallbacks = [];
+
+            foreach ($afterPersistCallbacks as $afterPersistCallback) {
                 $afterPersistCallback();
             }
-
-            $this->afterPersistCallbacks = [];
 
             $this->save($object);
         }


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/830