### PR TITLE
Merge 2.3.x in 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v2.3.6](https://github.com/zenstruck/foundry/releases/tag/v2.3.6)
+
+February 25th, 2025 - [v2.3.5...v2.3.6](https://github.com/zenstruck/foundry/compare/v2.3.5...v2.3.6)
+
+* 300645b fix: can call ->create() in after persist callback (#833) by @nikophil
+
 ## [v2.3.5](https://github.com/zenstruck/foundry/releases/tag/v2.3.5)
 
 February 24th, 2025 - [v2.3.4...v2.3.5](https://github.com/zenstruck/foundry/compare/v2.3.4...v2.3.5)

--- a/phpunit
+++ b/phpunit
@@ -35,7 +35,7 @@ SHOULD_UPDATE_PHPUNIT=$(check_phpunit_version "${PHPUNIT_VERSION}")
 
 if [ "${SHOULD_UPDATE_PHPUNIT}" = "0" ]; then
   echo "ℹ️  Upgrading PHPUnit to ${PHPUNIT_VERSION}"
-  composer update brianium/paratest "phpunit/phpunit:^${PHPUNIT_VERSION}" -W
+  composer update dama/doctrine-test-bundle brianium/paratest "phpunit/phpunit:^${PHPUNIT_VERSION}" -W
 fi
 ### <<
 

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -46,7 +46,7 @@ abstract class ObjectFactory extends Factory
     {
         parent::__construct();
 
-        $this->validationEnabled = Configuration::instance()->validationEnabled;
+        $this->validationEnabled = Configuration::isBooted() && Configuration::instance()->validationEnabled;
     }
 
     /**
@@ -194,7 +194,7 @@ abstract class ObjectFactory extends Factory
      */
     protected function initializeInternal(): static
     {
-        if (!Configuration::instance()->hasEventDispatcher()) {
+        if (!Configuration::isBooted() || !Configuration::instance()->hasEventDispatcher()) {
             return $this;
         }
 

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -76,11 +76,12 @@ final class PersistenceManager
         $this->flush($om);
 
         if ($this->afterPersistCallbacks) {
-            foreach ($this->afterPersistCallbacks as $afterPersistCallback) {
+            $afterPersistCallbacks = $this->afterPersistCallbacks;
+            $this->afterPersistCallbacks = [];
+
+            foreach ($afterPersistCallbacks as $afterPersistCallback) {
                 $afterPersistCallback();
             }
-
-            $this->afterPersistCallbacks = [];
 
             $this->save($object);
         }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Persistence;
 use Doctrine\Persistence\ObjectRepository;
 use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
 use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Exception\FoundryNotBooted;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Factory;
@@ -263,7 +264,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public function persistMode(): PersistMode
     {
-        $config = Configuration::instance();
+        try {
+            $config = Configuration::instance();
+        } catch (FoundryNotBooted) {
+            return PersistMode::WITHOUT_PERSISTING;
+        }
 
         if (!$config->isPersistenceEnabled()) {
             return PersistMode::WITHOUT_PERSISTING;

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -49,7 +49,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
     {
         parent::__construct();
 
-        $this->persist = Configuration::instance()->isPersistenceEnabled() ? PersistMode::PERSIST : PersistMode::WITHOUT_PERSISTING;
+        $this->persist = $this->isPersistenceEnabled() ? PersistMode::PERSIST : PersistMode::WITHOUT_PERSISTING;
     }
 
     /**
@@ -272,17 +272,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public function persistMode(): PersistMode
     {
-        return Configuration::instance()->isPersistenceEnabled() ? $this->persist : PersistMode::WITHOUT_PERSISTING;
+        return $this->isPersistenceEnabled() ? $this->persist : PersistMode::WITHOUT_PERSISTING;
     }
 
     final public function isPersisting(): bool
     {
-        $config = Configuration::instance();
-
-        if (!$config->isPersistenceEnabled()) {
-            return false;
-        }
-
         return $this->persistMode()->isPersisting();
     }
 
@@ -424,7 +418,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
                 }
             );
 
-        if (!Configuration::instance()->hasEventDispatcher()) {
+        if (!Configuration::isBooted() || !Configuration::instance()->hasEventDispatcher()) {
             return $factory;
         }
 
@@ -458,5 +452,14 @@ abstract class PersistentObjectFactory extends ObjectFactory
         }
 
         throw new \LogicException(\sprintf('Cannot create object in a data provider for non-proxy factories. Transform your factory into a "%s", or call "create()" method in the test. See https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#phpunit-data-providers', PersistentProxyObjectFactory::class));
+    }
+
+    private function isPersistenceEnabled(): bool
+    {
+        try {
+            return Configuration::instance()->isPersistenceEnabled();
+        } catch (FoundryNotBooted) {
+            return false;
+        }
     }
 }

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -66,10 +66,10 @@ final class ProxyGenerator
      *
      * @return T
      */
-    public static function unwrap(mixed $what): mixed
+    public static function unwrap(mixed $what, bool $withAutoRefresh = true): mixed
     {
         if (\is_array($what)) {
-            return \array_map(self::unwrap(...), $what); // @phpstan-ignore return.type
+            return \array_map(static fn(mixed $w) => self::unwrap($w, $withAutoRefresh), $what); // @phpstan-ignore return.type
         }
 
         if (\is_string($what) && \is_a($what, Proxy::class, true)) {
@@ -77,7 +77,7 @@ final class ProxyGenerator
         }
 
         if ($what instanceof Proxy) {
-            return $what->_real(); // @phpstan-ignore return.type
+            return $what->_real($withAutoRefresh); // @phpstan-ignore return.type
         }
 
         return $what;

--- a/src/Persistence/functions.php
+++ b/src/Persistence/functions.php
@@ -107,9 +107,9 @@ function proxy(object $object): object
  *
  * @return T
  */
-function unproxy(mixed $what): mixed
+function unproxy(mixed $what, bool $withAutoRefresh = true): mixed
 {
-    return ProxyGenerator::unwrap($what);
+    return ProxyGenerator::unwrap($what, $withAutoRefresh);
 }
 
 /**

--- a/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
+++ b/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
@@ -123,6 +124,8 @@ trait ChangesEntityRelationshipCascadePersist
         }
 
         yield from DoctrineCascadeRelationshipMetadata::allCombinations($relationshipFields);
+
+        Configuration::shutdown();
     }
 
     public static function setCurrentProvidedMethodName(string $methodName): void

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -31,9 +31,6 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 
-use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
-
-use function Zenstruck\Foundry\Persistence\persistent_factory;
 use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\unproxy;
 

--- a/tests/Unit/Persistence/PersistentObjectFactoryTest.php
+++ b/tests/Unit/Persistence/PersistentObjectFactoryTest.php
@@ -82,7 +82,7 @@ final class PersistentObjectFactoryTest extends TestCase
                 [
                     'prop1' => 'foo',
                 ],
-            ])
+            ]),
         ];
     }
 }

--- a/tests/Unit/Persistence/PersistentObjectFactoryTest.php
+++ b/tests/Unit/Persistence/PersistentObjectFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Unit\Persistence;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
@@ -57,5 +58,31 @@ final class PersistentObjectFactoryTest extends TestCase
         $entity = GenericEntityFactory::randomOrCreate(['prop1' => 'foo']);
 
         $this->assertSame('foo', $entity->getProp1());
+    }
+
+    /**
+     * @test
+     * @dataProvider factoryCollectionDataProvider
+     * @param FactoryCollection<GenericEntity, GenericEntityFactory> $collection
+     */
+    public function can_use_factory_collection_methods_in_data_providers(FactoryCollection $collection): void // @phpstan-ignore generics.notSubtype
+    {
+        self::assertEquals(
+            [
+                new GenericEntity('foo'),
+            ],
+            $collection->create(),
+        );
+    }
+
+    public static function factoryCollectionDataProvider(): iterable
+    {
+        yield [
+            GenericEntityFactory::new()->sequence([
+                [
+                    'prop1' => 'foo',
+                ],
+            ])
+        ];
     }
 }

--- a/tests/Unit/Persistence/PersistentObjectFactoryTest.php
+++ b/tests/Unit/Persistence/PersistentObjectFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Unit\Persistence;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\FactoryCollection;
@@ -69,7 +70,9 @@ final class PersistentObjectFactoryTest extends TestCase
      * @dataProvider factoryCollectionDataProvider
      * @param FactoryCollection<GenericEntity, GenericEntityFactory> $collection
      */
-    public function can_use_factory_collection_methods_in_data_providers(FactoryCollection $collection): void // @phpstan-ignore generics.notSubtype
+    #[Test] // @phpstan-ignore generics.notSubtype
+    #[DataProvider('factoryCollectionDataProvider')]
+    public function can_use_factory_collection_methods_in_data_providers(FactoryCollection $collection): void
     {
         self::assertEquals(
             [


### PR DESCRIPTION
- **fix: can call ->create() in after persist callback (#833)**
- **changelog: update [skip ci]**
- **bot: fix cs [skip ci]**
- **chore: upgrade also dama when upgrading phpunit version (#839)**
- **minor: add parameter "withAutoRefresh" to unproxy() function (#840)**
- **fix: use Doctrine metadata event when persist is disabled (#841)**
- **fix: bug with factory collectin of persistent factory in unit test (#842)**
- **bot: fix cs [skip ci]**
