### PR TITLE
minor: fix running `phpunit` w/o arguments

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -75,7 +75,7 @@ case ${PHPUNIT_VERSION} in
     ;;
 esac
 
-PHPUNIT_EXEC="${PHPUNIT_EXEC} ${@}"
+PHPUNIT_EXEC="${PHPUNIT_EXEC} $*"
 
 echo "${PHPUNIT_EXEC}"
 $PHPUNIT_EXEC


### PR DESCRIPTION
I was getting a

> `./phpunit: line 78: @: unbound variable`

error when running `./phpunit` w/o args (with args it worked ok).

(This fix is an AI suggestion)