### PR TITLE
fix: handle empty constructors

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -116,7 +116,7 @@ final class Configuration
     public function assertPersistenceEnabled(): void
     {
         if (!$this->isPersistenceEnabled()) {
-            throw new PersistenceDisabled('Cannot get repository when persist is disabled (if in a unit test, you probably should not try to get the repository.');
+            throw new PersistenceDisabled('Cannot get repository when persist is disabled (if in a unit test, you probably should not try to get the repository).');
         }
     }
 

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -39,18 +39,10 @@ abstract class ObjectFactory extends Factory
     /** @phpstan-var array<class-string, object> */
     private array $reusedObjects = [];
 
-    private bool $validationEnabled;
+    private bool $validationEnabled = false;
 
     /** @var string|GroupSequence|list<string>|null */
     private string|GroupSequence|array|null $validationGroups = [];
-
-    // keep an empty constructor for BC
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->validationEnabled = Configuration::isBooted() && Configuration::instance()->validationEnabled;
-    }
 
     /**
      * @return class-string<T>
@@ -262,6 +254,8 @@ abstract class ObjectFactory extends Factory
      */
     protected function initializeInternal(): static
     {
+        $this->validationEnabled = Configuration::isBooted() && Configuration::instance()->validationEnabled;
+
         if (!Configuration::isBooted() || !Configuration::instance()->hasEventDispatcher()) {
             return $this;
         }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -38,20 +38,13 @@ use function Zenstruck\Foundry\set;
  */
 abstract class PersistentObjectFactory extends ObjectFactory
 {
-    private PersistMode $persist;
+    private PersistMode $persist = PersistMode::PERSIST;
 
     /** @phpstan-var list<callable(T, Parameters, static):void> */
     private array $afterPersist = [];
 
     /** @var list<callable(T):void> */
     private array $tempAfterInstantiate = [];
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->persist = $this->isPersistenceEnabled() ? PersistMode::PERSIST : PersistMode::WITHOUT_PERSISTING;
-    }
 
     /**
      * @phpstan-param mixed|Parameters $criteriaOrId
@@ -411,6 +404,8 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
     final protected function initializeInternal(): static
     {
+        $this->persist = $this->isPersistenceEnabled() ? PersistMode::PERSIST : PersistMode::WITHOUT_PERSISTING;
+
         // Schedule any new object for insert right after instantiation
         $factory = parent::initializeInternal()
             ->afterInstantiate(

--- a/tests/Fixture/Factories/Entity/EmptyConstructorFactory.php
+++ b/tests/Fixture/Factories/Entity/EmptyConstructorFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity;
+
+use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
+use Zenstruck\Foundry\Tests\Fixture\Factories\GenericModelFactory;
+
+final class EmptyConstructorFactory extends GenericModelFactory
+{
+    public function __construct()
+    {
+    }
+
+    public static function class(): string
+    {
+        return GenericEntity::class;
+    }
+}

--- a/tests/Integration/ORM/GenericEntityFactoryTest.php
+++ b/tests/Integration/ORM/GenericEntityFactoryTest.php
@@ -11,9 +11,14 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
+use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EmptyConstructorFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\GenericFactoryTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+use function Zenstruck\Foundry\Persistence\disable_persisting;
+use function Zenstruck\Foundry\Persistence\enable_persisting;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -25,5 +30,33 @@ final class GenericEntityFactoryTest extends GenericFactoryTestCase
     protected static function factory(): GenericEntityFactory
     {
         return GenericEntityFactory::new();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_use_factory_with_empty_constructor(): void
+    {
+        EmptyConstructorFactory::assert()->count(0);
+
+        EmptyConstructorFactory::createOne();
+
+        EmptyConstructorFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_use_factory_with_empty_constructor_without_persistence(): void
+    {
+        EmptyConstructorFactory::assert()->count(0);
+
+        disable_persisting();
+        EmptyConstructorFactory::createOne();
+        enable_persisting();
+
+        EmptyConstructorFactory::assert()->count(0);
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -27,6 +27,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyAddressFactory
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EmptyConstructorFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
 
@@ -154,5 +155,16 @@ final class FactoryTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Category::class, $object->getCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_use_factory_with_empty_constructor(): void
+    {
+        $genericEntity = EmptyConstructorFactory::createOne();
+
+        self::assertInstanceOf(GenericEntity::class, $genericEntity);
     }
 }


### PR DESCRIPTION
because the `make:factory` command creates factories with empty constructor which doesn't call `parent::__constructor()`, there may be tons of factories with empty constructor in the wild :sweat_smile: 

so we should not rely on constructors to initialize things