### PR TITLE
fix: remove useless Configuration::boted() check

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -449,12 +449,6 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
     final protected function initializeInternal(): static
     {
-        if (!Configuration::isBooted()) {
-            return $this;
-        }
-
-        $this->persist = $this->isPersistenceEnabled() ? PersistMode::PERSIST : PersistMode::WITHOUT_PERSISTING;
-
         // Schedule any new object for insert right after instantiation
         return parent::initializeInternal()
             ->afterInstantiate(

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -764,6 +764,27 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         static::contactFactory()::assert()->count(0);
     }
 
+    /**
+     * @test
+     * @dataProvider provideCanUseFactoryInDataProviderWithRelationshipCases
+     * @param PersistentObjectFactory<Contact> $factory
+     */
+    #[Test]
+    #[DataProvider('provideCanUseFactoryInDataProviderWithRelationshipCases')]
+    public function can_create_many_with_factory_from_data_provider_with_relationship(PersistentObjectFactory $factory): void
+    {
+        $objects = $factory->many(2)->create();
+
+        self::assertCount(2, $objects);
+    }
+
+    public static function provideCanUseFactoryInDataProviderWithRelationshipCases(): iterable
+    {
+        yield [
+            static::contactFactory()
+        ];
+    }
+
     /** @return PersistentObjectFactory<Contact> */
     protected static function contactFactoryWithoutCategory(): PersistentObjectFactory
     {


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/928

ping @mvhirsch

:warning: I've created a 2.5.x branch, because I still need to perform some checks before releasing 2.6
