### PR TITLE
feat: add randomRangeOrCreate method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -237,6 +237,7 @@ This command will generate a ``PostFactory`` class that looks like this:
          * @method static Post[]&Proxy[] createSequence(iterable|callable $sequence)
          * @method static Post[]|Proxy[] findBy(array $attributes)
          * @method static Post[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+         * @method static Post[]|Proxy[] randomRangeOrCreate(int $min, int $max, array $attributes = [])
          * @method static Post[]|Proxy[] randomSet(int $number, array $attributes = []))
          *
          * @phpstan-method Proxy<Post>&Post create(array|callable $attributes = [])
@@ -252,6 +253,7 @@ This command will generate a ``PostFactory`` class that looks like this:
          * @phpstan-method static list<Proxy<Post>&Post> createSequence(array|callable $sequence)
          * @phpstan-method static list<Proxy<Post>&Post> findBy(array $attributes)
          * @phpstan-method static list<Proxy<Post>&Post> randomRange(int $min, int $max, array $attributes = [])
+         * @phpstan-method static list<Proxy<Post>&Post> randomRangeOrCreate(int $min, int $max, array $attributes = [])
          * @phpstan-method static list<Proxy<Post>&Post> randomSet(int $number, array $attributes = [])
          * @phpstan-method static RepositoryProxy<Post>&Post repository()
          */

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -373,6 +373,10 @@ Using your Factory
     $posts = PostFactory::randomRange(0, 5); // array containing 0-5 "Post|Proxy" objects
     $posts = PostFactory::randomRange(0, 5, ['author' => 'kevin']); // filter by the passed attributes
 
+    // or automatically persist a new random range of objects if none exists
+    $posts = PostFactory::randomRangeOrCreate(0, 5); // array containing 0-5 "Post|Proxy" objects
+    $posts = PostFactory::randomRangeOrCreate(0, 5, ['author' => 'kevin']); // filter by or create with the passed attributes
+
 Reusable Factory "States"
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Maker/Factory/MakeFactoryPHPDocMethod.php
+++ b/src/Maker/Factory/MakeFactoryPHPDocMethod.php
@@ -45,6 +45,7 @@ final class MakeFactoryPHPDocMethod
             $methods[] = new self($makeFactoryData->getObjectShortName(), 'all()', returnsCollection: true);
             $methods[] = new self($makeFactoryData->getObjectShortName(), 'findBy(array $attributes)', returnsCollection: true);
             $methods[] = new self($makeFactoryData->getObjectShortName(), 'randomRange(int $min, int $max, array $attributes = [])', returnsCollection: true);
+            $methods[] = new self($makeFactoryData->getObjectShortName(), 'randomRangeOrCreate(int $min, int $max, array $attributes = [])', returnsCollection: true);
             $methods[] = new self($makeFactoryData->getObjectShortName(), 'randomSet(int $number, array $attributes = [])', returnsCollection: true);
 
             if (null !== $makeFactoryData->getRepositoryReflectionClass()) {

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -117,6 +117,32 @@ abstract class PersistentObjectFactory extends ObjectFactory
     }
 
     /**
+     * @param int<0, max> $min
+     * @param int<0, max> $max
+     * @phpstan-param Parameters  $criteria
+     *
+     * @return list<T>
+     */
+    public static function randomRangeOrCreate(int $min, int $max, array $criteria = []): array
+    {
+        $targetCount = mt_rand($min, $max);
+
+        try {
+            return static::repository()->randomRange($min, $targetCount, $criteria);
+        } catch (NotEnoughObjects) {
+            $foundObjects = static::repository()->findBy($criteria);
+        } catch (PersistenceNotAvailable|PersistenceDisabled) {
+            $foundObjects = [];
+        }
+
+        $objectsToCreate = $targetCount - count($foundObjects);
+
+        $newObjects = static::createMany($objectsToCreate, $criteria);
+
+        return [...$foundObjects, ...$newObjects];
+    }
+
+    /**
      * @phpstan-param Parameters $criteria
      *
      * @return list<T>

--- a/src/Persistence/PersistentProxyObjectFactory.php
+++ b/src/Persistence/PersistentProxyObjectFactory.php
@@ -96,6 +96,14 @@ abstract class PersistentProxyObjectFactory extends PersistentObjectFactory
     /**
      * @return list<T&Proxy<T>>
      */
+    public static function randomRangeOrCreate(int $min, int $max, array $criteria = []): array
+    {
+        return \array_map(proxy(...), parent::randomRangeOrCreate($min, $max, $criteria));
+    }
+
+    /**
+     * @return list<T&Proxy<T>>
+     */
     final public static function findBy(array $criteria): array
     {
         return \array_map(proxy(...), parent::findBy($criteria));

--- a/stubs/phpstan/PersistentProxyObjectFactory.php
+++ b/stubs/phpstan/PersistentProxyObjectFactory.php
@@ -52,6 +52,7 @@ assertType("list<{$proxyType}>", UserProxyFactory::createMany(1));
 assertType("list<{$proxyType}>", UserProxyFactory::createRange(1, 2));
 assertType("list<{$proxyType}>", UserProxyFactory::createSequence([]));
 assertType("list<{$proxyType}>", UserProxyFactory::randomRange(1, 2));
+assertType("list<{$proxyType}>", UserProxyFactory::randomRangeOrCreate(1, 2));
 assertType("list<{$proxyType}>", UserProxyFactory::randomSet(2));
 assertType("list<{$proxyType}>", UserProxyFactory::findBy(['name' => 'foo']));
 
@@ -117,6 +118,7 @@ assertType("string", UserProxyFactory::createMany(1)[0]->name);
 assertType("string", UserProxyFactory::createRange(1, 2)[0]->name);
 assertType("string", UserProxyFactory::createSequence([])[0]->name);
 assertType("string", UserProxyFactory::randomRange(1, 2)[0]->name);
+assertType("string", UserProxyFactory::randomRangeOrCreate(1,2)[0]->name);
 assertType("string", UserProxyFactory::randomSet(2)[0]->name);
 assertType("string", UserProxyFactory::findBy(['name' => 'foo'])[0]->name);
 

--- a/stubs/psalm/PersistentProxyObjectFactory.php
+++ b/stubs/psalm/PersistentProxyObjectFactory.php
@@ -64,6 +64,8 @@ $var = UserProxyFactory::createSequence([]);
 /** @psalm-check-type-exact $var = list<UserForProxyFactory&Proxy<UserForProxyFactory>> */
 $var = UserProxyFactory::randomRange(1, 2);
 /** @psalm-check-type-exact $var = list<UserForProxyFactory&Proxy<UserForProxyFactory>> */
+$var = UserProxyFactory::randomRangeOrCreate(1, 2);
+/** @psalm-check-type-exact $var = list<UserForProxyFactory&Proxy<UserForProxyFactory>> */
 $var = UserProxyFactory::randomSet(2);
 /** @psalm-check-type-exact $var = list<UserForProxyFactory&Proxy<UserForProxyFactory>> */
 $var = UserProxyFactory::findBy(['name' => 'foo']);

--- a/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_for_entity_with_repository.php
@@ -35,6 +35,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Repository\GenericEntityRepository;
  * @method static GenericEntity[]|Proxy[]                          createSequence(iterable|callable $sequence)
  * @method static GenericEntity[]|Proxy[]                          findBy(array $attributes)
  * @method static GenericEntity[]|Proxy[]                          randomRange(int $min, int $max, array $attributes = [])
+ * @method static GenericEntity[]|Proxy[]                          randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @method static GenericEntity[]|Proxy[]                          randomSet(int $number, array $attributes = [])
  *
  * @phpstan-method        GenericEntity&Proxy<GenericEntity> create(array|callable $attributes = [])
@@ -51,6 +52,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Repository\GenericEntityRepository;
  * @phpstan-method static list<GenericEntity&Proxy<GenericEntity>> createSequence(iterable|callable $sequence)
  * @phpstan-method static list<GenericEntity&Proxy<GenericEntity>> findBy(array $attributes)
  * @phpstan-method static list<GenericEntity&Proxy<GenericEntity>> randomRange(int $min, int $max, array $attributes = [])
+ * @phpstan-method static list<GenericEntity&Proxy<GenericEntity>> randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @phpstan-method static list<GenericEntity&Proxy<GenericEntity>> randomSet(int $number, array $attributes = [])
  */
 final class GenericEntityFactory extends PersistentProxyObjectFactory

--- a/tests/Fixture/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_phpstan.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_phpstan.php
@@ -34,6 +34,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
  * @method static Category[]|Proxy[]                        createSequence(iterable|callable $sequence)
  * @method static Category[]|Proxy[]                        findBy(array $attributes)
  * @method static Category[]|Proxy[]                        randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]                        randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @method static Category[]|Proxy[]                        randomSet(int $number, array $attributes = [])
  *
  * @phpstan-method        Category&Proxy<Category> create(array|callable $attributes = [])
@@ -50,6 +51,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
  * @phpstan-method static list<Category&Proxy<Category>> createSequence(iterable|callable $sequence)
  * @phpstan-method static list<Category&Proxy<Category>> findBy(array $attributes)
  * @phpstan-method static list<Category&Proxy<Category>> randomRange(int $min, int $max, array $attributes = [])
+ * @phpstan-method static list<Category&Proxy<Category>> randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @phpstan-method static list<Category&Proxy<Category>> randomSet(int $number, array $attributes = [])
  */
 final class CategoryFactory extends PersistentProxyObjectFactory

--- a/tests/Fixture/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_psalm.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_with_static_analysis_annotations_with_data_set_psalm.php
@@ -34,6 +34,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
  * @method static Category[]|Proxy[]                        createSequence(iterable|callable $sequence)
  * @method static Category[]|Proxy[]                        findBy(array $attributes)
  * @method static Category[]|Proxy[]                        randomRange(int $min, int $max, array $attributes = [])
+ * @method static Category[]|Proxy[]                        randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @method static Category[]|Proxy[]                        randomSet(int $number, array $attributes = [])
  *
  * @psalm-method        Category&Proxy<Category> create(array|callable $attributes = [])
@@ -50,6 +51,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
  * @psalm-method static list<Category&Proxy<Category>> createSequence(iterable|callable $sequence)
  * @psalm-method static list<Category&Proxy<Category>> findBy(array $attributes)
  * @psalm-method static list<Category&Proxy<Category>> randomRange(int $min, int $max, array $attributes = [])
+ * @psalm-method static list<Category&Proxy<Category>> randomRangeOrCreate(int $min, int $max, array $attributes = [])
  * @psalm-method static list<Category&Proxy<Category>> randomSet(int $number, array $attributes = [])
  */
 final class CategoryFactory extends PersistentProxyObjectFactory

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -290,6 +290,45 @@ abstract class GenericFactoryTestCase extends KernelTestCase
      * @test
      */
     #[Test]
+    public function random_range_or_create(): void
+    {
+        static::factory()->create(['prop1' => 'a']);
+        static::factory()->create(['prop1' => 'b']);
+        static::factory()->create(['prop1' => 'b']);
+        static::factory()->create(['prop1' => 'b']);
+
+        $range = static::factory()::randomRangeOrCreate(0, 3);
+
+        $this->assertGreaterThanOrEqual(0, \count($range));
+        $this->assertLessThanOrEqual(3, \count($range));
+
+        foreach ($range as $object) {
+            $this->assertContains($object->getProp1(), ['a', 'b']);
+        }
+
+        $range = static::factory()::randomRangeOrCreate(0, 3, ['prop1' => 'b']);
+
+        $this->assertGreaterThanOrEqual(0, \count($range));
+        $this->assertLessThanOrEqual(3, \count($range));
+
+        foreach ($range as $object) {
+            $this->assertSame('b', $object->getProp1());
+        }
+
+        static::factory()::truncate();
+        $range = static::factory()::randomRangeOrCreate(1, 2, ['prop1' => 'c']);
+
+        $this->assertGreaterThanOrEqual(1, \count($range));
+        $this->assertLessThanOrEqual(2, \count($range));
+        foreach ($range as $object) {
+            $this->assertSame('c', $object->getProp1());
+        }
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
     public function random_set(): void
     {
         static::factory()->create(['prop1' => 'a']);

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -290,36 +290,72 @@ abstract class GenericFactoryTestCase extends KernelTestCase
      * @test
      */
     #[Test]
-    public function random_range_or_create(): void
+    public function random_range_or_create_enough_object(): void
     {
         static::factory()->create(['prop1' => 'a']);
-        static::factory()->create(['prop1' => 'b']);
-        static::factory()->create(['prop1' => 'b']);
-        static::factory()->create(['prop1' => 'b']);
+        static::factory()->create(['prop1' => 'a']);
+        static::factory()->create(['prop1' => 'a']);
 
-        $range = static::factory()::randomRangeOrCreate(0, 3);
+        $range = static::factory()::randomRangeOrCreate(2, 3);
 
-        $this->assertGreaterThanOrEqual(0, \count($range));
+        $this->assertGreaterThanOrEqual(2, \count($range));
         $this->assertLessThanOrEqual(3, \count($range));
 
         foreach ($range as $object) {
-            $this->assertContains($object->getProp1(), ['a', 'b']);
+            $this->assertSame('a', $object->getProp1());
         }
+    }
 
-        $range = static::factory()::randomRangeOrCreate(0, 3, ['prop1' => 'b']);
+    /**
+     * @test
+     */
+    #[Test]
+    public function random_range_or_create_not_enough_object(): void
+    {
+        static::factory()->create(['prop1' => 'a']);
 
-        $this->assertGreaterThanOrEqual(0, \count($range));
+        $range = static::factory()::randomRangeOrCreate(2, 3);
+
+        $this->assertGreaterThanOrEqual(2, \count($range));
+        $this->assertLessThanOrEqual(3, \count($range));
+
+        static::factory()::assert()
+            ->exists(['prop1' => 'default1']);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function random_range_or_create_not_enough_object_with_criteria(): void
+    {
+        static::factory()->create(['prop1' => 'a']);
+        static::factory()->create(['prop1' => 'b']);
+
+        $range = static::factory()::randomRangeOrCreate(2, 3, ['prop1' => 'b']);
+
+        $this->assertGreaterThanOrEqual(2, \count($range));
         $this->assertLessThanOrEqual(3, \count($range));
 
         foreach ($range as $object) {
             $this->assertSame('b', $object->getProp1());
         }
+    }
 
-        static::factory()::truncate();
-        $range = static::factory()::randomRangeOrCreate(1, 2, ['prop1' => 'c']);
+    /**
+     * @test
+     */
+    #[Test]
+    public function random_range_or_create_no_object_with_criteria(): void
+    {
+        static::factory()->create(['prop1' => 'a']);
+        static::factory()->create(['prop1' => 'b']);
 
-        $this->assertGreaterThanOrEqual(1, \count($range));
-        $this->assertLessThanOrEqual(2, \count($range));
+        $range = static::factory()::randomRangeOrCreate(2, 3, ['prop1' => 'c']);
+
+        $this->assertGreaterThanOrEqual(2, \count($range));
+        $this->assertLessThanOrEqual(3, \count($range));
+
         foreach ($range as $object) {
             $this->assertSame('c', $object->getProp1());
         }


### PR DESCRIPTION
Hello,

It would be helpful to have a `randomRangeOrCreate` method.

In some cases, we want to use randomRange without having to manually check if the required objects already exist or peristence is available.