### PR TITLE
feat: optimize performance of repository::random()

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -169,7 +169,18 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
      */
     public function random(array $criteria = []): object
     {
-        return $this->randomSet(1, $criteria)[0];
+        $count = $this->count($criteria);
+        $offset = 0;
+
+        if ($count === 0) {
+            throw new NotEnoughObjects(\sprintf('At least %d "%s" object(s) must have been persisted (%d persisted).', 1, $this->getClassName(), 0));
+        }
+
+        if ($count > 1) {
+            $offset = \random_int(0, $count - 1);
+        }
+
+        return $this->findBy($criteria, limit: 1, offset: $offset)[0];
     }
 
     /**


### PR DESCRIPTION
As discussed in #612, I had a go at fixing the issue where `random()` was quite slow and I managed to speed it up quite a bit, as can be seen in a [benchmark](https://github.com/zenstruck/foundry/pull/866) I ran:

```
PHPBench (1.4.1) running benchmarks... #standwithukraine
with configuration file: /home/maarten/Projects/Forks/foundry/phpbench.json
with PHP version 8.4.5, xdebug ❌, opcache ❌
comparing [actual vs. before]

\Zenstruck\Foundry\Tests\Benchmark\ORM\GenericEntityFactoryBench

    bench_random # 1........................I9 - [Mo2.111ms vs. Mo2.020ms] +4.48% (±3.89%)
    bench_random # 50.......................I9 - [Mo2.464ms vs. Mo3.504ms] -29.68% (±6.08%)
    bench_random # 500......................I9 - [Mo2.738ms vs. Mo11.773ms] -76.75% (±9.23%)
    bench_random # 1000.....................I9 - [Mo3.515ms vs. Mo35.876ms] -90.20% (±12.87%)

Subjects: 1, Assertions: 0, Failures: 0, Errors: 0
+---------------------------+--------------+------+------+-----+------------------+-----------------+-----------------+
| benchmark                 | subject      | set  | revs | its | mem_peak         | mode            | rstdev          |
+---------------------------+--------------+------+------+-----+------------------+-----------------+-----------------+
| GenericEntityFactoryBench | bench_random | 1    | 1    | 10  | 36.310mb +0.00%  | 2.111ms +4.48%  | ±3.89% -2.19%   |
| GenericEntityFactoryBench | bench_random | 50   | 1    | 10  | 37.108mb +0.00%  | 2.464ms -29.68% | ±6.08% -59.30%  |
| GenericEntityFactoryBench | bench_random | 500  | 1    | 10  | 45.293mb -1.22%  | 2.738ms -76.75% | ±9.23% -74.94%  |
| GenericEntityFactoryBench | bench_random | 1000 | 1    | 10  | 59.239mb -10.32% | 3.515ms -90.20% | ±12.87% -47.94% |
+---------------------------+--------------+------+------+-----+------------------+-----------------+-----------------+

```