### PR TITLE
Prevent random value collisions when kernel is rebooted

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -55,7 +55,9 @@ final class Configuration
         private readonly ?PersistenceManager $persistence = null,
         ?int $forcedFakerSeed = null,
     ) {
-        $this->faker->seed(self::fakerSeed($forcedFakerSeed));
+        if (null === self::$instance) {
+            $this->faker->seed(self::fakerSeed($forcedFakerSeed));
+        }
 
         $this->instantiator = $instantiator;
     }

--- a/tests/Fixture/Entity/WithUniqueColumn.php
+++ b/tests/Fixture/Entity/WithUniqueColumn.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+class WithUniqueColumn extends Base
+{
+    #[ORM\Column(unique: true)]
+    private int $uniqueCol;
+
+    public function __construct(int $uniqueCol)
+    {
+        $this->uniqueCol = $uniqueCol;
+    }
+
+    public function getUniqueCol(): int
+    {
+        return $this->uniqueCol;
+    }
+
+    public function setUniqueCol(int $uniqueCol): static
+    {
+        $this->uniqueCol = $uniqueCol;
+
+        return $this;
+    }
+}

--- a/tests/Fixture/Factories/Entity/WithUniqueColumn/WithUniqueColumnFactory.php
+++ b/tests/Fixture/Factories/Entity/WithUniqueColumn/WithUniqueColumnFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\WithUniqueColumn;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\WithUniqueColumn;
+
+/**
+ * @extends PersistentObjectFactory<WithUniqueColumn>
+ */
+final class WithUniqueColumnFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return WithUniqueColumn::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'uniqueCol' => self::faker()->randomNumber(),
+        ];
+    }
+}

--- a/tests/Integration/Faker/FakerSeedIsNotSetDuringRunKernelTest.php
+++ b/tests/Integration/Faker/FakerSeedIsNotSetDuringRunKernelTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\Faker;
+
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\WithUniqueColumn\WithUniqueColumnFactory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+/**
+ * @requires PHPUnit >=11.0
+ */
+#[RequiresPhpunit('>=11.0')]
+final class FakerSeedIsNotSetDuringRunKernelTest extends KernelTestCase
+{
+    use Factories, FakerTestTrait, RequiresORM, ResetDatabase;
+
+    #[Test]
+    public function faker_seed_is_no_set_during_run(): void
+    {
+        if (!\getenv('MONGO_URL')) {
+            self::markTestSkipped('doctrine/odm not enabled.');
+        }
+
+        self::bootKernel();
+
+        $e1 = WithUniqueColumnFactory::createOne();
+
+        self::ensureKernelShutdown();
+
+        $e2 = WithUniqueColumnFactory::createOne();
+
+        $this->assertNotSame($e1->getUniqueCol(), $e2->getUniqueCol());
+    }
+}


### PR DESCRIPTION
PR #807 introduced an interesting issue: when a fixed seed is used, `mt_srand()` generates the same sequence of random values every time it's called (see https://3v4l.org/AKjIO). As a result, if the kernel is shut down and rebooted, the random number generator is "reset".

This causes problems when using Foundry with Symfony's `KernelBrowser`. The kernel is shut down after the second request ([code](https://github.com/symfony/symfony/blob/01c26aa928ecc5dc42ce90268299c190c6b712ed/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php#L141-L157)), so any calls to Faker after that will return the same values as before.

Here's a simplified example:

```php
#[ORM\Entity]
class Test
{
    // ...

    #[ORM\Column(unique: true)]
    private ?int $example = null;

    // ...
}

final class TestFactory extends PersistentProxyObjectFactory
{
    public static function class(): string
    {
        return Test::class;
    }

    protected function defaults(): array|callable
    {
        return [
            'example' => self::faker()->randomNumber(),
        ];
    }
}

class MyTest extends WebTestCase
{
    use Factories;
    use ResetDatabase;

    public function testSomething(): void
    {
        static::createClient()->request('GET', '/');

        TestFactory::createOne();

        static::getClient()->request('GET', '/');

        TestFactory::createOne(); // ← Fails here
    }
}
```

This currently results in a `UniqueConstraintViolationException`:

```
Doctrine\DBAL\Exception\UniqueConstraintViolationException: An exception occurred while executing a query: SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint "uniq_d87f7e0c6eec9b9f"
DETAIL:  Key (example)=(52197) already exists.
```

This PR ensures the seed isn't reapplied in the middle of a test. Since `Configuration::$instance` is set at the beginning of each test and reset afterward, we assume that if it's set, a test is in progress and we skip seeding.