### PR TITLE
fix: bug with factory collection of persistent factory in unit test

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Persistence;
 use Doctrine\Persistence\ObjectRepository;
 use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
 use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Exception\FoundryNotBooted;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Factory;
@@ -263,7 +264,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public function persistMode(): PersistMode
     {
-        $config = Configuration::instance();
+        try {
+            $config = Configuration::instance();
+        } catch (FoundryNotBooted) {
+            return PersistMode::WITHOUT_PERSISTING;
+        }
 
         if (!$config->isPersistenceEnabled()) {
             return PersistMode::WITHOUT_PERSISTING;

--- a/tests/Unit/Persistence/PersistentObjectFactoryTest.php
+++ b/tests/Unit/Persistence/PersistentObjectFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Unit\Persistence;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
@@ -57,5 +58,31 @@ final class PersistentObjectFactoryTest extends TestCase
         $entity = GenericEntityFactory::randomOrCreate(['prop1' => 'foo']);
 
         $this->assertSame('foo', $entity->getProp1());
+    }
+
+    /**
+     * @test
+     * @dataProvider factoryCollectionDataProvider
+     * @param FactoryCollection<GenericEntity, GenericEntityFactory> $collection
+     */
+    public function can_use_factory_collection_methods_in_data_providers(FactoryCollection $collection): void // @phpstan-ignore generics.notSubtype
+    {
+        self::assertEquals(
+            [
+                new GenericEntity('foo'),
+            ],
+            $collection->create(),
+        );
+    }
+
+    public static function factoryCollectionDataProvider(): iterable
+    {
+        yield [
+            GenericEntityFactory::new()->sequence([
+                [
+                    'prop1' => 'foo',
+                ],
+            ])
+        ];
     }
 }


### PR DESCRIPTION
very specific bug: 
we need to know the "persistence mode" when creating a `FactoryCollection` from a persistance factory, but this needs access to the configuration, so this was failing in a unit test, if used in a data provider :sweat_smile:  