### PR TITLE
fix: resolve CI problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           dependency-versions: ${{ matrix.deps }}
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 7.1.*
+          SYMFONY_REQUIRE: 7.3.*
 
       - name: Set up MySQL
         if: contains(matrix.database, 'mysql')
@@ -230,7 +230,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.3
           coverage: none
           tools: flex
 
@@ -240,7 +240,7 @@ jobs:
           dependency-versions: highest
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 7.2.*
+          SYMFONY_REQUIRE: 7.3.*
 
       - name: Set up MySQL
         run: sudo /etc/init.d/mysql start

--- a/phpunit
+++ b/phpunit
@@ -72,6 +72,10 @@ case ${PHPUNIT_VERSION} in
     if [ "${USE_FOUNDRY_PHPUNIT_EXTENSION:-0}" = "1" ]; then
       PHPUNIT_EXEC="${PHPUNIT_EXEC} --extension "${FOUNDRY_EXTENSION}""
     fi
+
+    if [ "${PHPUNIT_VERSION}" = "12" ]; then
+      PHPUNIT_EXEC="${PHPUNIT_EXEC} --do-not-fail-on-phpunit-warning --do-not-fail-on-deprecation"
+    fi
     ;;
 esac
 

--- a/phpunit-deprecation-baseline.xml
+++ b/phpunit-deprecation-baseline.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0"?>
 <files version="1">
- <file path="vendor/symfony/deprecation-contracts/function.php">
-  <line number="25" hash="c6af5d66288d0667e424978000f29571e4954b81">
-   <issue><![CDATA[Since symfony/framework-bundle 6.4: Not setting the "framework.php_errors.log" config option is deprecated. It will default to "true" in 7.0.]]></issue>
-   <issue><![CDATA[Since symfony/var-exporter 7.3: Generating lazy proxy for class "Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage\SomeObject" is deprecated; leverage native lazy objects instead.]]></issue>
-  </line>
- </file>
+    <file path="vendor/symfony/deprecation-contracts/function.php">
+        <line number="25" hash="c6af5d66288d0667e424978000f29571e4954b81">
+            <issue><![CDATA[Since symfony/framework-bundle 6.4: Not setting the "framework.php_errors.log" config option is deprecated. It will default to "true" in 7.0.]]></issue>
+            <issue><![CDATA[Since symfony/var-exporter 7.3: Generating lazy proxy for class "Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage\SomeObject" is deprecated; leverage native lazy objects instead.]]></issue>
+        </line>
+    </file>
+    <file path="vendor/doctrine/deprecations/src/Deprecation.php">
+        <line number="208" hash="815824609bbd80ce3a5cc8a6a19c2e6dd0c6985c">
+            <issue><![CDATA[Using nullable columns in a primary key index is deprecated. (Table.php:182 called by Table.php:197, https://github.com/doctrine/dbal/pull/6787, package doctrine/dbal)]]></issue>
+        </line>
+    </file>
 </files>

--- a/phpunit-paratest.xml.dist
+++ b/phpunit-paratest.xml.dist
@@ -11,7 +11,7 @@
         <ini name="error_reporting" value="-1"/>
         <server name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixture\TestKernel"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <env name="PARATEST" value="1"/>
     </php>
     <testsuites>
         <testsuite name="main">

--- a/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
+++ b/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
@@ -75,13 +75,14 @@ trait ChangesEntityRelationshipCascadePersist
      */
     public static function provideCascadeRelationshipsCombinations(): iterable
     {
-        if (ConstraintRequirement::from('>=12')->isSatisfiedBy(PHPunitVersion::id())) {
+        // paratest does not still provide option --do-not-fail-on-phpunit-warning
+        // so we need to skip all relationships permutations for paratest
+        if (isset($_ENV['PARATEST'])) {
             yield []; // @phpstan-ignore generator.valueType
 
             return;
         }
 
-        // @phpstan-ignore deadCode.unreachable
         if (!\getenv('DATABASE_URL') || !self::$methodName) {
             // this test requires the ORM, but trait RequiresORM is analysed after data provider are called
             // then we need to return at least one empty array to avoid an error


### PR DESCRIPTION
- added `--do-not-fail-on-phpunit-warning` for PHPUnit 12 until PHPUnit 12.3 is released and [`#[IgnorePHPUnitWarnings]`](https://github.com/sebastianbergmann/phpunit/pull/6268) is available
- added `--do-not-fail-on-deprecation` for PHPUnit 12 until https://github.com/sebastianbergmann/phpunit/issues/6279 is resolved