### PR TITLE
feat: use PHP 8.4 native proxy system for `create()` calls in data providers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1163,7 +1163,7 @@ once. To do this, wrap the operations in a ``flush_after()`` callback:
         TagFactory::createMany(200); // instantiated/persisted but not flushed
     }); // single flush
 
-The ``flush_after()`` function forwards the callback’s return, in case you need to use the objects in your tests:
+The ``flush_after()`` function forwards the callback's return, in case you need to use the objects in your tests:
 
 ::
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -69,6 +69,10 @@ parameters:
         - identifier: missingType.callable
           path: tests/Fixture/Maker/expected/
 
+        # we're currently running static analysis with PHP 8.3
+        - message: '#Call to an undefined method ReflectionClass\<(.*)\>::isUninitializedLazyObject\(\).#'
+        - message: '#Call to an undefined method ReflectionClass\<(.*)\>::initializeLazyObject\(\).#'
+
     excludePaths:
         - tests/Fixture/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php
         - tests/Fixture/Maker/expected/can_create_factory_interactively.php

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -203,6 +203,12 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public function create(callable|array $attributes = []): object
     {
+        $configuration = Configuration::instance();
+
+        if ($configuration->inADataProvider() && \PHP_VERSION_ID >= 80400 && !$this instanceof PersistentProxyObjectFactory) {
+            return ProxyGenerator::wrapFactoryNativeProxy($this, $attributes);
+        }
+
         $object = parent::create($attributes);
 
         foreach ($this->tempAfterInstantiate as $callback) {
@@ -216,8 +222,6 @@ abstract class PersistentObjectFactory extends ObjectFactory
         if (PersistMode::PERSIST !== $this->persistMode()) {
             return $object;
         }
-
-        $configuration = Configuration::instance();
 
         if ($configuration->flushOnce && !$this->isRootFactory) {
             return $object;

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -60,6 +60,25 @@ final class ProxyGenerator
     }
 
     /**
+     * @template T of object
+     *
+     * @param PersistentObjectFactory<T> $factory
+     * @phpstan-param Attributes $attributes
+     *
+     * @return T
+     */
+    public static function wrapFactoryNativeProxy(PersistentObjectFactory $factory, callable|array $attributes): object
+    {
+        if (\PHP_VERSION_ID < 80400) {
+            throw new \LogicException('Native proxy generation requires PHP 8.4 or higher.');
+        }
+
+        $reflector = new \ReflectionClass($factory::class());
+
+        return $reflector->newLazyProxy(static fn() => $factory->create($attributes)); // @phpstan-ignore-line
+    }
+
+    /**
      * @template T
      *
      * @param T $what
@@ -78,6 +97,10 @@ final class ProxyGenerator
 
         if ($what instanceof Proxy) {
             return $what->_real($withAutoRefresh); // @phpstan-ignore return.type
+        }
+
+        if (\PHP_VERSION_ID >= 80400 && is_object($what) && ($reflector = new \ReflectionClass($what))->isUninitializedLazyObject($what)) {
+            return $reflector->initializeLazyObject($what);
         }
 
         return $what;

--- a/src/Persistence/functions.php
+++ b/src/Persistence/functions.php
@@ -181,6 +181,12 @@ function enable_persisting(): void
  */
 function initialize_proxy_object(mixed $what): void
 {
+    if (\PHP_VERSION_ID >= 80400 && is_object($what) && ($reflector = new \ReflectionClass($what))->isUninitializedLazyObject($what)) {
+        $reflector->initializeLazyObject($what);
+
+        return;
+    }
+
     match (true) {
         $what instanceof Proxy => $what->_initializeLazyObject(),
         \is_array($what) => \array_map(initialize_proxy_object(...), $what),

--- a/tests/Integration/DataProvider/DataProviderWithNonProxyFactoryInKernelTestCaseTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithNonProxyFactoryInKernelTestCaseTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Integration\DataProvider;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
@@ -28,6 +29,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
  * @requires PHPUnit >=11.4
  */
 #[RequiresPhpunit('>=11.4')]
+#[RequiresPhp('<8.4')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class DataProviderWithNonProxyFactoryInKernelTestCaseTest extends KernelTestCase
 {

--- a/tests/Integration/DataProvider/DataProviderWithPersistentFactoryAndPHP84InKernelTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentFactoryAndPHP84InKernelTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\DataProvider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
+
+use function Zenstruck\Foundry\Persistence\unproxy;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit >=11.4
+ */
+#[RequiresPhpunit('>=11.4')]
+#[RequiresPhp('>=8.4')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
+final class DataProviderWithPersistentFactoryAndPHP84InKernelTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    #[DataProvider('createOneObjectInDataProvider')]
+    public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
+    {
+        GenericEntityFactory::assert()->count(1);
+
+        self::assertNotNull($providedData);
+        self::assertFalse((new \ReflectionClass($providedData))->isUninitializedLazyObject($providedData));
+        self::assertSame('value set in data provider', $providedData->getProp1());
+    }
+
+    public static function createOneObjectInDataProvider(): iterable
+    {
+        yield 'createOne()' => [
+            GenericEntityFactory::createOne(['prop1' => 'value set in data provider']),
+        ];
+
+        yield 'create()' => [
+            GenericEntityFactory::new()->create(['prop1' => 'value set in data provider']),
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('createMultipleObjectsInDataProvider')]
+    public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
+    {
+        self::assertIsArray($providedData);
+        GenericEntityFactory::assert()->count(2);
+
+        foreach ($providedData as $providedDatum) {
+            self::assertFalse((new \ReflectionClass($providedDatum))->isUninitializedLazyObject($providedDatum));
+        }
+
+        self::assertSame('prop 1', $providedData[0]->getProp1());
+        self::assertSame('prop 2', $providedData[1]->getProp1());
+    }
+
+    public static function createMultipleObjectsInDataProvider(): iterable
+    {
+        yield 'createSequence()' => [
+            GenericEntityFactory::createSequence([
+                ['prop1' => 'prop 1'],
+                ['prop1' => 'prop 2'],
+            ]),
+        ];
+
+        yield 'FactoryCollection::create()' => [
+            GenericEntityFactory::new()->sequence([
+                ['prop1' => 'prop 1'],
+                ['prop1' => 'prop 2'],
+            ])->create(),
+        ];
+    }
+}


### PR DESCRIPTION
one step forward for https://github.com/zenstruck/foundry/issues/899