### PR TITLE
chore: decouple from framework bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,43 @@ jobs:
           ./phpunit --testsuite reset-database --bootstrap tests/bootstrap-reset-database.php
         shell: bash
 
+  test-no-framework:
+    name: No framework - PHP${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: flex
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --prefer-dist
+
+      - name: Remove
+        run: |
+          composer remove --dev \
+            dama/doctrine-test-bundle \
+            doctrine/doctrine-bundle \
+            doctrine/doctrine-migrations-bundle \
+            doctrine/mongodb-odm-bundle \
+            symfony/maker-bundle \
+            symfony/framework-bundle
+
+      - name: Test
+        run: |
+          vendor/bin/phpunit tests/Unit
+
   test-with-paratest:
     name: Test with paratest
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "doctrine/persistence": "^2.0|^3.0|^4.0",
         "fakerphp/faker": "^1.23",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/var-exporter": "^6.4.9|~7.0.9|^7.1.2",
@@ -34,12 +32,14 @@
         "doctrine/common": "^3.2.2",
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
+        "doctrine/persistence": "^2.0|^3.0|^4.0",
         "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
         "doctrine/mongodb-odm": "^2.4",
         "doctrine/orm": "^2.16|^3.0",
         "phpunit/phpunit": "^9.5.0 || ^10.0 || ^11.0 || ^12.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/dotenv": "^6.4|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/maker-bundle": "^1.55",
         "symfony/phpunit-bridge": "^6.4|^7.0",
         "symfony/runtime": "^6.4|^7.0",
@@ -75,6 +75,10 @@
             "symfony/flex": true,
             "symfony/runtime": false
         }
+    },
+    "conflict": {
+        "doctrine/persistence": "<2.0",
+        "symfony/framework-bundle": "<6.4"
     },
     "extra": {
         "bamarni-bin": {

--- a/tests/Fixture/FoundryTestKernel.php
+++ b/tests/Fixture/FoundryTestKernel.php
@@ -72,12 +72,20 @@ abstract class FoundryTestKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
-        $c->loadFromExtension('framework', [
+        $frameworkConfiguration = [
             'http_method_override' => false,
             'secret' => 'S3CRET',
             'router' => ['utf8' => true],
             'test' => true,
-        ]);
+            'uid' => ['default_uuid_version' => 7, 'time_based_uuid_version' => 7],
+        ];
+
+        if (\str_starts_with(self::VERSION, '6.4')) {
+            // prevent a deprecation notice in Symfony 6.4
+            $frameworkConfiguration['handle_all_throwables'] = true;
+        }
+
+        $c->loadFromExtension('framework', $frameworkConfiguration);
 
         if (self::hasORM()) {
             $c->loadFromExtension('doctrine', [

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -47,11 +47,6 @@ final class TestKernel extends FoundryTestKernel
             ],
         ]);
 
-        // prevent a deprecation notice in Symfony 6.4
-        if (\str_starts_with(self::VERSION, '6.4')) {
-            $c->loadFromExtension('framework', ['handle_all_throwables' => true]);
-        }
-
         $c->register(ArrayFactory::class)->setAutowired(true)->setAutoconfigured(true);
         $c->register(Object1Factory::class)->setAutowired(true)->setAutoconfigured(true);
         $c->register(ServiceStory::class)->setAutowired(true)->setAutoconfigured(true);

--- a/tests/Unit/ZenstruckFoundryBundleTest.php
+++ b/tests/Unit/ZenstruckFoundryBundleTest.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Tests\Unit;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
@@ -43,6 +44,10 @@ final class ZenstruckFoundryBundleTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!\class_exists(FrameworkBundle::class)) {
+            self::markTestSkipped('symfony/framework-bundle needed.');
+        }
+
         $this->container = new ContainerBuilder(new ParameterBag([
             'kernel.bundles' => [],
             'kernel.cache_dir' => \sys_get_temp_dir(),


### PR DESCRIPTION
[This discussion](https://phpc.social/@Crell/114354438064545079) made me realize that we're forcing the installation of `symfony/framework-bundle` and `doctrine/persistence` although Foundry could run without them.

This would allow to use Foundry as a standalone library.

At some point I would really like to provide an abstraction in order to allow custom persistence (see https://github.com/zenstruck/foundry/issues/695). This is already kinda doable using [this trick](https://github.com/zenstruck/foundry/issues/838#issuecomment-2705884373), but a proper persistence abstraction could be better. I even think it should not be very complex to do (as long as we don't handle relationships :sweat_smile:  - BTW that's what we do with Mongo)

