### PR TITLE
fix: should not use flush_after() in FactoryCollection::create()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
             doctrine/doctrine-migrations-bundle \
             doctrine/mongodb-odm-bundle \
             symfony/maker-bundle \
+            symfony/phpunit-bridge \
             symfony/framework-bundle
 
       - name: Test

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -14,8 +14,6 @@ namespace Zenstruck\Foundry;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\PersistMode;
 
-use function Zenstruck\Foundry\Persistence\flush_after;
-
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
@@ -146,13 +144,16 @@ final class FactoryCollection implements \IteratorAggregate
      */
     public function create(array|callable $attributes = []): array
     {
+        $factories = $this->all();
+
         if (Configuration::instance()->flushOnce && $this->isRootFactory && $this->factory instanceof PersistentObjectFactory && $this->factory->isPersisting()) {
-            return flush_after(
-                fn() => \array_map(static fn(Factory $f) => $f->create($attributes), $this->all())
-            );
+            $lastFactory = array_pop($factories);
+            // @phpstan-ignore method.notFound (phpstan does not understand that we only have persistent factories here)
+            $factories = array_map(static fn(Factory $f) => $f->notRootFactory(), $factories);
+            $factories[] = $lastFactory;
         }
 
-        return \array_map(static fn(Factory $f) => $f->create($attributes), $this->all());
+        return \array_map(static fn(Factory $f) => $f->create($attributes), $factories);
     }
 
     /**

--- a/tests/Integration/ArrayFactoryTest.php
+++ b/tests/Integration/ArrayFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\LazyValue;
@@ -28,6 +29,7 @@ final class ArrayFactoryTest extends KernelTestCase
      * @test
      */
     #[Test]
+    #[IgnoreDeprecations]
     public function can_create_with_defaults(): void
     {
         $this->assertSame(

--- a/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
+++ b/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\Tests\Integration\InMemory;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
@@ -177,8 +178,10 @@ final class DoctrineInMemoryDecoratorTest extends KernelTestCase
 
     /**
      * @test
+     * @group legacy
      */
     #[Test]
+    #[IgnoreDeprecations]
     public function it_can_find_by_entity_proxified(): void
     {
         ContactFactory::createMany(2, fn() => ['category' => CategoryFactory::createOne()]);

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -34,6 +34,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
 
 use function Zenstruck\Foundry\lazy;
+use function Zenstruck\Foundry\Persistence\flush_after;
 use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\unproxy;
 
@@ -710,6 +711,44 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
             )->create();
 
         self::assertNotNull($address->getContact());
+    }
+
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Contact::class, ['category'])]
+    public function find_or_create_used_in_many_actually_create_only_one_object(): void
+    {
+        static::contactFactory()
+            ->many(2)
+            ->create(['category' => lazy(fn() => static::categoryFactory()::findOrCreate([]))]);
+
+        static::contactFactory()::assert()->count(2);
+        static::categoryFactory()::assert()->count(1);
+    }
+
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Contact::class, ['category'])]
+    public function ensure_inverse_one_to_many_is_hydrated_before_persisting_in_flush_after(): void
+    {
+        flush_after(
+            static function() {
+                $contactFactory = static::contactFactory()
+                    ->afterPersist(static function(Contact $contact) {
+                        self::assertNotNull($contact->getCategory());
+                    });
+
+                static::categoryFactory()::createMany(
+                    2,
+                    ['contacts' => lazy(static fn() => $contactFactory->many(2)->create(['category' => null]))]
+                );
+            }
+        );
+
+        static::contactFactory()::assert()->count(4);
+        static::categoryFactory()::assert()->count(2);
     }
 
     /** @return PersistentObjectFactory<Contact> */


### PR DESCRIPTION
this reproduces both https://github.com/zenstruck/foundry/issues/907 and https://github.com/zenstruck/foundry/issues/911 and fixes them  (two issue, same fix) - @phasdev [did add a feature flag](https://github.com/zenstruck/foundry/pull/912) for flush once, but the bug still remains.

`flush_after()` was definitely not a good idea in `FactoryCollection::create()`: "flush once" behavior should not be a hard requirement, and something like `findOrCreate()` should actually flush.

thanks again to @phasdev, the reproducers were very helpful!

fixes #907 fixes #911