### PR TITLE
fix: reuse should work with all kind of relationships

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -185,7 +185,7 @@ abstract class Factory
         // "reused" attributes will override the ones from "defaults()"
         // but should be overridden by the other states of the factory
         if ($this instanceof ObjectFactory) {
-            $mergedAttributes[] = $this->reusedAttributes();
+            $mergedAttributes[] = $this->normalizeReusedAttributes();
         }
 
         $mergedAttributes = [...$mergedAttributes, ...$this->attributes, $attributes];

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -212,6 +212,26 @@ final class FactoryCollection implements \IteratorAggregate
         );
     }
 
+    /**
+     * @internal
+     */
+    public function reuse(object ...$objects): static
+    {
+        if (0 === \count($objects)) {
+            return $this;
+        }
+
+        $factories = $this->all();
+
+        return new self(
+            $this->factory,
+            static fn() => \array_map(
+                static fn(Factory $f) => $f instanceof ObjectFactory ? $f->reuse(...$objects) : $f,
+                $factories,
+            )
+        );
+    }
+
     public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->all());

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -13,6 +13,8 @@ namespace Zenstruck\Foundry;
 
 use Zenstruck\Foundry\Object\Instantiator;
 
+use function Zenstruck\Foundry\Persistence\unproxy;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
@@ -33,7 +35,7 @@ abstract class ObjectFactory extends Factory
     /** @phpstan-var InstantiatorCallable|null */
     private $instantiator;
 
-    /** @phpstan-var array<class-string, object> */
+    /** @var array<class-string, object> */
     private array $reusedObjects = [];
 
     /**
@@ -110,18 +112,23 @@ abstract class ObjectFactory extends Factory
      * @psalm-return static<T>
      * @phpstan-return static
      */
-    final public function reuse(object $object): static
+    final public function reuse(object ...$objects): static
     {
-        if (isset($this->reusedObjects[$object::class])) {
-            throw new \InvalidArgumentException(\sprintf('An object of class "%s" is already being reused.', $object::class));
-        }
-
-        if ($object instanceof Factory) {
-            throw new \InvalidArgumentException('Cannot reuse a factory.');
+        if (0 === \count($objects)) {
+            return $this;
         }
 
         $clone = clone $this;
-        $clone->reusedObjects[$object::class] = $object;
+
+        foreach ($objects as $object) {
+            $object = unproxy($object, withAutoRefresh: false);
+
+            if ($object instanceof Factory) {
+                throw new \InvalidArgumentException('Cannot reuse a factory.');
+            }
+
+            $clone->reusedObjects[$object::class] = $object;
+        }
 
         return $clone;
     }
@@ -145,7 +152,7 @@ abstract class ObjectFactory extends Factory
      * @internal
      * @phpstan-return Parameters
      */
-    final protected function reusedAttributes(): array
+    final protected function normalizeReusedAttributes(): array
     {
         if ([] === $this->reusedObjects) {
             return [];
@@ -183,5 +190,14 @@ abstract class ObjectFactory extends Factory
         }
 
         return $attributes;
+    }
+
+    /**
+     * @return list<object>
+     * @internal
+     */
+    final protected function reusedObjects(): array
+    {
+        return \array_values($this->reusedObjects);
     }
 }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -301,7 +301,9 @@ abstract class PersistentObjectFactory extends ObjectFactory
         }
 
         if ($value instanceof self) {
-            $value = $value->withPersistMode($this->persist)->notRootFactory();
+            $value = $value
+                ->withPersistMode($this->persist)
+                ->notRootFactory();
 
             $pm = Configuration::instance()->persistence();
 
@@ -311,9 +313,12 @@ abstract class PersistentObjectFactory extends ObjectFactory
             if ($relationshipMetadata instanceof OneToOneRelationship && !$relationshipMetadata->isOwning) {
                 $inverseField = $relationshipMetadata->inverseField();
 
-                $value = $value->withPersistMode(
-                    $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
-                );
+                $value = $value
+                    ->reuse(...$this->reusedObjects(), ...$value->reusedObjects())
+                    ->withPersistMode(
+                        $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
+                    )
+                ;
 
                 if (($fieldType = (new \ReflectionClass(static::class()))->getProperty($field)->getType())?->allowsNull()) {
                     $this->tempAfterInstantiate[] = static function(object $object) use ($value, $inverseField, $field) {
@@ -363,9 +368,9 @@ abstract class PersistentObjectFactory extends ObjectFactory
             $this->tempAfterInstantiate[] = function(object $object) use ($collection, $inverseRelationshipMetadata, $field) {
                 $inverseField = $inverseRelationshipMetadata->inverseField();
 
-                $inverseObjects = $collection->withPersistMode(
-                    $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
-                )
+                $inverseObjects = $collection
+                    ->reuse(...$this->reusedObjects())
+                    ->withPersistMode($this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING)
                     ->create([$inverseField => $object]);
 
                 $inverseObjects = unproxy($inverseObjects, withAutoRefresh: false);

--- a/tests/Integration/ORM/ReuseEntityTest.php
+++ b/tests/Integration/ORM/ReuseEntityTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\TagFactory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+final class ReuseEntityTest extends KernelTestCase
+{
+    use Factories, RequiresORM, ResetDatabase;
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_reuse_an_object_in_one_to_one(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($address)
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_reuse_an_object_in_inverse_one_to_one(): void
+    {
+        $contact = ContactFactory::createOne();
+
+        $address = AddressFactory::new()
+            ->reuse($contact)
+            ->create();
+
+        self::assertSame($contact, $address->getContact());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_propagate_reused_objects_through_inversed_one_to_one(): void
+    {
+        $category = CategoryFactory::createOne();
+
+        $address = AddressFactory::new(['contact' => ContactFactory::new()])
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($category, $address->getContact()?->getCategory());
+        self::assertSame($category, $address->getContact()->getSecondaryCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function reused_object_in_sub_factory_has_priority(): void
+    {
+        $category = CategoryFactory::createOne();
+
+        $address = AddressFactory::new([
+            'contact' => ContactFactory::new()->reuse($category2 = CategoryFactory::createOne()),
+        ])
+            ->reuse($category)
+            ->create();
+
+        self::assertSame($category2, $address->getContact()?->getCategory());
+        self::assertSame($category2, $address->getContact()->getSecondaryCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function reuse_has_no_effect_on_collections(): void
+    {
+        $contact = ContactFactory::createOne();
+
+        $category = CategoryFactory::new()
+            ->reuse($contact)
+            ->create(['contacts' => ContactFactory::new()->many(2)]);
+
+        self::assertNotSame($contact, $category->getContacts()[0]);
+        self::assertNotSame($contact, $category->getContacts()[1]);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_propagate_reused_objects_through_inversed_one_to_many(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $category = CategoryFactory::new()
+            ->reuse($address)
+            ->create(['contacts' => ContactFactory::new()->many(2)]);
+
+        self::assertCount(2, $category->getContacts());
+        foreach ($category->getContacts() as $contact) {
+            self::assertSame($address, $contact->getAddress());
+        }
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_propagate_reused_objects_through_inversed_many_to_many(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $tag = TagFactory::new()
+            ->reuse($address)
+            ->create(['contacts' => ContactFactory::new()->many(2)]);
+
+        self::assertCount(2, $tag->getContacts());
+        foreach ($tag->getContacts() as $contact) {
+            self::assertSame($address, $contact->getAddress());
+        }
+    }
+}

--- a/tests/Unit/ReuseEntityTest.php
+++ b/tests/Unit/ReuseEntityTest.php
@@ -23,6 +23,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
 
 use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\object;
+use function Zenstruck\Foundry\Persistence\proxy;
 
 final class ReuseEntityTest extends TestCase
 {
@@ -47,14 +48,42 @@ final class ReuseEntityTest extends TestCase
      * @test
      */
     #[Test]
-    public function it_throws_if_recycling_two_objects_of_same_type(): void
+    public function it_can_reuse_a_proxy_object(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $address = AddressFactory::createOne();
 
-        ContactFactory::new()
-            ->reuse(AddressFactory::createOne())
-            ->reuse(AddressFactory::createOne())
+        $contact = ContactFactory::new()
+            ->reuse(proxy($address))
             ->create();
+
+        self::assertSame($address, $contact->getAddress());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function last_reused_object_is_used_if_recycling_two_objects_of_same_type(): void
+    {
+        $contact = ContactFactory::new()
+            ->reuse(AddressFactory::createOne())
+            ->reuse($address = AddressFactory::createOne())
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_throws_if_recycling_two_objects_of_same_type_with_spread_parameters(): void
+    {
+        $contact = ContactFactory::new()
+            ->reuse(AddressFactory::createOne(), $address = AddressFactory::createOne())
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
     }
 
     /**
@@ -95,6 +124,23 @@ final class ReuseEntityTest extends TestCase
         $contact = ContactFactory::new()
             ->reuse($address)
             ->reuse($category)
+            ->create();
+
+        self::assertSame($address, $contact->getAddress());
+        self::assertSame($category, $contact->getCategory());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_call_reuse_multiple_times_with_spread_parameters(): void
+    {
+        $address = AddressFactory::createOne();
+        $category = CategoryFactory::createOne();
+
+        $contact = ContactFactory::new()
+            ->reuse($address, $category)
             ->create();
 
         self::assertSame($address, $contact->getAddress());
@@ -178,5 +224,40 @@ final class ReuseEntityTest extends TestCase
         ;
 
         self::assertSame($entity, $otherEntity->entity);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_reuse_objects_in_collection(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $contacts = ContactFactory::new()
+            ->reuse($address)
+            ->many(2)
+            ->create();
+
+        self::assertSame($address, $contacts[0]->getAddress());
+        self::assertSame($address, $contacts[1]->getAddress());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_propagates_reused_objects_to_collection(): void
+    {
+        $address = AddressFactory::createOne();
+
+        $category = CategoryFactory::new()
+            ->reuse($address)
+            ->create(['contacts' => ContactFactory::new()->many(2)]);
+
+        self::assertCount(2, $category->getContacts());
+        foreach ($category->getContacts() as $contact) {
+            self::assertSame($address, $contact->getAddress());
+        }
     }
 }


### PR DESCRIPTION
I tried to use `reuse()` with real world examples, and I find out that some stuff was missing :sweat_smile: 

now I think we cover all possible cases