### PR TITLE
docs: minor fixes

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -95,7 +95,7 @@ final class Configuration
     public function assertPersistenceEnabled(): void
     {
         if (!$this->isPersistenceEnabled()) {
-            throw new PersistenceDisabled('Cannot get repository when persist is disabled.');
+            throw new PersistenceDisabled('Cannot get repository when persist is disabled (if in a unit test, you probably should not try to get the repository.');
         }
     }
 

--- a/src/Maker/MakeFactory.php
+++ b/src/Maker/MakeFactory.php
@@ -137,7 +137,7 @@ final class MakeFactory extends AbstractMaker
 
         $io->text([
             'Next: Open your new factory and set default values/states.',
-            'Find the documentation at https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories',
+            'Find the documentation at https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories',
         ]);
     }
 


### PR DESCRIPTION
Here are a few fixes for the docs:

after the discussion in [this issue](https://github.com/zenstruck/foundry/issues/831), I think we need to be clearer on how to use "services factories" in unit test (ie: all injected deps should be nullable).

Still from the same discussion, I think we can do better in the exception message when trying to get a repository within a unit test.

I've also made some code examples a little bit more "modern" (type properties, constructor promotion...).

And lastly, this fixes some link problems introduced in https://github.com/zenstruck/foundry/pull/825(I merged this a little bit too quickly :sweat_smile: )