### PR TITLE
minor: allow 10% gap in benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,4 +94,4 @@ jobs:
             --iterations=5 \
             --progress=plain \
             --retry-threshold=10 \
-            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%"
+            --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%"


### PR DESCRIPTION
This has already been done, but in 2.5.x 😬