### PR TITLE
fix: performance problem with reuse

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -38,7 +38,6 @@ return static function (ContainerConfigurator $container): void {
             '%env(default:zenstruck_foundry.faker.seed:int:FOUNDRY_FAKER_SEED)%',
             param('.zenstruck_foundry.validation_enabled'),
             abstract_arg('validation_available'),
-            service('property_info'),
         ])
         ->public()
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -41,8 +41,6 @@ final class Configuration
      */
     public $instantiator;
 
-    public readonly PropertyInfoExtractorInterface&PropertyInitializableExtractorInterface $propertyInfo;
-
     /**
      * This property is only filled if the PHPUnit extension is used!
      */
@@ -66,23 +64,10 @@ final class Configuration
         ?int $forcedFakerSeed = null,
         public readonly bool $validationEnabled = false,
         public readonly bool $validationAvailable = false,
-        ?PropertyInfoExtractorInterface $propertyInfoExtractor = null,
     ) {
         $this->faker->seed(self::fakerSeed($forcedFakerSeed));
 
         $this->instantiator = $instantiator;
-
-        // @phpstan-ignore assign.propertyType (DNF wa shipped in PHP 8.2, so we cannot make the parameter nullable and intersection)
-        $this->propertyInfo = $propertyInfoExtractor ?? new PropertyInfoCacheExtractor(
-            new PropertyInfoExtractor(
-                [$reflectionExtractor = new ReflectionExtractor()],
-                [$reflectionExtractor],
-                [$reflectionExtractor],
-                [$reflectionExtractor],
-                [$reflectionExtractor],
-            ),
-            new ArrayAdapter()
-        );
     }
 
     public static function fakerSeed(?int $forcedFakerSeed = null): int

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -225,24 +225,27 @@ abstract class ObjectFactory extends Factory
      */
     final protected function reusedAttributes(): array
     {
+        if ($this->reusedObjects === []) {
+            return [];
+        }
+
         $attributes = [];
 
-        $propertyInfo = Configuration::instance()->propertyInfo;
+        $properties = (new \ReflectionClass(static::class()))->getProperties();
 
-        $properties = $propertyInfo->getProperties(static::class());
-        foreach ($properties ?? [] as $property) {
-            $types = $propertyInfo->getTypes(static::class(), $property);
+        foreach ($properties as $property) {
+            $type = $property->getType();
 
-            foreach ($types ?? [] as $type) {
-                if (null === $type->getClassName()) {
-                    continue;
-                }
+            if (null === $type) {
+                continue;
+            }
 
-                if (isset($this->reusedObjects[$type->getClassName()])) {
-                    $attributes[$property] = $this->reusedObjects[$type->getClassName()];
+            if (!$type instanceof \ReflectionNamedType) {
+                continue;
+            }
 
-                    break;
-                }
+            if (isset($this->reusedObjects[$type->getName()])) {
+                $attributes[$property->getName()] = $this->reusedObjects[$type->getName()];
             }
         }
 


### PR DESCRIPTION
now we're checking all the attributes of the current class only if the factory has some "reuse" attributes

second performance improvement is to not use property info for this. I'd rather use `symfony/type-info`, but it is not  available for php  8.1 :shrug: 