### PR TITLE
fix: generated proxy code for methods with union or intersection return type

### DIFF
--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -129,11 +129,11 @@ final class ProxyGenerator
          * (?!__)                               # 4. Negative lookahead to exclude magic methods (like __serialize)
          * \w+                                  # 5. Method name
          * \s*\([^\)]*\)\s*                     # 6. Parameters inside parentheses (not captured)
-         * ):?\s*\??[\w\\\\]*                   # 7. Optional return type, can be nullable (starts with `?`), supports namespaced types (`\Foo\Bar`)
+         * ):?\s*\??[\w\\\\|&]*                 # 7. Optional return type, can be nullable (starts with `?`), supports namespaced types (`\Foo\Bar`), union types and intersection types
          * \s*\{\s*$                            # 8. Opening brace `{` at the end of the line, with optional spaces before
          */
         $proxyCode = \preg_replace_callback(
-            '/^(\s*(?:public|protected|private)?\s*function\s+(?!__)\w+\s*\([^\)]*\)\s*):?\s*\??[\w\\\\]*\s*\{\s*$/m',
+            '/^(\s*(?:public|protected|private)?\s*function\s+(?!__)\w+\s*\([^\)]*\)\s*):?\s*\??[\w\\\\|&]*\s*\{\s*$/m',
             fn($matches) => \rtrim($matches[0])."\n    \$this->_autoRefresh();",
             $proxyCode
         );

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -77,6 +77,27 @@ final class ProxyGeneratorTest extends TestCase
         $proxyfiedObj = ProxyGenerator::wrap(new ClassWithoutReturnType());
         self::assertSame(1, $proxyfiedObj->returnsSeomthing());
     }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_generate_proxy_for_class_with_method_with_union_return_type(): void
+    {
+        $proxyfiedObj = ProxyGenerator::wrap(new ClassWithUnionReturnType());
+        self::assertSame(1, $proxyfiedObj->returnsUnionType());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_generate_proxy_for_class_with_method_with_intersectionReturnType(): void
+    {
+        $proxyfiedObj = ProxyGenerator::wrap(new ClassWithInterSectionReturnType());
+        self::assertInstanceOf(One::class, $proxyfiedObj->returnsIntersectionType());
+        self::assertInstanceOf(Two::class, $proxyfiedObj->returnsIntersectionType());
+    }
 }
 
 class ClassWithNoTypeHintInUnserialize
@@ -114,5 +135,24 @@ class ClassWithSelfReturnType
     public function returnsSelf(): self
     {
         return $this;
+    }
+}
+
+class ClassWithUnionReturnType
+{
+    public function returnsUnionType(): int|string|\DateTimeImmutable
+    {
+        return 1;
+    }
+}
+
+interface One {}
+interface Two {}
+
+class ClassWithInterSectionReturnType
+{
+    public function returnsIntersectionType(): One&Two
+    {
+        return new class implements One, Two {};
     }
 }


### PR DESCRIPTION
A method with a union or intersection return type would miss the `$this->_autoRefresh();` call, as it would be missed by the regex. A missing auto refresh causes the following error in combination with symfony /var-exporter 7.3.0 or higher.

```
Error: Typed property Symfony\Component\VarExporter\Internal\LazyObjectState::$realInstance must not be accessed before initialization
```