### PR TITLE
chore(phpbench): actually run phpbench with a baseline

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,29 +40,32 @@ jobs:
           coverage: none
           tools: flex
 
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#        with:
-#          ref: 2.x
-#          fetch-depth: 1
-#
-#      - name: Install dependencies
-#        uses: ramsey/composer-install@v2
-#        with:
-#          dependency-versions: ${{ matrix.deps }}
-#          composer-options: --prefer-dist
-#        env:
-#          SYMFONY_REQUIRE: ${{ matrix.symfony }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: 2.x
+          fetch-depth: 1
 
-#      - name: Run benchmarks baseline
-#        run: |
-#          bin/tools/phpbench/vendor/phpbench/phpbench/bin/phpbench run \
-#            tests/Benchmark \
-#            --report=aggregate \
-#            --tag=2.x \
-#            --iterations=5 \
-#            --progress=plain \
-#            --revs=10
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.deps }}
+          composer-options: --prefer-dist
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony }}
+
+      - name: Install PHPBench
+        run: composer bin phpbench install
+
+      - name: Run benchmarks baseline
+        run: |
+          bin/tools/phpbench/vendor/phpbench/phpbench/bin/phpbench run \
+            tests/Benchmark \
+            --report=aggregate \
+            --tag=2.x \
+            --iterations=5 \
+            --progress=plain \
+            --retry-threshold=10
 
       - name: Clear vendor files
         run: |
@@ -82,25 +85,13 @@ jobs:
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony }}
 
-      - name: Install PHPBench
-        run: composer bin phpbench install
-
-#      - name: Run benchmarks and compare
-#        run: |
-#          bin/tools/phpbench/vendor/phpbench/phpbench/bin/phpbench run \
-#            tests/Benchmark \
-#            --report=aggregate \
-#            --ref=2.x \
-#            --iterations=5 \
-#            --progress=plain \
-#            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%"
-
-      - name: Run benchmarks baseline
+      - name: Run benchmarks and compare
         run: |
           bin/tools/phpbench/vendor/phpbench/phpbench/bin/phpbench run \
             tests/Benchmark \
             --report=aggregate \
-            --tag=2.x \
+            --ref=2.x \
             --iterations=5 \
             --progress=plain \
-            --retry-threshold=10
+            --retry-threshold=10 \
+            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%"

--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -212,7 +212,7 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
             throw new NotEnoughObjects(\sprintf('At least %d "%s" object(s) must have been persisted (%d persisted).', $max, $this->getClassName(), \count($all)));
         }
 
-        return \array_slice($all, 0, \random_int($min, $max));
+        return \array_slice($all, 0, \random_int($min, $max)); // @phpstan-ignore argument.type
     }
 
     public function getIterator(): \Traversable

--- a/tests/Benchmark/ORM/CategoryFactoryBench.php
+++ b/tests/Benchmark/ORM/CategoryFactoryBench.php
@@ -21,6 +21,6 @@ class CategoryFactoryBench extends PersistentFactoryBench
     {
         return CategoryFactory::new([
             'contacts' => ContactFactory::new()->many(5),
-        ]);
+        ])->noRandom();
     }
 }

--- a/tests/Benchmark/ORM/ContactFactoryBench.php
+++ b/tests/Benchmark/ORM/ContactFactoryBench.php
@@ -18,6 +18,6 @@ class ContactFactoryBench extends PersistentFactoryBench
 {
     protected static function factory(): ContactFactory
     {
-        return ContactFactory::new();
+        return ContactFactory::new()->noRandom();
     }
 }

--- a/tests/Benchmark/Persistence/GenericFactoryBench.php
+++ b/tests/Benchmark/Persistence/GenericFactoryBench.php
@@ -15,6 +15,7 @@ use PhpBench\Attributes\BeforeClassMethods;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\ParamProviders;
 use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Skip;
 use PhpBench\Attributes\Warmup;
 use Zenstruck\Foundry\Tests\Benchmark\KernelBench;
 use Zenstruck\Foundry\Tests\Fixture\Factories\GenericModelFactory;
@@ -23,6 +24,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\GenericModelFactory;
 #[BeforeMethods(['_bootFoundry', '_resetDatabaseBeforeEachBench'])]
 #[Warmup(1)]
 #[Revs(100)]
+#[Skip]
 abstract class GenericFactoryBench extends KernelBench
 {
     #[ParamProviders('_param_bench_random')]

--- a/tests/Fixture/Factories/Entity/Address/AddressFactory.php
+++ b/tests/Fixture/Factories/Entity/Address/AddressFactory.php
@@ -26,6 +26,13 @@ final class AddressFactory extends PersistentObjectFactory
         return Address::class;
     }
 
+    public function noRandom(): static
+    {
+        return $this->with([
+            'city' => 'some city',
+        ]);
+    }
+
     protected function defaults(): array
     {
         return [

--- a/tests/Fixture/Factories/Entity/Category/CategoryFactory.php
+++ b/tests/Fixture/Factories/Entity/Category/CategoryFactory.php
@@ -26,6 +26,13 @@ final class CategoryFactory extends PersistentObjectFactory
         return Category::class;
     }
 
+    public function noRandom(): static
+    {
+        return $this->with([
+            'name' => 'some name',
+        ]);
+    }
+
     protected function defaults(): array
     {
         return [

--- a/tests/Fixture/Factories/Entity/Contact/ContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/ContactFactory.php
@@ -28,6 +28,15 @@ class ContactFactory extends PersistentObjectFactory
         return Contact::class;
     }
 
+    public function noRandom(): static
+    {
+        return $this->with([
+            'name' => 'some_name',
+            'address' => AddressFactory::new()->noRandom(),
+            'category' => CategoryFactory::new()->noRandom(),
+        ]);
+    }
+
     protected function defaults(): array
     {
         return [


### PR DESCRIPTION
@mdeboer @kbond here is the "real" benchmark, with baseline

https://github.com/zenstruck/foundry/actions/runs/14386901974/job/40344450707?pr=868

aaaand... it fails for ALL `GenericEntityFactoryBench::random` benchs, although it runs on the same code :shrug: 
it also fails for `ContactFactoryBench::bench_create` (the test asserts the new code is not more than 5% slower)

this is kinda deceptive... I'll temporary deactivate the "random", until we find a solution