### PR TITLE
feat: `auto` ORM reset mode

### DIFF
--- a/src/ORM/ResetDatabase/AutoDatabaseResetter.php
+++ b/src/ORM/ResetDatabase/AutoDatabaseResetter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Zenstruck\Foundry\ORM\ResetDatabase;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\Migrations\DependencyFactory;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ * @internal
+ */
+final class AutoDatabaseResetter implements OrmResetter
+{
+    private OrmResetter $inner;
+
+    /**
+     * @param list<string> $configurations
+     */
+    public function __construct(
+        private readonly array $configurations,
+        private Registry $registry,
+        private array $managers,
+        private array $connections,
+        private ?DependencyFactory $dependencyFactory,
+    ) {
+    }
+
+    public function resetBeforeFirstTest(KernelInterface $kernel): void
+    {
+        $this->inner()->resetBeforeFirstTest($kernel);
+    }
+
+    public function resetBeforeEachTest(KernelInterface $kernel): void
+    {
+        $this->inner()->resetBeforeEachTest($kernel);
+    }
+
+    private function inner(): OrmResetter
+    {
+        if (isset($this->inner)) {
+            return $this->inner;
+        }
+
+        if (!$this->hasMigrations()) {
+            return $this->inner = new SchemaDatabaseResetter(
+                $this->registry,
+                $this->managers,
+                $this->connections,
+            );
+        }
+
+        return $this->inner = new MigrateDatabaseResetter(
+            $this->configurations,
+            $this->registry,
+            $this->managers,
+            $this->connections,
+        );
+    }
+
+    private function hasMigrations(): bool
+    {
+        if (!$this->dependencyFactory) {
+            return false;
+        }
+
+        return 0 !== $this->dependencyFactory->getMigrationPlanCalculator()->getMigrations()->count();
+    }
+}

--- a/src/ORM/ResetDatabase/ResetDatabaseMode.php
+++ b/src/ORM/ResetDatabase/ResetDatabaseMode.php
@@ -20,4 +20,10 @@ enum ResetDatabaseMode: string
 {
     case SCHEMA = 'schema';
     case MIGRATE = 'migrate';
+    case AUTO = 'auto';
+
+    public function requiresMigrationConfiguration(): bool
+    {
+        return self::SCHEMA !== $this;
+    }
 }

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,6 +26,7 @@ use Zenstruck\Foundry\InMemory\DependencyInjection\InMemoryCompilerPass;
 use Zenstruck\Foundry\InMemory\InMemoryRepository;
 use Zenstruck\Foundry\Mongo\MongoResetter;
 use Zenstruck\Foundry\Object\Instantiator;
+use Zenstruck\Foundry\ORM\ResetDatabase\AutoDatabaseResetter;
 use Zenstruck\Foundry\ORM\ResetDatabase\MigrateDatabaseResetter;
 use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
 use Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode;
@@ -404,10 +406,17 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
                 match ($resetMode) {
                     ResetDatabaseMode::SCHEMA => SchemaDatabaseResetter::class,
                     ResetDatabaseMode::MIGRATE => MigrateDatabaseResetter::class,
+                    ResetDatabaseMode::AUTO => AutoDatabaseResetter::class,
                 }
             );
 
-        if (ResetDatabaseMode::MIGRATE === $resetMode) {
+        if (ResetDatabaseMode::AUTO === $resetMode) {
+            $container->getDefinition(OrmResetter::class)
+                ->replaceArgument('$dependencyFactory', new Reference('doctrine.migrations.dependency_factory', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+            ;
+        }
+
+        if ($resetMode->requiresMigrationConfiguration()) {
             $container->getDefinition(OrmResetter::class)
                 ->replaceArgument('$configurations', $ormConfig['reset']['migrations']['configurations']);
         }


### PR DESCRIPTION
- if migrations enabled and available: `migrate`
- otherwise: `schema`

TODO
- [ ] Tests (2 permutations: `auto` w/o migrations, `auto` /w migrations)
- [ ] Docs
- [ ] Add `auto` to recipe?
- [ ] Deprecate not setting so we can default to `auto` in 3.0
- [ ] Throw exception when `migration_configurations` is used and mode !== migrate