### PR TITLE
chore(tests): Adds `ZenstruckFoundryBundleTest`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,9 @@
         <testsuite name="reset-database">
             <directory>tests/Integration/ResetDatabase</directory>
         </testsuite>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
     </testsuites>
 
     <coverage>

--- a/tests/Fixture/ExtendedGenerator.php
+++ b/tests/Fixture/ExtendedGenerator.php
@@ -18,4 +18,8 @@ use Faker\Generator;
  */
 final class ExtendedGenerator extends Generator
 {
+    public function customMethod(): string
+    {
+        return 'custom';
+    }
 }

--- a/tests/Fixture/ExtendedGenerator.php
+++ b/tests/Fixture/ExtendedGenerator.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture;
+
+use Faker\Generator;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class ExtendedGenerator extends Generator
+{
+}

--- a/tests/Fixture/config/faker_custom_service.yaml
+++ b/tests/Fixture/config/faker_custom_service.yaml
@@ -1,0 +1,6 @@
+zenstruck_foundry:
+    faker:
+        service: 'Zenstruck\Foundry\Tests\Fixture\ExtendedGenerator'
+
+services:
+    Zenstruck\Foundry\Tests\Fixture\ExtendedGenerator: ~

--- a/tests/Integration/Faker/FakerCustomServiceKernelTest.php
+++ b/tests/Integration/Faker/FakerCustomServiceKernelTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\Faker;
+
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\ExtendedGenerator;
+
+use function Zenstruck\Foundry\faker;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ * @requires PHPUnit >=11.0
+ */
+#[RequiresPhpunit('>=11.0')]
+final class FakerCustomServiceKernelTest extends KernelTestCase
+{
+    use Factories, FakerTestTrait, ResetDatabase;
+
+    #[Test]
+    public function faker_service_can_be_set(): void
+    {
+        self::bootKernel(['environment' => 'faker_custom_service']);
+
+        self::assertInstanceOf(ExtendedGenerator::class, faker());
+        self::assertSame('custom', faker()->customMethod());
+
+        self::$currentSeed = Configuration::fakerSeed();
+
+        self::assertSame(self::$currentSeed, Configuration::fakerSeed());
+    }
+
+    #[Test]
+    #[Depends('faker_service_can_be_set')]
+    public function faker_seed_does_not_change_between_tests(): void
+    {
+        self::assertSame(self::$currentSeed, Configuration::fakerSeed());
+    }
+
+    #[Test]
+    public function faker_service_set_and_seed_is_still_available(): void
+    {
+        self::bootKernel(['environment' => 'faker_custom_service']);
+
+        self::assertTrue(self::getContainer()->hasParameter('zenstruck_foundry.faker.seed'));
+    }
+}

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
@@ -38,8 +37,6 @@ use Zenstruck\Foundry\ZenstruckFoundryBundle;
  */
 final class ZenstruckFoundryBundleTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     private ZenstruckFoundryBundle $bundle;
     private ContainerBuilder $container;
     private ContainerConfigurator $configurator;
@@ -85,11 +82,9 @@ final class ZenstruckFoundryBundleTest extends TestCase
      * @group legacy
      */
     #[Test]
-    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function faker_seed_value_overridden(): void
     {
-        self::expectDeprecation('Since zenstruck/foundry 2.4: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead.');
-
         $config = self::buildConfiguration([['faker' => ['seed' => $expected = 1234]]]);
 
         $this->bundle->loadExtension($config,  $this->configurator, $this->container);

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -32,6 +32,7 @@ use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
 final class ZenstruckFoundryBundleTest extends TestCase
 {
+    
     private ZenstruckFoundryBundle $bundle;
     private ContainerBuilder $container;
     private ContainerConfigurator $configurator;

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -50,10 +50,10 @@ final class ZenstruckFoundryBundleTest extends TestCase
 
         $this->bundle = new ZenstruckFoundryBundle();
 
-        $instancof = [];
+        $instanceof = [];
         $fileLoader = new PhpFileLoader($this->container, new FileLocator(__DIR__));
 
-        $this->configurator = new ContainerConfigurator($this->container, $fileLoader, $instancof, __DIR__, '');
+        $this->configurator = new ContainerConfigurator($this->container, $fileLoader, $instanceof, __DIR__, '');
     }
 
     /**

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -28,11 +28,15 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode;
+use Zenstruck\Foundry\Tests\Fixture\ExtendedGenerator;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
 final class ZenstruckFoundryBundleTest extends TestCase
 {
-    
+
     private ZenstruckFoundryBundle $bundle;
     private ContainerBuilder $container;
     private ContainerConfigurator $configurator;
@@ -120,7 +124,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
     #[Test]
     public function faker_service_can_be_overridden_with_configuration(): void
     {
-        $config = self::buildConfiguration([['faker' => ['service' => $expected = self::class]]]);
+        $config = self::buildConfiguration([['faker' => ['service' => $expected = ExtendedGenerator::class]]]);
         $this->container->setDefinition($expected, new Definition($expected));
 
         $this->bundle->loadExtension($config,  $this->configurator, $this->container);
@@ -149,7 +153,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
     #[Test]
     public function service_can_be_overridden_with_configuration(): void
     {
-        $config = self::buildConfiguration([['instantiator' => ['service' => $expected = self::class]]]);
+        $config = self::buildConfiguration([['instantiator' => ['service' => $expected = ExtendedGenerator::class]]]);
         $this->container->setDefinition($expected, new Definition($expected));
 
         $this->bundle->loadExtension($config,  $this->configurator, $this->container);

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -105,6 +105,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
 
         $this->bundle->loadExtension($config,  $this->configurator, $this->container);
 
+        self::assertTrue($this->container->hasParameter('zenstruck_foundry.faker.seed'));
         self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.faker'));
 
         $definition = $this->container->getDefinition('.zenstruck_foundry.faker');
@@ -124,6 +125,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
 
         self::assertTrue($this->container->hasAlias('.zenstruck_foundry.faker'));
         self::assertSame($expected, $this->container->get('.zenstruck_foundry.faker')::class);
+        self::assertTrue($this->container->hasParameter('zenstruck_foundry.faker.seed'));
     }
 
     /**

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
@@ -99,7 +100,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
      * @test
      */
     #[Test]
-    public function container_has_default_faker_service_definition_with_locale(): void
+    public function default_faker_service_can_receive_a_locale_via_configuration(): void
     {
         $config = self::buildConfiguration([['faker' => ['locale' => $expected = 'en_US']]]);
 
@@ -116,7 +117,7 @@ final class ZenstruckFoundryBundleTest extends TestCase
      * @test
      */
     #[Test]
-    public function container_has_aliased_as_default_faker_service_when_custom_service_was_configured(): void
+    public function faker_service_can_be_overridden_with_configuration(): void
     {
         $config = self::buildConfiguration([['faker' => ['service' => $expected = self::class]]]);
         $this->container->setDefinition($expected, new Definition($expected));
@@ -126,6 +127,82 @@ final class ZenstruckFoundryBundleTest extends TestCase
         self::assertTrue($this->container->hasAlias('.zenstruck_foundry.faker'));
         self::assertSame($expected, $this->container->get('.zenstruck_foundry.faker')::class);
         self::assertTrue($this->container->hasParameter('zenstruck_foundry.faker.seed'));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function container_has_default_instanciator(): void
+    {
+        $this->bundle->loadExtension(self::buildConfiguration(),  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.instantiator'));
+        self::assertSame([Instantiator::class, 'withConstructor'], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getFactory());
+        self::assertEmpty($this->container->getDefinition('.zenstruck_foundry.instantiator')->getMethodCalls());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function service_can_be_overridden_with_configuration(): void
+    {
+        $config = self::buildConfiguration([['instantiator' => ['service' => $expected = self::class]]]);
+        $this->container->setDefinition($expected, new Definition($expected));
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasAlias('.zenstruck_foundry.instantiator'));
+        self::assertSame($expected, $this->container->get('.zenstruck_foundry.instantiator')::class);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function create_instantiator_without_constructor_configuration(): void
+    {
+        $config = self::buildConfiguration([['instantiator' => ['use_constructor' => false]]]);
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.instantiator'));
+
+        self::assertSame([Instantiator::class, 'withoutConstructor'], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getFactory());
+        self::assertSame([], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getMethodCalls());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function create_instantiator_without_constructor_and_with_extra_configuration(): void
+    {
+        $config = self::buildConfiguration([['instantiator' => ['use_constructor' => false, 'allow_extra_attributes' => true]]]);
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.instantiator'));
+
+        self::assertSame([Instantiator::class, 'withoutConstructor'], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getFactory());
+        self::assertSame([['allowExtra', [], true]], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getMethodCalls());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function create_instantiator_without_constructor_and_with_extra_and_with_forced_properties_configuration(): void
+    {
+        $config = self::buildConfiguration([['instantiator' => ['use_constructor' => false, 'allow_extra_attributes' => true, 'always_force_properties' => true]]]);
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.instantiator'));
+
+        self::assertSame([Instantiator::class, 'withoutConstructor'], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getFactory());
+        self::assertSame([['allowExtra', [], true], ['alwaysForce', [], true]], $this->container->getDefinition('.zenstruck_foundry.instantiator')->getMethodCalls());
     }
 
     /**

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -20,20 +20,110 @@ use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
 final class ZenstruckFoundryBundleTest extends TestCase
 {
-    private function buildConfiguration(array $config = []): array
+    private ZenstruckFoundryBundle $bundle;
+    private ContainerBuilder $container;
+    private ContainerConfigurator $configurator;
+
+    protected function setUp(): void
     {
-        $treeBuilder = new TreeBuilder('zenstruck_foundry');
-        $definitionLoader = new DefinitionFileLoader($treeBuilder, new FileLocator());
-        $configurator = new DefinitionConfigurator($treeBuilder, $definitionLoader, __DIR__,'');
+        $this->container = new ContainerBuilder(new ParameterBag([
+            'kernel.bundles'         => [],
+            'kernel.cache_dir'       => sys_get_temp_dir(),
+            'kernel.root_dir'        => sys_get_temp_dir(),
+            'kernel.project_dir'     => sys_get_temp_dir(),
+            'kernel.environment'     => 'test',
+            'kernel.name'            => 'kernel',
+            'kernel.debug'           => true,
+            'kernel.container_class' => Container::class,
+        ]));
 
-        (new ZenstruckFoundryBundle())->configure($configurator);
+        $this->bundle = new ZenstruckFoundryBundle();
 
-        return (new Processor())->process($treeBuilder->buildTree(), $config);
+        $instancof = [];
+        $fileLoader = new PhpFileLoader($this->container, new FileLocator(__DIR__));
+
+        $this->configurator = new ContainerConfigurator($this->container, $fileLoader, $instancof, __DIR__, '');
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function faker_seed_default_value(): void
+    {
+        $config = self::buildConfiguration();
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasParameter('zenstruck_foundry.faker.seed'));
+        self::assertNull($this->container->getParameter('zenstruck_foundry.faker.seed'));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function faker_seed_value_overridden(): void
+    {
+        $config = self::buildConfiguration([['faker' => ['seed' => $expected = 1234]]]);
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasParameter('zenstruck_foundry.faker.seed'));
+        self::assertSame($expected, $this->container->getParameter('zenstruck_foundry.faker.seed'));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function container_has_default_faker_service_definition(): void
+    {
+        $this->bundle->loadExtension(self::buildConfiguration(),  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.faker'));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function container_has_default_faker_service_definition_with_locale(): void
+    {
+        $config = self::buildConfiguration([['faker' => ['locale' => $expected = 'en_US']]]);
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasDefinition('.zenstruck_foundry.faker'));
+
+        $definition = $this->container->getDefinition('.zenstruck_foundry.faker');
+        self::assertSame($expected, $definition->getArgument(0));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function container_has_aliased_as_default_faker_service_when_custom_service_was_configured(): void
+    {
+        $config = self::buildConfiguration([['faker' => ['service' => $expected = self::class]]]);
+        $this->container->setDefinition($expected, new Definition($expected));
+
+        $this->bundle->loadExtension($config,  $this->configurator, $this->container);
+
+        self::assertTrue($this->container->hasAlias('.zenstruck_foundry.faker'));
+        self::assertSame($expected, $this->container->get('.zenstruck_foundry.faker')::class);
     }
 
     /**
@@ -80,6 +170,17 @@ final class ZenstruckFoundryBundleTest extends TestCase
             'make_story' => [
                 'default_namespace' => 'Story',
             ]
-        ], $this->buildConfiguration());
+        ], self::buildConfiguration());
+    }
+
+    private static function buildConfiguration(array $config = []): array
+    {
+        $treeBuilder = new TreeBuilder('zenstruck_foundry');
+        $definitionLoader = new DefinitionFileLoader($treeBuilder, new FileLocator());
+        $configurator = new DefinitionConfigurator($treeBuilder, $definitionLoader, __DIR__,'');
+
+        (new ZenstruckFoundryBundle())->configure($configurator);
+
+        return (new Processor())->process($treeBuilder->buildTree(), $config);
     }
 }

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
+use Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode;
+use Zenstruck\Foundry\ZenstruckFoundryBundle;
+
+final class ZenstruckFoundryBundleTest extends TestCase
+{
+    private function buildConfiguration(array $config = []): array
+    {
+        $treeBuilder = new TreeBuilder('zenstruck_foundry');
+        $definitionLoader = new DefinitionFileLoader($treeBuilder, new FileLocator());
+        $configurator = new DefinitionConfigurator($treeBuilder, $definitionLoader, __DIR__,'');
+
+        (new ZenstruckFoundryBundle())->configure($configurator);
+
+        return (new Processor())->process($treeBuilder->buildTree(), $config);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function configuration_default_values(): void
+    {
+        self::assertSame([
+            'auto_refresh_proxies' => null,
+            'faker' => [
+                'locale' => null,
+                'seed' => null,
+                'service' => null,
+            ],
+            'instantiator' => [
+                'use_constructor' => true,
+                'allow_extra_attributes' => false,
+                'always_force_properties' => false,
+                'service' => null,
+            ],
+            'global_state' => [],
+            'orm' => [
+                'auto_persist' => true,
+                'reset' => [
+                    'connections' => ['default'],
+                    'entity_managers' => ['default'],
+                    'mode' => ResetDatabaseMode::SCHEMA,
+                    'migrations' => [
+                        'configurations' => [],
+                    ]
+                ],
+            ],
+            'mongo' => [
+                'auto_persist' => true,
+                'reset' => [
+                    'document_managers' => ['default'],
+                ],
+            ],
+            'make_factory' => [
+                'default_namespace' => 'Factory',
+                'add_hints' => true,
+            ],
+            'make_story' => [
+                'default_namespace' => 'Story',
+            ]
+        ], $this->buildConfiguration());
+    }
+}

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Unit;
+namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
@@ -36,6 +38,7 @@ use Zenstruck\Foundry\ZenstruckFoundryBundle;
  */
 final class ZenstruckFoundryBundleTest extends TestCase
 {
+    use ExpectDeprecationTrait;
 
     private ZenstruckFoundryBundle $bundle;
     private ContainerBuilder $container;
@@ -78,10 +81,15 @@ final class ZenstruckFoundryBundleTest extends TestCase
 
     /**
      * @test
+     *
+     * @group legacy
      */
     #[Test]
+    #[Group('legacy')]
     public function faker_seed_value_overridden(): void
     {
+        self::expectDeprecation('Since zenstruck/foundry 2.4: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead.');
+
         $config = self::buildConfiguration([['faker' => ['seed' => $expected = 1234]]]);
 
         $this->bundle->loadExtension($config,  $this->configurator, $this->container);


### PR DESCRIPTION
This will test the default configuration values for now. and offers a bridge to test symfony configurations.