### PR TITLE
docs: fix wrong class name

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -972,7 +972,7 @@ the LazyValue can be `memoized <https://en.wikipedia.org/wiki/Memoization>`_ so 
                 return [
                     // Call CategoryFactory::random() everytime this factory is instantiated
                     'category' => LazyValue::new(fn() => CategoryFactory::random()),
-                    // The same UserForPersistentFactory instance will be both added to the Project and set as the Task owner
+                    // The same User instance will be both added to the Project and set as the Task owner
                     'project' => ProjectFactory::new(['users' => [$owner]]),
                     'owner'   => $owner,
                 ];
@@ -1006,7 +1006,7 @@ common use-case: encoding a password with the ``UserPasswordHasherInterface`` se
 
         public static function class(): string
         {
-            return UserForPersistentFactory::class;
+            return User::class;
         }
 
         protected function defaults(): array
@@ -1020,7 +1020,7 @@ common use-case: encoding a password with the ``UserPasswordHasherInterface`` se
         protected function initialize(): static
         {
             return $this
-                ->afterInstantiate(function(UserForPersistentFactory $user) {
+                ->afterInstantiate(function(User $user) {
                     if ($this->passwordHasher !== null) {
                         $user->setPassword($this->passwordHasher->hashPassword($user, $user->getPassword()));
                     }
@@ -2035,7 +2035,7 @@ You can improve the speed by reducing the *work factor* of your encoder:
     # config/packages/test/security.yaml
     encoders:
         # use your user class name here
-        App\Entity\UserForPersistentFactory:
+        App\Entity\User:
             # This should be the same value as in config/packages/security.yaml
             algorithm: auto
             cost: 4 # Lowest possible value for bcrypt


### PR DESCRIPTION
this has been introduced by a wrong refactor that no one spotted, in https://github.com/zenstruck/foundry/pull/704/files#diff-f437bff1a19e2365e122512047817595ed5e2e2a415d317fed8dc1c7ffa3334aR10  :facepalm: 

fixes https://github.com/zenstruck/foundry/issues/843