### PR TITLE
minor: allow `doctrine/persistence` 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "doctrine/persistence": "^1.3.3|^2.0|^3.0",
+        "doctrine/persistence": "^1.3.3|^2.0|^3.0|^4.0",
         "fakerphp/faker": "^1.10",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/property-access": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
Same as #852 but for 1.x.