### PR TITLE
feat: rename `foundry:load-stories` to `foundry:load-fixtures`

### DIFF
--- a/config/persistence.php
+++ b/config/persistence.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Zenstruck\Foundry\Command\LoadStoryCommand;
+use Zenstruck\Foundry\Command\LoadFixturesCommand;
 use Zenstruck\Foundry\Persistence\PersistenceManager;
 use Zenstruck\Foundry\Persistence\ResetDatabase\ResetDatabaseManager;
 
@@ -19,11 +19,11 @@ return static function (ContainerConfigurator $container): void {
                 tagged_iterator('.foundry.persistence.schema_resetter'),
             ])
 
-        ->set('.zenstruck_foundry.story.load_story-command', LoadStoryCommand::class)
+        ->set('.zenstruck_foundry.command.load_fixtures', LoadFixturesCommand::class)
             ->arg('$databaseResetters', tagged_iterator('.foundry.persistence.database_resetter'))
             ->arg('$kernel', service('kernel'))
             ->tag('console.command', [
-                'command' => 'foundry:load-stories|foundry:load-fixtures|foundry:load-story',
+                'command' => 'foundry:load-fixtures|foundry:load-stories|foundry:load-story',
                 'description' => 'Load stories which are marked with #[AsFixture] attribute.',
             ])
     ;

--- a/config/persistence.php
+++ b/config/persistence.php
@@ -23,8 +23,7 @@ return static function (ContainerConfigurator $container): void {
             ->arg('$databaseResetters', tagged_iterator('.foundry.persistence.database_resetter'))
             ->arg('$kernel', service('kernel'))
             ->tag('console.command', [
-                'command' => 'foundry:load-stories',
-                'aliases' => ['foundry:load-fixtures', 'foundry:load-fixture', 'foundry:load-story'],
+                'command' => 'foundry:load-stories|foundry:load-fixtures|foundry:load-story',
                 'description' => 'Load stories which are marked with #[AsFixture] attribute.',
             ])
     ;

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1526,9 +1526,9 @@ Local Development Fixtures
 
 .. versionadded:: 2.6
 
-    The ``foundry:load-stories`` command and ``#[AsFixture]`` attribute were added in 2.6.
+    The ``foundry:load-fixtures`` command and ``#[AsFixture]`` attribute were added in 2.6.
 
-Using ``bin/console foundry:load-stories``, you can load stories as fixtures in your database.
+Using ``bin/console foundry:load-fixtures``, you can load stories as fixtures in your database.
 This is mainly useful to load fixtures in "dev" mode.
 
 Mark `Stories`_ you want loaded by the command with the ``#[AsFixture]`` attribute:
@@ -1543,11 +1543,11 @@ Mark `Stories`_ you want loaded by the command with the ``#[AsFixture]`` attribu
         // ...
     }
 
-``bin/console foundry:load-stories category`` will now load the story ``CategoryStory`` in your database.
+``bin/console foundry:load-fixtures category`` will now load the story ``CategoryStory`` in your database.
 
 .. note::
 
-    If only a single story exists, you can omit the argument and just call ``bin/console foundry:load-stories`` to load it.
+    If only a single story exists, you can omit the argument and just call ``bin/console foundry:load-fixtures`` to load it.
 
 You can also load stories by group, by using the ``groups`` option:
 
@@ -1555,13 +1555,13 @@ You can also load stories by group, by using the ``groups`` option:
 
     use Zenstruck\Foundry\Attribute\AsFixture;
 
-    #[AsFixture(name: 'category', groups: ['all-stories'])]
+    #[AsFixture(name: 'category', groups: ['all'])]
     final class CategoryStory extends Story {}
 
-    #[AsFixture(name: 'post', groups: ['all-stories'])]
+    #[AsFixture(name: 'post', groups: ['all'])]
     final class PostStory extends Story {}
 
-``bin/console foundry:load-stories all-stories`` will load both stories ``CategoryStory`` and ``PostStory``.
+``bin/console foundry:load-fixtures all`` will load both stories ``CategoryStory`` and ``PostStory``.
 
 .. tip::
 

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -26,8 +26,10 @@ use Zenstruck\Foundry\Story;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
  */
-final class LoadStoryCommand extends Command
+final class LoadFixturesCommand extends Command
 {
     public function __construct(
         /** @var array<string, class-string<Story>> */

--- a/src/DependencyInjection/AsFixtureStoryCompilerPass.php
+++ b/src/DependencyInjection/AsFixtureStoryCompilerPass.php
@@ -20,7 +20,7 @@ final class AsFixtureStoryCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has('.zenstruck_foundry.story.load_story-command')) {
+        if (!$container->has('.zenstruck_foundry.command.load_fixtures')) {
             return;
         }
 
@@ -58,7 +58,7 @@ final class AsFixtureStoryCompilerPass implements CompilerPassInterface
             throw new LogicException("Cannot use #[AsFixture] group(s) \"{$collisionNames}\", they collide with fixture names.");
         }
 
-        $container->findDefinition('.zenstruck_foundry.story.load_story-command')
+        $container->findDefinition('.zenstruck_foundry.command.load_fixtures')
             ->setArgument('$stories', $fixtureStories)
             ->setArgument('$groupedStories', $groupedFixtureStories);
     }

--- a/tests/Integration/Command/LoadFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadFixturesCommandTest.php
@@ -30,7 +30,7 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 use function Zenstruck\Foundry\Persistence\repository;
 
-final class LoadStoryCommandTest extends KernelTestCase
+final class LoadFixturesCommandTest extends KernelTestCase
 {
     use Factories, RequiresORM, ResetDatabase;
 
@@ -280,10 +280,10 @@ final class LoadStoryCommandTest extends KernelTestCase
     {
         // randomly choose the real command name or an alias
         $commands = [
-            'foundry:load-stories',
-            'foundry:load-story',
             'foundry:load-fixtures',
             'foundry:load-fixture',
+            'foundry:load-stories',
+            'foundry:load-story',
         ];
 
         return new CommandTester((new Application(self::bootKernel($options)))->find(

--- a/tests/Integration/Command/LoadStoryCommandTest.php
+++ b/tests/Integration/Command/LoadStoryCommandTest.php
@@ -278,6 +278,16 @@ final class LoadStoryCommandTest extends KernelTestCase
 
     private function commandTester(array $options = []): CommandTester
     {
-        return new CommandTester((new Application(self::bootKernel($options)))->find('foundry:load-stories'));
+        // randomly choose the real command name or an alias
+        $commands = [
+            'foundry:load-stories',
+            'foundry:load-story',
+            'foundry:load-fixtures',
+            'foundry:load-fixture',
+        ];
+
+        return new CommandTester((new Application(self::bootKernel($options)))->find(
+            $commands[\array_rand($commands)]
+        ));
     }
 }


### PR DESCRIPTION
Ref: https://x.com/loic_425/status/1930565067394727947

30aa0046111235df706b2fef28d3c1ed75927f50 fixes a problem where the aliases weren't being registered.

The main command is `foundry:load-fixtures` with the following aliases:
1. `foundry:load-stories` (the previous command name)
2. `foundry:load-story`
3. `foundry:load-fixture` (not really an alias but *just* works)