### PR TITLE
fix: proxying of classes that have tenative return types

### DIFF
--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -124,16 +124,17 @@ final class ProxyGenerator
          * Add `$this->_autoRefresh();` after every method declaration.
          *
          * (\s*                                 # 1. Optional indentation
-         * (?:public|protected|private)?\s*     # 2. Optional visibility
-         * function\s+                          # 3. The "function" keyword followed by space
-         * (?!__)                               # 4. Negative lookahead to exclude magic methods (like __serialize)
-         * \w+                                  # 5. Method name
-         * \s*\([^\)]*\)\s*                     # 6. Parameters inside parentheses (not captured)
-         * ):?\s*\??[\w\\\\|&]*                 # 7. Optional return type, can be nullable (starts with `?`), supports namespaced types (`\Foo\Bar`), union types and intersection types
-         * \s*\{\s*$                            # 8. Opening brace `{` at the end of the line, with optional spaces before
+         * (?:#\[\\\ReturnTypeWillChange\]\s*)? # 2. Optional ReturnTypeWillChange attribute (This gets added by the ProxyHelper)
+         * (?:public|protected|private)?\s*     # 3. Optional visibility
+         * function\s+                          # 4. The "function" keyword followed by space
+         * (?!__)                               # 5. Negative lookahead to exclude magic methods (like __serialize)
+         * \w+                                  # 6. Method name
+         * \s*\([^\)]*\)\s*                     # 7. Parameters inside parentheses (not captured)
+         * ):?\s*\??[\w\\\\|&]*                 # 8. Optional return type, can be nullable (starts with `?`), supports namespaced types (`\Foo\Bar`), union types and intersection types
+         * \s*\{\s*$                            # 9. Opening brace `{` at the end of the line, with optional spaces before
          */
         $proxyCode = \preg_replace_callback(
-            '/^(\s*(?:public|protected|private)?\s*function\s+(?!__)\w+\s*\([^\)]*\)\s*):?\s*\??[\w\\\\|&]*\s*\{\s*$/m',
+            '/^(\s*(?:#\[\\\ReturnTypeWillChange\]\s*)?(?:public|protected|private)?\s*function\s+(?!__)\w+\s*\([^\)]*\)\s*):?\s*\??[\w\\\\|&]*\s*\{\s*$/m',
             fn($matches) => \rtrim($matches[0])."\n    \$this->_autoRefresh();",
             $proxyCode
         );

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -98,6 +98,16 @@ final class ProxyGeneratorTest extends TestCase
         self::assertInstanceOf(One::class, $proxyfiedObj->returnsIntersectionType());
         self::assertInstanceOf(Two::class, $proxyfiedObj->returnsIntersectionType());
     }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_generate_proxy_for_class_with_method_with_attribute_added_by_proxy_helper(): void
+    {
+        $proxyfiedObj = ProxyGenerator::wrap(new ClassWithAttributeAddedByProxyHelper());
+        self::assertSame(1, $proxyfiedObj->jsonSerialize());
+    }
 }
 
 class ClassWithNoTypeHintInUnserialize
@@ -158,5 +168,13 @@ class ClassWithInterSectionReturnType
     public function returnsIntersectionType(): One&Two
     {
         return new class implements One, Two {};
+    }
+}
+
+class ClassWithAttributeAddedByProxyHelper implements \JsonSerializable
+{
+    public function jsonSerialize(): mixed
+    {
+        return 1;
     }
 }


### PR DESCRIPTION
The symfony Proxy Helper will add a `ReturnTypeWillChange` attribute to methods with tenative return types.
The regex wasn't able to handle attributes on methods so it wouldn't add the `_autoRefresh`.
The 'best' example of this is jsonSerialize