### PR TITLE
minor: add UID types to factory maker

### DIFF
--- a/src/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
+++ b/src/Maker/Factory/DoctrineScalarFieldsDefaultPropertiesGuesser.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @internal
@@ -37,6 +38,7 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
         'DATETIMETZ_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),',
         'DECIMAL' => 'self::faker()->randomFloat(),',
         'FLOAT' => 'self::faker()->randomFloat(),',
+        'GUID' => 'self::faker()->uuid(),',
         'INTEGER' => 'self::faker()->randomNumber(),',
         'INT' => 'self::faker()->randomNumber(),',
         'JSON' => '[],',
@@ -47,6 +49,7 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
         'TEXT' => 'self::faker()->text({length}),',
         'TIME_MUTABLE' => 'self::faker()->datetime(),',
         'TIME_IMMUTABLE' => '\DateTimeImmutable::createFromMutable(self::faker()->datetime()),',
+        'UUID' => 'Uuid::fromString(self::faker()->uuid()),',
     ];
 
     public function __invoke(SymfonyStyle $io, MakeFactoryData $makeFactoryData, MakeFactoryQuery $makeFactoryQuery): void
@@ -83,6 +86,10 @@ final class DoctrineScalarFieldsDefaultPropertiesGuesser extends AbstractDoctrin
 
             $value = "null, // TODO add {$type} type manually";
             $length = $this->extractFieldMappingData($property, 'length', '');
+
+            if ('UUID' === $type) {
+                $makeFactoryData->addUse(Uuid::class);
+            }
 
             if (\array_key_exists($type, self::DEFAULTS)) {
                 $value = self::DEFAULTS[$type];

--- a/tests/Fixture/Entity/WithUidColumn.php
+++ b/tests/Fixture/Entity/WithUidColumn.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+class WithUidColumn extends Base
+{
+    #[ORM\Column(type: Types::GUID)]
+    private string $guid;
+
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $uuid;
+
+    public function __construct(string $guid, Uuid $uuid)
+    {
+        $this->guid = $guid;
+        $this->uuid = $uuid;
+    }
+
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    public function setGuid(string $guid): static
+    {
+        $this->guid = $guid;
+
+        return $this;
+    }
+
+    public function getUuid(): Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(Uuid $uuid): static
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+}

--- a/tests/Fixture/Maker/expected/can_create_factory_with_uid.php
+++ b/tests/Fixture/Maker/expected/can_create_factory_with_uid.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Factory;
+
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\WithUidColumn;
+
+/**
+ * @extends PersistentProxyObjectFactory<WithUidColumn>
+ */
+final class WithUidColumnFactory extends PersistentProxyObjectFactory
+{
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
+     *
+     * @todo inject services if required
+     */
+    public function __construct()
+    {
+    }
+
+    public static function class(): string
+    {
+        return WithUidColumn::class;
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
+     *
+     * @todo add your default values here
+     */
+    protected function defaults(): array|callable
+    {
+        return [
+            'guid' => self::faker()->uuid(),
+            'uuid' => Uuid::fromString(self::faker()->uuid()),
+        ];
+    }
+
+    /**
+     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
+     */
+    protected function initialize(): static
+    {
+        return $this
+            // ->afterInstantiate(function(WithUidColumn $withUidColumn): void {})
+        ;
+    }
+}

--- a/tests/Integration/Maker/MakeFactoryTest.php
+++ b/tests/Integration/Maker/MakeFactoryTest.php
@@ -24,6 +24,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Entity\WithEmbeddableEntity;
+use Zenstruck\Foundry\Tests\Fixture\Entity\WithUidColumn;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
 use Zenstruck\Foundry\Tests\Fixture\ObjectWithEnum;
 use Zenstruck\Foundry\Tests\Fixture\ObjectWithNonWriteable;
@@ -79,6 +80,27 @@ final class MakeFactoryTest extends MakerTestCase
         $this->assertStringContainsString('Note: pass --test if you want to generate factories in your tests/ directory', $output);
 
         $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/CategoryFactory.php'));
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_create_factory_with_uid(): void
+    {
+        if (!\getenv('DATABASE_URL')) {
+            self::markTestSkipped('doctrine/orm not enabled.');
+        }
+
+        $tester = $this->makeFactoryCommandTester();
+
+        $tester->execute(['class' => WithUidColumn::class]);
+
+        $output = $tester->getDisplay();
+
+        $this->assertStringContainsString('Note: pass --test if you want to generate factories in your tests/ directory', $output);
+
+        $this->assertFileFromMakerSameAsExpectedFile(self::tempFile('src/Factory/WithUidColumnFactory.php'));
     }
 
     /**


### PR DESCRIPTION
Adds defaults for Doctrine's GUID and Symfony's UUID types to the factory maker.