### PR TITLE
fix: fix doctrine collection with union/intersection type

### DIFF
--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -138,12 +138,24 @@ final class Hydrator
 
     private static function isDoctrineCollection(object $object, string $property): bool
     {
-        $reflectionType = self::reflectionProperty(new \ReflectionClass($object), $property)?->getType();
+        $type = self::reflectionProperty(new \ReflectionClass($object), $property)?->getType();
 
-        if (!$reflectionType instanceof \ReflectionNamedType) {
+        if (null === $type) {
             return false;
         }
 
-        return Collection::class === $reflectionType->getName();
+        if ($type instanceof \ReflectionNamedType) {
+            return Collection::class === $type->getName();
+        }
+
+        if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
+            foreach ($type->getTypes() as $type) {
+                if ($type instanceof \ReflectionNamedType && Collection::class === $type->getName()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Fixture/Entity/EdgeCases/OneToManyWithUnionType/HasOneToManyWithUnionType.php
+++ b/tests/Fixture/Entity/EdgeCases/OneToManyWithUnionType/HasOneToManyWithUnionType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OneToManyWithUnionType;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+class HasOneToManyWithUnionType extends Base
+{
+    public function __construct(
+        /** @var Collection<int,OwningSideEntity>|list<OwningSideEntity> */
+        #[ORM\OneToMany(targetEntity: OwningSideEntity::class, mappedBy: 'item')] // @phpstan-ignore doctrine.associationType, doctrine.associationType
+        public Collection|array $collection,
+    ) {
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/OneToManyWithUnionType/OwningSideEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/OneToManyWithUnionType/OwningSideEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OneToManyWithUnionType;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+#[ORM\Table('union_type_owning_side_entity')]
+class OwningSideEntity extends Base
+{
+    public function __construct(
+        #[ORM\ManyToOne(inversedBy: 'collection')]
+        #[ORM\JoinColumn(nullable: false)]
+        public HasOneToManyWithUnionType $item,
+    ) {
+    }
+}

--- a/tests/Integration/ORM/EdgeCasesRelationshipTest.php
+++ b/tests/Integration/ORM/EdgeCasesRelationshipTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
+use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
@@ -26,6 +27,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\InversedOneToOneWithNonNull
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\InversedOneToOneWithOneToMany;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\InversedOneToOneWithSetter;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\ManyToOneToSelfReferencing;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OneToManyWithUnionType;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
@@ -156,6 +158,26 @@ final class EdgeCasesRelationshipTest extends KernelTestCase
         $childFactory::assert()->count(1);
 
         self::assertNotNull($parent->getItems()->get('en')); // @phpstan-ignore argument.type
+    }
+
+    /** @test */
+    #[Test]
+    public function object_with_union_type(): void
+    {
+        $owningSideFactory = persistent_factory(OneToManyWithUnionType\OwningSideEntity::class);
+        $hasOneToManyWithUnionTypeFactory = persistent_factory(OneToManyWithUnionType\HasOneToManyWithUnionType::class);
+
+        $object = $hasOneToManyWithUnionTypeFactory->create(
+            [
+                'collection' => $owningSideFactory->many(2),
+            ]
+        );
+
+        $owningSideFactory::assert()->count(2);
+        $hasOneToManyWithUnionTypeFactory::assert()->count(1);
+
+        self::assertCount(2, $object->collection);
+        self::assertInstanceOf(Collection::class, $object->collection);
     }
 
     /**

--- a/tests/Unit/Object/HydratorTest.php
+++ b/tests/Unit/Object/HydratorTest.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Unit\Object;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Selectable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
@@ -26,6 +27,7 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
+    #[Test]
     public function can_hydrate_scalar(): void
     {
         $value = 'Hello world';
@@ -42,6 +44,7 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
+    #[Test]
     public function can_hydrate_scalar_array(): void
     {
         $value = ['foo', 'bar'];
@@ -58,6 +61,7 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
+    #[Test]
     public function can_hydrate_object(): void
     {
         $object = new class {
@@ -79,6 +83,7 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
+    #[Test]
     public function can_hydrate_object_array(): void
     {
         $object = new class {
@@ -99,6 +104,7 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
+    #[Test]
     public function can_hydrate_doctrine_collection(): void
     {
         $object = new class {
@@ -125,7 +131,8 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
-    public function can_hydrate_doctrine_collection_intersection(): void
+    #[Test]
+    public function can_hydrate_doctrine_collection_union(): void
     {
         $object = new class {
             /** @var Collection<array-key, Object1>|Selectable<array-key, Object1> */
@@ -151,7 +158,8 @@ class HydratorTest extends TestCase
     /**
      * @test
      */
-    public function can_hydrate_doctrine_collection_union(): void
+    #[Test]
+    public function can_hydrate_doctrine_collection_intersection(): void
     {
         $object = new class {
             /** @var Collection<array-key, Object1>&Selectable<array-key, Object1> */

--- a/tests/Unit/Object/HydratorTest.php
+++ b/tests/Unit/Object/HydratorTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Unit\Object;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Object\Hydrator;
+use Zenstruck\Foundry\Tests\Fixture\Object1;
+
+/**
+ * @author Maarten de Boer <info@maartendeboer.net>
+ */
+class HydratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_hydrate_scalar(): void
+    {
+        $value = 'Hello world';
+
+        $object = new class {
+            public string $foo = '';
+        };
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertSame($value, $object->foo);
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_scalar_array(): void
+    {
+        $value = ['foo', 'bar'];
+
+        $object = new class {
+            public array $foo = [];
+        };
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertSame($value, $object->foo);
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_object(): void
+    {
+        $object = new class {
+            public Object1 $foo;
+
+            public function __construct()
+            {
+                $this->foo = new Object1('nope');
+            }
+        };
+
+        $value = new Object1('foo');
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertSame($value, $object->foo);
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_object_array(): void
+    {
+        $object = new class {
+            /** @var Object1[] */
+            public array $foo = [];
+        };
+
+        $value = [
+            new Object1('foo'),
+            new Object1('bar'),
+        ];
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertSame($value, $object->foo);
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_doctrine_collection(): void
+    {
+        $object = new class {
+            /** @var Collection<array-key, Object1> */
+            public Collection $foo;
+
+            public function __construct()
+            {
+                $this->foo = new ArrayCollection();
+            }
+        };
+
+        $value = [
+            new Object1('foo'),
+            new Object1('bar'),
+        ];
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertInstanceOf(ArrayCollection::class, $object->foo);
+        $this->assertSame($value, $object->foo->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_doctrine_collection_intersection(): void
+    {
+        $object = new class {
+            /** @var Collection<array-key, Object1>|Selectable<array-key, Object1> */
+            public Collection|Selectable $foo;
+
+            public function __construct()
+            {
+                $this->foo = new ArrayCollection();
+            }
+        };
+
+        $value = [
+            new Object1('foo'),
+            new Object1('bar'),
+        ];
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertInstanceOf(ArrayCollection::class, $object->foo);
+        $this->assertSame($value, $object->foo->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function can_hydrate_doctrine_collection_union(): void
+    {
+        $object = new class {
+            /** @var Collection<array-key, Object1>&Selectable<array-key, Object1> */
+            public Collection&Selectable $foo;
+
+            public function __construct()
+            {
+                $this->foo = new ArrayCollection();
+            }
+        };
+
+        $value = [
+            new Object1('foo'),
+            new Object1('bar'),
+        ];
+
+        Hydrator::set($object, 'foo', $value);
+
+        $this->assertInstanceOf(ArrayCollection::class, $object->foo);
+        $this->assertSame($value, $object->foo->toArray());
+    }
+}


### PR DESCRIPTION
This PR fixes an issue introduced in v2.3.2 where hydrating doctrine collections with a union or intersection type failed. These types were not recognized as doctrine collections and therefore they were assigned as `array` instead of `ArrayCollection`.