### PR TITLE
Fix TypeError FactoryCollection::create when calling many with 0

### DIFF
--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -150,7 +150,10 @@ final class FactoryCollection implements \IteratorAggregate
             $lastFactory = \array_pop($factories);
             // @phpstan-ignore method.notFound (phpstan does not understand that we only have persistent factories here)
             $factories = \array_map(static fn(Factory $f) => $f->notRootFactory(), $factories);
-            $factories[] = $lastFactory;
+
+            if ($lastFactory !== null)  {
+                $factories[] = $lastFactory;
+            }
         }
 
         return \array_map(static fn(Factory $f) => $f->create($attributes), $factories);

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -751,6 +751,19 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         static::categoryFactory()::assert()->count(2);
     }
 
+    /** @test */
+    #[Test]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    #[UsingRelationships(Contact::class, ['category'])]
+    public function call_many_with_zero_do_nothing(): void
+    {
+        static::contactFactory()
+            ->many(0)
+            ->create();
+
+        static::contactFactory()::assert()->count(0);
+    }
+
     /** @return PersistentObjectFactory<Contact> */
     protected static function contactFactoryWithoutCategory(): PersistentObjectFactory
     {


### PR DESCRIPTION
Fix issue #924 

The issue is caused when calling the `FactoryCollection::many` with `0`.

This could happen when using it in a PHPUnit data provider.