### PR TITLE
feat: flush once

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,4 +94,4 @@ jobs:
             --iterations=5 \
             --progress=plain \
             --retry-threshold=10 \
-            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%"
+            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%"

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,7 +1,8 @@
 {
     "$schema": "./bin/tools/phpbench/vendor/phpbench/phpbench/phpbench.schema.json",
-    "runner.bootstrap": "./tests/bootstrap.php",
+    "runner.bootstrap": "./vendor/autoload.php",
     "runner.php_env": {
-        "KERNEL_CLASS": "Zenstruck\\Foundry\\Tests\\Fixture\\TestKernel"
+        "KERNEL_CLASS": "Zenstruck\\Foundry\\Tests\\Fixture\\TestKernel",
+        "APP_ENV": "dev"
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -256,7 +256,7 @@ abstract class Factory
             );
         }
 
-        return \is_object($value) ? $this->normalizeObject($value) : $value;
+        return \is_object($value) ? $this->normalizeObject($field, $value) : $value;
     }
 
     /**
@@ -274,7 +274,7 @@ abstract class Factory
     /**
      * @internal
      */
-    protected function normalizeObject(object $object): object
+    protected function normalizeObject(string $field, object $object): object
     {
         return $object;
     }

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -14,6 +14,8 @@ namespace Zenstruck\Foundry;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistMode;
 
+use function Zenstruck\Foundry\Persistence\flush_after;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
@@ -26,6 +28,7 @@ use Zenstruck\Foundry\Persistence\PersistMode;
 final class FactoryCollection implements \IteratorAggregate
 {
     private PersistMode $persistMode;
+    private bool $isRootFactory = true;
 
     /**
      * @param TFactory $factory
@@ -45,6 +48,18 @@ final class FactoryCollection implements \IteratorAggregate
     {
         $clone = clone $this;
         $clone->persistMode = $persistMode;
+
+        return $clone;
+    }
+
+    /**
+     * @internal
+     * @return self<T, TFactory>
+     */
+    public function notRootFactory(): static
+    {
+        $clone = clone $this;
+        $clone->isRootFactory = false;
 
         return $clone;
     }
@@ -131,6 +146,12 @@ final class FactoryCollection implements \IteratorAggregate
      */
     public function create(array|callable $attributes = []): array
     {
+        if ($this->isRootFactory && $this->factory instanceof PersistentObjectFactory && $this->factory->isPersisting()) {
+            return flush_after(
+               fn() => \array_map(static fn(Factory $f) => $f->create($attributes), $this->all())
+            );
+        }
+
         return \array_map(static fn(Factory $f) => $f->create($attributes), $this->all());
     }
 
@@ -155,6 +176,10 @@ final class FactoryCollection implements \IteratorAggregate
         return \array_map( // @phpstan-ignore return.type (PHPStan does not understand we have an array of factories)
             function(Factory $f) {
                 if ($f instanceof PersistentObjectFactory) {
+                    if (!$this->isRootFactory) {
+                        $f = $f->notRootFactory();
+                    }
+
                     return $f->withPersistMode($this->persistMode);
                 }
 

--- a/src/ORM/OrmV2PersistenceStrategy.php
+++ b/src/ORM/OrmV2PersistenceStrategy.php
@@ -16,7 +16,10 @@ namespace Zenstruck\Foundry\ORM;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\Persistence\Mapping\MappingException;
-use Zenstruck\Foundry\Persistence\InverseRelationshipMetadata;
+use Zenstruck\Foundry\Persistence\Relationship\ManyToOneRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToManyRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToOneRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\RelationshipMetadata;
 
 /**
  * @internal
@@ -25,49 +28,42 @@ use Zenstruck\Foundry\Persistence\InverseRelationshipMetadata;
  */
 final class OrmV2PersistenceStrategy extends AbstractORMPersistenceStrategy
 {
-    public function inversedRelationshipMetadata(string $parent, string $child, string $field): ?InverseRelationshipMetadata
+    public function bidirectionalRelationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
-        $metadata = $this->classMetadata($child);
+        $associationMapping = $this->getAssociationMapping($parent, $child, $field);
 
-        $inversedAssociation = $this->getAssociationMapping($parent, $child, $field);
-
-        if (null === $inversedAssociation || !$metadata instanceof ClassMetadataInfo) {
+        if (null === $associationMapping) {
             return null;
         }
 
         if (!\is_a(
             $child,
-            $inversedAssociation['targetEntity'],
+            $associationMapping['targetEntity'],
             allow_string: true
         )) { // is_a() handles inheritance as well
             throw new \LogicException("Cannot find correct association named \"{$field}\" between classes [parent: \"{$parent}\", child: \"{$child}\"]");
         }
 
-        // exclude "owning" side of the association (owning OneToOne or ManyToOne)
-        if (!\in_array(
-            $inversedAssociation['type'],
-            [ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::ONE_TO_ONE],
-            true
-        )
-            || !isset($inversedAssociation['mappedBy'])
-        ) {
+        $inverseField = $associationMapping['isOwningSide'] ? $associationMapping['inversedBy'] ?? null : $associationMapping['mappedBy'] ?? null;
+
+        if (null === $inverseField) {
             return null;
         }
 
-        $association = $metadata->getAssociationMapping($inversedAssociation['mappedBy']);
-
-        // only keep *ToOne associations
-        if (!$metadata->isSingleValuedAssociation($association['fieldName'])) {
-            return null;
-        }
-
-        $inversedAssociationMetadata = $this->classMetadata($inversedAssociation['sourceEntity']);
-
-        return new InverseRelationshipMetadata(
-            inverseField: $association['fieldName'],
-            isCollection: $inversedAssociationMetadata->isCollectionValuedAssociation($inversedAssociation['fieldName']),
-            collectionIndexedBy: $inversedAssociation['indexBy'] ?? null
-        );
+        return match (true) {
+            ClassMetadataInfo::ONE_TO_MANY === $associationMapping['type'] => new OneToManyRelationship(
+                inverseField: $inverseField,
+                collectionIndexedBy: $associationMapping['indexBy'] ?? null
+            ),
+            ClassMetadataInfo::ONE_TO_ONE === $associationMapping['type'] => new OneToOneRelationship(
+                inverseField: $inverseField,
+                isOwning: $associationMapping['isOwningSide'] ?? false
+            ),
+            ClassMetadataInfo::MANY_TO_ONE === $associationMapping['type'] => new ManyToOneRelationship(
+                inverseField: $inverseField,
+            ),
+            default => null,
+        };
     }
 
     /**

--- a/src/ORM/OrmV3PersistenceStrategy.php
+++ b/src/ORM/OrmV3PersistenceStrategy.php
@@ -14,50 +14,54 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\ORM;
 
 use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\InverseSideMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
-use Doctrine\ORM\Mapping\ToManyAssociationMapping;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneAssociationMapping;
 use Doctrine\Persistence\Mapping\MappingException;
-use Zenstruck\Foundry\Persistence\InverseRelationshipMetadata;
+use Zenstruck\Foundry\Persistence\Relationship\ManyToOneRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToManyRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToOneRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\RelationshipMetadata;
 
 final class OrmV3PersistenceStrategy extends AbstractORMPersistenceStrategy
 {
-    public function inversedRelationshipMetadata(string $parent, string $child, string $field): ?InverseRelationshipMetadata
+    public function bidirectionalRelationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
-        $metadata = $this->classMetadata($child);
+        $associationMapping = $this->getAssociationMapping($parent, $child, $field);
 
-        $inversedAssociation = $this->getAssociationMapping($parent, $child, $field);
-
-        if (null === $inversedAssociation || !$metadata instanceof ClassMetadata) {
+        if (null === $associationMapping) {
             return null;
         }
 
         if (!\is_a(
             $child,
-            $inversedAssociation->targetEntity,
+            $associationMapping->targetEntity,
             allow_string: true
         )) { // is_a() handles inheritance as well
             throw new \LogicException("Cannot find correct association named \"{$field}\" between classes [parent: \"{$parent}\", child: \"{$child}\"]");
         }
 
-        // exclude "owning" side of the association (owning OneToOne or ManyToOne)
-        if (!$inversedAssociation instanceof InverseSideMapping) {
+        $inverseField = $associationMapping->isOwningSide() ? $associationMapping->inversedBy : $associationMapping->mappedBy;
+
+        if (null === $inverseField) {
             return null;
         }
 
-        $association = $metadata->getAssociationMapping($inversedAssociation->mappedBy);
-
-        // only keep *ToOne associations
-        if (!$metadata->isSingleValuedAssociation($association->fieldName)) {
-            return null;
-        }
-
-        return new InverseRelationshipMetadata(
-            inverseField: $association->fieldName,
-            isCollection: $inversedAssociation instanceof ToManyAssociationMapping,
-            collectionIndexedBy: $inversedAssociation->isIndexed() ? $inversedAssociation->indexBy() : null
-        );
+        return match (true) {
+            $associationMapping instanceof OneToManyAssociationMapping => new OneToManyRelationship(
+                inverseField: $inverseField,
+                collectionIndexedBy: $associationMapping->isIndexed() ? $associationMapping->indexBy() : null
+            ),
+            $associationMapping instanceof OneToOneAssociationMapping => new OneToOneRelationship(
+                inverseField: $inverseField,
+                isOwning: $associationMapping->isOwningSide()
+            ),
+            $associationMapping instanceof ManyToOneAssociationMapping => new ManyToOneRelationship(
+                inverseField: $inverseField,
+            ),
+            default => null,
+        };
     }
 
     /**

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -97,7 +97,7 @@ final class Hydrator
         return $clone;
     }
 
-    public static function set(object $object, string $property, mixed $value): void
+    public static function set(object $object, string $property, mixed $value, bool $catchErrors = false): void
     {
         $value = ForceValue::unwrap($value);
 
@@ -108,7 +108,23 @@ final class Hydrator
             $value = new ArrayCollection($value);
         }
 
-        self::accessibleProperty($object, $property)->setValue($object, $value);
+        try {
+            self::accessibleProperty($object, $property)->setValue($object, $value);
+        } catch (\Throwable $e) {
+            if (!$catchErrors) {
+                throw $e;
+            }
+        }
+    }
+
+    public static function add(object $object, string $property, mixed $value): void
+    {
+        $inverseValue = self::get($object, $property);
+
+        if (is_array($inverseValue) || $inverseValue instanceof \ArrayAccess) {
+            $inverseValue[] = $value;
+            self::set($object, $property, $inverseValue, catchErrors: true);
+        }
     }
 
     public static function get(object $object, string $property): mixed

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -121,10 +121,19 @@ final class Hydrator
     {
         $inverseValue = self::get($object, $property);
 
-        if (is_array($inverseValue) || $inverseValue instanceof \ArrayAccess) {
-            $inverseValue[] = $value;
-            self::set($object, $property, $inverseValue, catchErrors: true);
+        $shouldAdd = match (true) {
+            $inverseValue instanceof Collection => !$inverseValue->contains($value),
+            is_array($inverseValue) => !in_array($value, $inverseValue, true),
+            $inverseValue instanceof \Traversable => !in_array($value, iterator_to_array($inverseValue), true),
+            default => false,
+        };
+
+        if (!$shouldAdd) {
+            return;
         }
+
+        $inverseValue[] = $value;
+        self::set($object, $property, $inverseValue, catchErrors: true);
     }
 
     public static function get(object $object, string $property): mixed

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -76,7 +76,11 @@ final class PersistenceManager
         $om->persist($object);
         $this->flush($om);
 
-        $this->callPostPersistCallbacks();
+        $callbacksCalled = $this->callPostPersistCallbacks();
+
+        if ($callbacksCalled) {
+            $this->flush($om);
+        }
 
         return $object;
     }
@@ -120,7 +124,11 @@ final class PersistenceManager
 
         $this->flushAllStrategies();
 
-        $this->callPostPersistCallbacks();
+        $callbacksCalled = $this->callPostPersistCallbacks();
+
+        if ($callbacksCalled) {
+            $this->flushAllStrategies();
+        }
 
         return $result;
     }
@@ -348,10 +356,13 @@ final class PersistenceManager
         }
     }
 
-    private function callPostPersistCallbacks(): void
+    /**
+     * @return bool whether or not some callbacks were called
+     */
+    private function callPostPersistCallbacks(): bool
     {
         if (!$this->flush || [] === $this->afterPersistCallbacks) {
-            return;
+            return false;
         }
 
         $afterPersistCallbacks = $this->afterPersistCallbacks;
@@ -361,7 +372,7 @@ final class PersistenceManager
             $afterPersistCallback();
         }
 
-        $this->flushAllStrategies();
+        return true;
     }
 
     /**

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -19,6 +19,7 @@ use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\ORM\AbstractORMPersistenceStrategy;
 use Zenstruck\Foundry\Persistence\Exception\NoPersistenceStrategy;
 use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
+use Zenstruck\Foundry\Persistence\Relationship\RelationshipMetadata;
 use Zenstruck\Foundry\Persistence\ResetDatabase\ResetDatabaseManager;
 
 /**
@@ -257,12 +258,12 @@ final class PersistenceManager
      * @param class-string $parent
      * @param class-string $child
      */
-    public function inverseRelationshipMetadata(string $parent, string $child, string $field): ?InverseRelationshipMetadata
+    public function bidirectionalRelationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
         $parent = unproxy($parent);
         $child = unproxy($child);
 
-        return $this->strategyFor($parent)->inversedRelationshipMetadata($parent, $child, $field);
+        return $this->strategyFor($parent)->bidirectionalRelationshipMetadata($parent, $child, $field);
     }
 
     /**

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -76,16 +76,7 @@ final class PersistenceManager
         $om->persist($object);
         $this->flush($om);
 
-        if ($this->afterPersistCallbacks) {
-            $afterPersistCallbacks = $this->afterPersistCallbacks;
-            $this->afterPersistCallbacks = [];
-
-            foreach ($afterPersistCallbacks as $afterPersistCallback) {
-                $afterPersistCallback();
-            }
-
-            $this->save($object);
-        }
+        $this->callPostPersistCallbacks();
 
         return $object;
     }
@@ -127,11 +118,9 @@ final class PersistenceManager
 
         $this->flush = true;
 
-        foreach ($this->strategies as $strategy) {
-            foreach ($strategy->objectManagers() as $om) {
-                $this->flush($om);
-            }
-        }
+        $this->flushAllStrategies();
+
+        $this->callPostPersistCallbacks();
 
         return $result;
     }
@@ -348,6 +337,31 @@ final class PersistenceManager
 
             return 1 === \count($strategies) && $strategies[0] instanceof AbstractORMPersistenceStrategy;
         })();
+    }
+
+    private function flushAllStrategies(): void
+    {
+        foreach ($this->strategies as $strategy) {
+            foreach ($strategy->objectManagers() as $om) {
+                $this->flush($om);
+            }
+        }
+    }
+
+    private function callPostPersistCallbacks(): void
+    {
+        if (!$this->flush || [] === $this->afterPersistCallbacks) {
+            return;
+        }
+
+        $afterPersistCallbacks = $this->afterPersistCallbacks;
+        $this->afterPersistCallbacks = [];
+
+        foreach ($afterPersistCallbacks as $afterPersistCallback) {
+            $afterPersistCallback();
+        }
+
+        $this->flushAllStrategies();
     }
 
     /**

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectManager;
+use Zenstruck\Foundry\Persistence\Relationship\RelationshipMetadata;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -55,7 +56,7 @@ abstract class PersistenceStrategy
      * @param class-string $parent
      * @param class-string $child
      */
-    public function inversedRelationshipMetadata(string $parent, string $child, string $field): ?InverseRelationshipMetadata
+    public function bidirectionalRelationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
         return null;
     }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Persistence;
 
 use Doctrine\Persistence\ObjectRepository;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\FoundryNotBooted;
@@ -19,9 +20,15 @@ use Zenstruck\Foundry\Exception\PersistenceDisabled;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\FactoryCollection;
+use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\ObjectFactory;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
 use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
+
+use Zenstruck\Foundry\Persistence\Relationship\ManyToOneRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToManyRelationship;
+use Zenstruck\Foundry\Persistence\Relationship\OneToOneRelationship;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 
 use function Zenstruck\Foundry\force;
 use function Zenstruck\Foundry\get;
@@ -44,6 +51,8 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
     /** @var list<callable(T):void> */
     private array $tempAfterInstantiate = [];
+
+    private bool $isRootFactory = true;
 
     /**
      * @phpstan-param mixed|Parameters $criteriaOrId
@@ -207,7 +216,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         $this->throwIfCannotCreateObject();
 
-        if (PersistMode::PERSIST !== $this->persistMode()) {
+        if (PersistMode::PERSIST !== $this->persistMode() || !$this->isRootFactory) {
             return $object;
         }
 
@@ -280,17 +289,15 @@ abstract class PersistentObjectFactory extends ObjectFactory
         }
 
         if ($value instanceof self) {
-            $value = $value->withPersistMode($this->persist);
-        }
+            $value = $value->withPersistMode($this->persist)->notRootFactory();
 
-        if ($value instanceof self) {
             $pm = Configuration::instance()->persistence();
 
-            $relationshipMetadata = $pm->inverseRelationshipMetadata(static::class(), $value::class(), $field);
+            $relationshipMetadata = $pm->bidirectionalRelationshipMetadata(static::class(), $value::class(), $field);
 
             // handle inverse OneToOne
-            if ($relationshipMetadata && !$relationshipMetadata->isCollection) {
-                $inverseField = $relationshipMetadata->inverseField;
+            if ($relationshipMetadata instanceof OneToOneRelationship && !$relationshipMetadata->isOwning) {
+                $inverseField = $relationshipMetadata->inverseField();
 
                 $value = $value->withPersistMode(
                     $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
@@ -336,11 +343,13 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         $pm = Configuration::instance()->persistence();
 
-        $inverseRelationshipMetadata = $pm->inverseRelationshipMetadata(static::class(), $collection->factory::class(), $field);
+        $inverseRelationshipMetadata = $pm->bidirectionalRelationshipMetadata(static::class(), $collection->factory::class(), $field);
 
-        if ($inverseRelationshipMetadata && $inverseRelationshipMetadata->isCollection) {
+        $collection = $collection->notRootFactory();
+
+        if ($inverseRelationshipMetadata instanceof OneToManyRelationship) {
             $this->tempAfterInstantiate[] = function(object $object) use ($collection, $inverseRelationshipMetadata, $field) {
-                $inverseField = $inverseRelationshipMetadata->inverseField;
+                $inverseField = $inverseRelationshipMetadata->inverseField();
 
                 $inverseObjects = $collection->withPersistMode(
                     $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
@@ -372,26 +381,46 @@ abstract class PersistentObjectFactory extends ObjectFactory
      *
      * @internal
      */
-    protected function normalizeObject(object $object): object
+    protected function normalizeObject(string $field, object $object): object
     {
         $configuration = Configuration::instance();
 
-        if (
-            !$this->isPersisting()
-            || !$configuration->isPersistenceAvailable()
-        ) {
+        $object = unproxy($object, withAutoRefresh: false);
+
+        if (!$configuration->isPersistenceAvailable()) {
             return $object;
         }
 
-        $object = unproxy($object, withAutoRefresh: false);
-
         $persistenceManager = $configuration->persistence();
+
         if (!$persistenceManager->hasPersistenceFor($object)) {
+            return $object;
+        }
+
+        $inverseRelationship = $persistenceManager->bidirectionalRelationshipMetadata(static::class(), $object::class, $field);
+
+        if ($inverseRelationship instanceof OneToOneRelationship) {
+            $this->tempAfterInstantiate[] = static function(object $newObject) use ($object, $inverseRelationship) {
+                Hydrator::set($object, $inverseRelationship->inverseField(), $newObject, catchErrors: true);
+            };
+        }
+
+        if ($inverseRelationship instanceof ManyToOneRelationship) {
+            $this->tempAfterInstantiate[] = static function(object $newObject) use ($object, $inverseRelationship) {
+                Hydrator::add($object, $inverseRelationship->inverseField(), $newObject);
+            };
+        }
+
+        if (
+            !$this->isPersisting()
+        ) {
             return $object;
         }
 
         if (!$persistenceManager->isPersisted($object)) {
             $persistenceManager->scheduleForInsert($object);
+
+            return $object;
         }
 
         try {
@@ -427,7 +456,8 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
                     Configuration::instance()->persistence()->scheduleForInsert($object, $afterPersistCallbacks);
                 }
-            );
+            )
+        ;
     }
 
     private function throwIfCannotCreateObject(): void
@@ -459,5 +489,16 @@ abstract class PersistentObjectFactory extends ObjectFactory
         } catch (FoundryNotBooted) {
             return false;
         }
+    }
+
+    /**
+     * @internal
+     */
+    public function notRootFactory(): static
+    {
+        $clone = clone $this;
+        $clone->isRootFactory = false;
+
+        return $clone;
     }
 }

--- a/src/Persistence/Relationship/ManyToOneRelationship.php
+++ b/src/Persistence/Relationship/ManyToOneRelationship.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Persistence\Relationship;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
+ */
+final class ManyToOneRelationship implements RelationshipMetadata
+{
+    public function __construct(
+        private readonly string $inverseField,
+    ) {
+    }
+
+    public function inverseField(): string
+    {
+        return $this->inverseField;
+    }
+}

--- a/src/Persistence/Relationship/OneToManyRelationship.php
+++ b/src/Persistence/Relationship/OneToManyRelationship.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Persistence\Relationship;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
+ */
+final class OneToManyRelationship implements RelationshipMetadata
+{
+    public function __construct(
+        private readonly string $inverseField,
+        public readonly ?string $collectionIndexedBy,
+    ) {
+    }
+
+    public function inverseField(): string
+    {
+        return $this->inverseField;
+    }
+}

--- a/src/Persistence/Relationship/OneToOneRelationship.php
+++ b/src/Persistence/Relationship/OneToOneRelationship.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Persistence\Relationship;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
+ */
+final class OneToOneRelationship implements RelationshipMetadata
+{
+    public function __construct(
+        private readonly string $inverseField,
+        public readonly bool $isOwning,
+    ) {
+    }
+
+    public function inverseField(): string
+    {
+        return $this->inverseField;
+    }
+}

--- a/src/Persistence/Relationship/RelationshipMetadata.php
+++ b/src/Persistence/Relationship/RelationshipMetadata.php
@@ -9,19 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Foundry\Persistence;
+namespace Zenstruck\Foundry\Persistence\Relationship;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @internal
  */
-final class InverseRelationshipMetadata
+interface RelationshipMetadata
 {
-    public function __construct(
-        public readonly string $inverseField,
-        public readonly bool $isCollection,
-        public readonly ?string $collectionIndexedBy,
-    ) {
-    }
+    public function inverseField(): string;
 }

--- a/tests/Integration/ORM/EdgeCasesRelationshipTest.php
+++ b/tests/Integration/ORM/EdgeCasesRelationshipTest.php
@@ -265,6 +265,31 @@ final class EdgeCasesRelationshipTest extends KernelTestCase
         );
     }
 
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(InversedOneToOneWithNonNullableOwning\OwningSide::class, ['inverseSide'])]
+    #[RequiresPhpunit('>=11.4')]
+    public function after_instantiate_flushing_using_current_object_in_relationship_inverse_one_to_one(): void
+    {
+        $owningSideFactory = persistent_factory(InversedOneToOneWithNonNullableOwning\OwningSide::class);
+        $inverseSideFactory = persistent_factory(InversedOneToOneWithNonNullableOwning\InverseSide::class);
+
+        $owningSide = $owningSideFactory
+            ->afterInstantiate(
+                static function(InversedOneToOneWithNonNullableOwning\OwningSide $o) use ($inverseSideFactory) {
+                    $inverseSideFactory->create(['owningSide' => $o]);
+                }
+            )
+            ->create();
+
+        $owningSideFactory::assert()->count(1);
+        $inverseSideFactory::assert()->count(1);
+
+        self::assertNotNull($owningSide->inverseSide);
+        self::assertSame($owningSide, $owningSide->inverseSide->getOwningSide());
+    }
+
     /**
      * @test
      */

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -31,6 +31,9 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
+
 use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\unproxy;
@@ -69,6 +72,20 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
     public function one_to_many_with_factory_collection(): void
     {
         $this->one_to_many(static::contactFactory()->many(2));
+    }
+
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Category::class, ['contacts'])]
+    public function create_many_one_to_many_with_factory_collection(): void
+    {
+        CategoryFactory::new([
+            'contacts' => ContactFactory::new()->many(5),
+        ])->noRandom()->create();
+
+        ContactFactory::assert()->count(5);
+        CategoryFactory::assert()->count(1);
     }
 
     /** @test */
@@ -640,6 +657,29 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
     #[Test]
     #[DataProvider('provideCascadeRelationshipsCombinations')]
     #[UsingRelationships(Contact::class, ['category'])]
+    public function after_instantiate_flushing_using_current_object_in_relationship_multiple_many_to_one(): void
+    {
+        $category = static::categoryFactory()
+            ->afterInstantiate(
+                static function(Category $c): void {
+                    static::contactFactory()->create(['category' => $c]);
+                    static::contactFactory()->create(['category' => $c]);
+                }
+            )
+            ->create();
+
+        static::contactFactory()::assert()->count(2);
+        static::categoryFactory()::assert()->count(1);
+
+        self::assertCount(2, $category->getContacts());
+        self::assertNotNull($category->getContacts()[0] ?? null);
+        self::assertNotNull($category->getContacts()[1] ?? null);
+    }
+
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Contact::class, ['category'])]
     public function after_instantiate_flushing_using_current_object_in_relationship_one_to_many(): void
     {
         $contact = static::contactFactory()
@@ -655,6 +695,22 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
 
         self::assertNotNull($contact->getCategory());
         self::assertCount(1, $contact->getCategory()->getContacts());
+    }
+
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Contact::class, ['category'])]
+    public function after_instantiate_flushing_using_current_object_in_relationship_one_to_one(): void
+    {
+        $address = static::addressFactory()
+            ->afterInstantiate(
+                static function(Address $a): void {
+                    static::contactFactory()->create(['address' => $a]);
+                }
+            )->create();
+
+        self::assertNotNull($address->getContact());
     }
 
     /** @return PersistentObjectFactory<Contact> */

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -599,6 +599,43 @@ abstract class GenericFactoryTestCase extends KernelTestCase
     }
 
     /**
+     * @test
+     */
+    #[Test]
+    public function it_actually_calls_post_persist_hook_after_persist_when_in_flush_after(): void
+    {
+        $object = flush_after(
+            function() {
+                return static::factory()->afterPersist(
+                    static function(GenericModel $o) {
+                        $o->setProp1((string) $o->id);
+                    }
+                )->create();
+            }
+        );
+
+        self::assertSame((string) $object->id, $object->getProp1());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_actually_calls_post_persist_hook_after_persist_when_in_create_many(): void
+    {
+        $objects = static::factory()->afterPersist(
+            static function(GenericModel $o) {
+                $o->setProp1((string) $o->id);
+            }
+        )->many(2)->create();
+
+        self::assertCount(2, $objects);
+        foreach ($objects as $object) {
+            self::assertSame((string) $object->id, $object->getProp1());
+        }
+    }
+
+    /**
      * @return class-string<GenericModel>
      */
     protected function modelClass(): string


### PR DESCRIPTION
"flush once" is back :grin: 

and with very promising performances:
```
 +--------------------------------+-------------------+-----+------+-----+------------------+-------------------+-----------------+
| benchmark                      | subject           | set | revs | its | mem_peak         | mode              | rstdev          |
+--------------------------------+-------------------+-----+------+-----+------------------+-------------------+-----------------+
| ContactFactoryBench            | bench_create      |     | 10   | 5   | 36.505mb -0.91%  | 2.014ms -55.82%   | ±3.01% +0.62%   |
| ContactFactoryBench            | bench_create_many | 1   | 10   | 5   | 36.510mb -0.91%  | 2.006ms -56.51%   | ±5.87% +33.85%  |
| ContactFactoryBench            | bench_create_many | 10  | 10   | 5   | 38.641mb -4.17%  | 9.827ms -86.69%   | ±1.07% -28.84%  |
| ContactFactoryBench            | bench_create_many | 50  | 10   | 5   | 47.611mb -13.50% | 43.849ms -95.14%  | ±1.03% -46.15%  |
| CategoryFactoryBench           | bench_create      |     | 10   | 5   | 36.368mb +0.03%  | 4.456ms -3.47%    | ±2.42% +65.48%  |
| CategoryFactoryBench           | bench_create_many | 1   | 10   | 5   | 36.374mb +0.05%  | 5.055ms +9.20%    | ±5.23% +185.21% |
| CategoryFactoryBench           | bench_create_many | 10  | 10   | 5   | 39.982mb -0.36%  | 35.603ms -54.27%  | ±0.83% +14.62%  |
| CategoryFactoryBench           | bench_create_many | 50  | 10   | 5   | 55.253mb -1.41%  | 168.601ms -84.58% | ±1.25% +94.84%  |
| PersistentDocumentFactoryBench | bench_create      |     | 10   | 5   | 34.787mb +0.02%  | 728.893μs -0.38%  | ±2.72% +96.36%  |
| PersistentDocumentFactoryBench | bench_create_many | 1   | 10   | 5   | 34.788mb +0.02%  | 770.702μs +3.88%  | ±1.96% -8.50%   |
| PersistentDocumentFactoryBench | bench_create_many | 10  | 10   | 5   | 35.304mb -0.63%  | 4.798ms -42.16%   | ±1.55% +243.60% |
| PersistentDocumentFactoryBench | bench_create_many | 50  | 10   | 5   | 38.073mb -3.69%  | 22.310ms -67.85%  | ±1.15% +48.26%  |
+--------------------------------+-------------------+-----+------+-----+------------------+-------------------+-----------------+
```
(I really like that we can rely on real numbers for this!)

As I said already said [here](https://github.com/zenstruck/foundry/pull/836#discussion_r2010945096), it was a fluke that this kind of code did work before:
```php
        $address = static::addressFactory()
            ->afterInstantiate(
                static function(Address $a): void {
                    static::contactFactory()->create(['address' => $a]);
                }
            )->create();

        self::assertNotNull($address->getContact());
```
OR
```php
        $category = static::categoryFactory()
            ->afterInstantiate(
                static function(Category $c): void {
                    static::contactFactory()->create(['category' => $c]);
                }
            )
            ->create();

        self::assertCount(1, $category->getContacts());
```
I'm not totally sure of the magic that was involved, but for the second example, before "flush once" `$category->getContacts()` was a `PersistentCollection` with `initialized: false`, and with "flush once" it became an empty `PersistentCollection` with `initialized: true`

Hence all the modifications around this, in `PersistentFactoryCollection::normalizeObject()`