### PR TITLE
feat: use ghost objects for auto refresh mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: P:${{ matrix.php }}, S:${{ matrix.symfony }}, D:${{ matrix.database }}, PU:${{ matrix.phpunit }}${{ matrix.deps == 'lowest' && ' (lowest)' || '' }}${{ matrix.use-phpunit-extension == 1 && ' (phpunit extension)' || '' }}
+    name: P:${{ matrix.php }}, S:${{ matrix.symfony }}, D:${{ matrix.database }}, PU:${{ matrix.phpunit }}${{ matrix.deps == 'lowest' && ' (lowest)' || '' }}${{ matrix.use-phpunit-extension == 1 && ' (phpunit extension)' || '' }}${{ (matrix.use-php-84-lazy-objects != 1 || matrix.php != '8.4') && ' (legacy proxy)' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -95,9 +95,6 @@ You'll also need to update the PHPDoc `@extends` annotation to use the new class
   - `_assertPersisted()` => `\Zenstruck\Foundry\Persistence\assert_persisted()`
   - `_assertNotPersisted()` => `\Zenstruck\Foundry\Persistence\assert_not_persisted()`
 
-> [!NOTE]
-> Calls to `Proxy::refresh()` also need to be replaced, but they are not covered by a Rector rule.
-
 - Remove `Proxy` type for parameters in the prototype in methods and functions (covered by `ChangeProxyParamTypesRector`).
 - Remove `Proxy` return type in methods and functions (covered by `ChangeProxyReturnTypesRector`).
 - Remove all `Proxy` type hints in PHPDoc (covered by `RemovePhpDocProxyTypeHintRector`).

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,7 +72,7 @@ parameters:
         # we're currently running static analysis with PHP 8.3
         - message: '#Call to an undefined method ReflectionClass\<(.*)\>::isUninitializedLazyObject\(\).#'
         - message: '#Call to an undefined method ReflectionClass\<(.*)\>::initializeLazyObject\(\).#'
-        - message: '#Call to an undefined method ReflectionClass\<(.*)\>::resetAsLazyProxy\(\).#'
+        - message: '#Call to an undefined method ReflectionClass\<(.*)\>::resetAsLazyGhost\(\).#'
 
     excludePaths:
         - tests/Fixture/Maker/expected/can_create_factory_with_auto_activated_not_persisted_option.php

--- a/phpunit-deprecation-baseline.xml
+++ b/phpunit-deprecation-baseline.xml
@@ -4,6 +4,8 @@
         <line number="25" hash="c6af5d66288d0667e424978000f29571e4954b81">
             <issue><![CDATA[Since symfony/framework-bundle 6.4: Not setting the "framework.php_errors.log" config option is deprecated. It will default to "true" in 7.0.]]></issue>
             <issue><![CDATA[Since symfony/var-exporter 7.3: Generating lazy proxy for class "Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage\SomeObject" is deprecated; leverage native lazy objects instead.]]></issue>
+            <issue><![CDATA[Since symfony/var-exporter 7.3: Using ProxyHelper::generateLazyGhost() is deprecated, use native lazy objects instead.]]></issue>
+            <issue><![CDATA[Since symfony/var-exporter 7.3: The "Symfony\Component\VarExporter\LazyGhostTrait" trait is deprecated, use native lazy objects instead.]]></issue>
             <issue><![CDATA[Since zenstruck/foundry 2.7: Proxy usage is deprecated in PHP 8.4. Use directly PersistentObjectFactory, Foundry now leverages the native PHP lazy system to auto-refresh objects.]]></issue>
             <issue><![CDATA[Since zenstruck/foundry 2.7: Proxy usage is deprecated in PHP 8.4. You should extend directly PersistentObjectFactory in your factories.
 Foundry now leverages the native PHP lazy system to auto-refresh objects (it can be enabled with "zenstruck_foundry.enable_auto_refresh_with_lazy_objects" configuration).

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -130,6 +130,7 @@ final class Configuration
     /** @param \Closure():self|self $configuration */
     public static function boot(\Closure|self $configuration): void
     {
+        PersistedObjectsTracker::reset();
         self::$instance = $configuration;
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -142,6 +142,7 @@ final class Configuration
 
     public static function shutdown(): void
     {
+        PersistedObjectsTracker::reset();
         StoryRegistry::reset();
         self::$instance = null;
     }

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -141,6 +141,29 @@ final class Hydrator
         return self::accessibleProperty($object, $property)->getValue($object);
     }
 
+    /**
+     * @template T of object
+     *
+     * @param T $object
+     * @param T $other
+     */
+    public static function hydrateFromOtherObject(object $object, object $other): void
+    {
+        $classes = [$object::class, ...\array_values(\class_parents($object))];
+
+        $properties = [];
+        foreach ($classes as $class) {
+            $reflector = new \ReflectionClass($class);
+            foreach ($reflector->getProperties() as $property) {
+                $properties[$property->getName()] = $property->getName();
+            }
+        }
+
+        foreach ($properties as $property) {
+            self::set($object, $property, self::get($other, $property), catchErrors: true);
+        }
+    }
+
     private static function accessibleProperty(object $object, string $name): \ReflectionProperty
     {
         $class = new \ReflectionClass($object);

--- a/src/Persistence/Exception/ObjectHasUnsavedChanges.php
+++ b/src/Persistence/Exception/ObjectHasUnsavedChanges.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Persistence\Exception;
+
+final class ObjectHasUnsavedChanges extends RefreshObjectFailed
+{
+    public function __construct(string $objectClass)
+    {
+        parent::__construct(
+            "Cannot auto refresh \"{$objectClass}\" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details)."
+        );
+    }
+}

--- a/src/Persistence/Exception/ObjectNoLongerExist.php
+++ b/src/Persistence/Exception/ObjectNoLongerExist.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Zenstruck\Foundry\Persistence\Exception;
 
-abstract class RefreshObjectFailed extends \RuntimeException
+final class ObjectNoLongerExist extends RefreshObjectFailed
 {
+    public function __construct(public readonly object $originalObject)
+    {
+        parent::__construct('object no longer exists...');
+    }
 }

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -16,7 +16,7 @@ use Zenstruck\Assert;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Object\Hydrator;
-use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
+use Zenstruck\Foundry\Persistence\Exception\ObjectNoLongerExist;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -152,10 +152,7 @@ trait IsProxy // @phpstan-ignore trait.unused
             // we don't want that "transparent" calls to _refresh() to trigger a PersistenceNotAvailable exception
             // or a RefreshObjectFailed exception when the object was deleted
             $this->_refresh();
-        } catch (PersistenceNotAvailable|RefreshObjectFailed $e) {
-            if ($e instanceof RefreshObjectFailed && false === $e->objectWasDeleted()) {
-                throw $e;
-            }
+        } catch (PersistenceNotAvailable|ObjectNoLongerExist) {
         }
     }
 

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -16,8 +16,11 @@ use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
+use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\ORM\AbstractORMPersistenceStrategy;
 use Zenstruck\Foundry\Persistence\Exception\NoPersistenceStrategy;
+use Zenstruck\Foundry\Persistence\Exception\ObjectHasUnsavedChanges;
+use Zenstruck\Foundry\Persistence\Exception\ObjectNoLongerExist;
 use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 use Zenstruck\Foundry\Persistence\Relationship\RelationshipMetadata;
 use Zenstruck\Foundry\Persistence\ResetDatabase\ResetDatabaseManager;
@@ -144,10 +147,49 @@ final class PersistenceManager
      * @template T of object
      *
      * @param T $object
+     */
+    public function autorefresh(object $object, object $clone): void
+    {
+        $strategy = $this->strategyFor($object::class);
+        $om = $strategy->objectManagerFor($object::class);
+
+        $id = $strategy->getIdentifierValues($clone);
+
+        if ($id) {
+            try {
+                $om->refresh($object);
+
+                if ($strategy->getIdentifierValues($object)) {
+                    // no identifier values means the object no longer exists
+                    return;
+                }
+            } catch (\Throwable $e) {
+            }
+
+            // let's detach the object, in order to prevent Doctrine cache
+            $om->detach($object);
+            if ($refreshedObject = $om->find($object::class, $id)) {
+                Hydrator::hydrateFromOtherObject($object, $refreshedObject);
+
+                return;
+            }
+        }
+
+        // the object no longer exists
+        Hydrator::hydrateFromOtherObject($object, $clone);
+        $om->detach($object);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param T $object
      *
      * @return T
+     *
+     * @throws RefreshObjectFailed
      */
-    public function refresh(object &$object, bool $force = false, bool $allowRefreshDeletedObject = false): object
+    public function refresh(object &$object, bool $force = false): object
     {
         if (!$this->flush && !$force) {
             return $object;
@@ -167,44 +209,35 @@ final class PersistenceManager
 
         $strategy = $this->strategyFor($object::class);
 
-        if ($strategy->hasChanges($object)) {
-            throw RefreshObjectFailed::objectHasUnsavedChanges($object::class);
-        }
-
-        $om = $strategy->objectManagerFor($object::class);
-
         if ($strategy->isEmbeddable($object)) {
             return $object;
         }
 
-        if (!$strategy->contains($object)) {
-            $objectFromDb = null;
-
-            $id = $om->getClassMetadata($object::class)->getIdentifierValues($object);
-
-            if ($id) {
-                // "merge" object if it is not managed
-                $objectFromDb = $om->find($object::class, $id);
-            }
-
-            if ($objectFromDb) {
-                $object = $objectFromDb;
-            } else {
-                if ($allowRefreshDeletedObject) {
-                    return $object;
-                }
-
-                throw RefreshObjectFailed::objectNoLongExists();
-            }
+        if ($strategy->hasChanges($object)) {
+            throw new ObjectHasUnsavedChanges($object::class);
         }
 
-        try {
-            $om->refresh($object);
-        } catch (\LogicException|\Error) {
-            // prevent entities/documents with readonly properties to create an error
-            // LogicException is for ORM / Error is for ODM
-            // @see https://github.com/doctrine/orm/issues/9505
+        $om = $strategy->objectManagerFor($object::class);
+
+        if ($strategy->contains($object)) {
+            try {
+                $om->refresh($object);
+            } catch (\LogicException|\Error) {
+                // prevent entities/documents with readonly properties to create an error
+                // LogicException is for ORM / Error is for ODM
+                // @see https://github.com/doctrine/orm/issues/9505
+            }
+
+            return $object;
         }
+
+        $id = $strategy->getIdentifierValues($object);
+
+        if (!$id || !($objectFromDB = $om->find($object::class, $id))) {
+            throw new ObjectNoLongerExist($object);
+        }
+
+        $object = $objectFromDB;
 
         return $object;
     }
@@ -223,8 +256,10 @@ final class PersistenceManager
             $object = $reflector->initializeLazyObject($object);
         }
 
+        $persistenceStrategy = $this->strategyFor($object::class);
+
         // prevents doctrine to use its cache and think the object is persisted
-        if ($this->strategyFor($object::class)->isScheduledForInsert($object)) {
+        if ($persistenceStrategy->isScheduledForInsert($object)) {
             return false;
         }
 
@@ -232,8 +267,8 @@ final class PersistenceManager
             $object = ProxyGenerator::unwrap($object);
         }
 
-        $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
-        $id = $om->getClassMetadata($object::class)->getIdentifierValues($object);
+        $om = $persistenceStrategy->objectManagerFor($object::class);
+        $id = $persistenceStrategy->getIdentifierValues($object);
 
         return $id && null !== $om->find($object::class, $id);
     }

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -80,6 +80,14 @@ abstract class PersistenceStrategy
     abstract public function truncate(string $class): void;
 
     /**
+     * @return array<string, mixed>
+     */
+    public function getIdentifierValues(object $object): array
+    {
+        return $this->classMetadata($object::class)->getIdentifierValues($object);
+    }
+
+    /**
      * @return list<string>
      */
     abstract public function managedNamespaces(): array;

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -475,7 +475,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         try {
             return $configuration->persistence()->refresh($object);
-        } catch (RefreshObjectFailed|VarExportLogicException) {
+        } catch (RefreshObjectFailed|VarExportLogicException) { // @phpstan-ignore catch.neverThrown (thrown by var exporter)
             return $object;
         }
     }

--- a/src/Persistence/Proxy/PersistedObjectsTracker.php
+++ b/src/Persistence/Proxy/PersistedObjectsTracker.php
@@ -63,10 +63,8 @@ final class PersistedObjectsTracker
                     }
 
                     $clone = clone $object;
-                    $reflector->resetAsLazyProxy($object, function() use ($clone, $reflector) {
-                        Configuration::instance()->persistence()->refresh($clone, allowRefreshDeletedObject: true);
-
-                        return $reflector->initializeLazyObject($clone);
+                    $reflector->resetAsLazyGhost($object, function($object) use ($clone) {
+                        Configuration::instance()->persistence()->autorefresh($object, $clone);
                     });
 
                     return \WeakReference::create($object);

--- a/src/Persistence/Proxy/PersistedObjectsTracker.php
+++ b/src/Persistence/Proxy/PersistedObjectsTracker.php
@@ -37,7 +37,7 @@ final class PersistedObjectsTracker
         }
     }
 
-    public function reset(): void
+    public static function reset(): void
     {
         self::$buffer = [];
     }

--- a/tests/Fixture/App/Controller/DeleteGenericModel.php
+++ b/tests/Fixture/App/Controller/DeleteGenericModel.php
@@ -41,4 +41,20 @@ final class DeleteGenericModel
 
         return new Response();
     }
+
+    #[Route('/orm/db/delete/{id}')]
+    public function ormDbDelete(EntityManagerInterface $entityManager, int $id): Response
+    {
+        $entityManager->getConnection()->delete('generic_entity', ['id' => $id]);
+
+        return new Response();
+    }
+
+    #[Route('/mongo/db/delete/{id}')]
+    public function mongoDbDelete(DocumentManager $documentManager, int $id): Response
+    {
+        $documentManager->getDocumentCollection(GenericDocument::class)->deleteOne(['_id' => $id]);
+
+        return new Response();
+    }
 }

--- a/tests/Fixture/App/Controller/UpdateGenericModel.php
+++ b/tests/Fixture/App/Controller/UpdateGenericModel.php
@@ -22,21 +22,21 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 #[AsController]
 final class UpdateGenericModel
 {
-    #[Route('/orm/update/{id}')]
-    public function ormDelete(EntityManagerInterface $entityManager, int $id): Response
+    #[Route('/orm/update/{id}/{newValue}')]
+    public function ormDelete(EntityManagerInterface $entityManager, int $id, string $newValue = 'foo'): Response
     {
         $genericEntity = $entityManager->find(GenericEntity::class, $id);
-        $genericEntity?->setProp1('foo');
+        $genericEntity?->setProp1($newValue);
         $entityManager->flush();
 
         return new Response();
     }
 
-    #[Route('/mongo/update/{id}')]
-    public function mongoDelete(DocumentManager $entityManager, int $id): Response
+    #[Route('/mongo/update/{id}/{newValue}')]
+    public function mongoDelete(DocumentManager $entityManager, int $id, string $newValue = 'foo'): Response
     {
         $genericDocument = $entityManager->find(GenericDocument::class, $id);
-        $genericDocument?->setProp1('foo');
+        $genericDocument?->setProp1($newValue);
         $entityManager->flush();
 
         return new Response();

--- a/tests/Fixture/Entity/Address.php
+++ b/tests/Fixture/Entity/Address.php
@@ -18,6 +18,7 @@ use Zenstruck\Foundry\Tests\Fixture\Model\Base;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[ORM\Entity]
+#[ORM\Table('address')]
 class Address extends Base
 {
     #[ORM\OneToOne(targetEntity: Contact::class, mappedBy: 'address')]

--- a/tests/Fixture/Entity/Category.php
+++ b/tests/Fixture/Entity/Category.php
@@ -20,6 +20,7 @@ use Zenstruck\Foundry\Tests\Fixture\Model\Base;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[ORM\Entity]
+#[ORM\Table('category')]
 class Category extends Base
 {
     /** @var Collection<int,Contact> */

--- a/tests/Integration/DataProvider/DataProviderInUnitTest.php
+++ b/tests/Integration/DataProvider/DataProviderInUnitTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Integration\DataProvider;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
@@ -30,7 +31,6 @@ use Zenstruck\Foundry\Tests\Fixture\Object1;
 use Zenstruck\Foundry\Tests\Fixture\Object2;
 
 use function Zenstruck\Foundry\faker;
-use function Zenstruck\Foundry\Persistence\unproxy;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -57,6 +57,7 @@ final class DataProviderInUnitTest extends TestCase
 
     #[Test]
     #[DataProvider('createObjectWithPersistentObjectFactoryInDataProvider')]
+    #[IgnoreDeprecations]
     public function assert_it_can_create_object_with_persistent_factory_in_data_provider(mixed $providedData, mixed $expectedData): void
     {
         self::assertEquals($expectedData, ProxyGenerator::unwrap($providedData));

--- a/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
@@ -31,8 +31,6 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyContactFactory
 use Zenstruck\Foundry\Tests\Fixture\InMemory\InMemoryContactRepository;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
-use function Zenstruck\Foundry\Persistence\unproxy;
-
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit 11.4

--- a/tests/Integration/DataProvider/DataProviderWithProxyFactoryInKernelTestCase.php
+++ b/tests/Integration/DataProvider/DataProviderWithProxyFactoryInKernelTestCase.php
@@ -27,8 +27,6 @@ use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 
-use function Zenstruck\Foundry\Persistence\unproxy;
-
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit >=11.4

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -17,6 +17,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
@@ -33,6 +34,22 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 {
     use RequiresMongo;
 
+    #[Test]
+    public function it_can_refresh_after_services_reset(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        self::assertSame('foo', $object->getProp1());
+
+        self::assertTrue($this->objectManager()->contains($object));
+    }
+
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();
@@ -45,12 +62,12 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 
     protected function updateObject(mixed $objectId): void
     {
-        $this->documentManager()->getDocumentCollection(GenericDocument::class)
+        $this->objectManager()->getDocumentCollection(GenericDocument::class)
             ->updateOne(['_id' => $objectId], ['$set' => ['prop1' => 'foo']])
         ;
     }
 
-    private function documentManager(): DocumentManager
+    protected function objectManager(): DocumentManager
     {
         return self::getContainer()->get(DocumentManager::class); // @phpstan-ignore return.type
     }

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -14,13 +14,21 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Integration\Mongo;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
-use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
 
+/**
+ * @requires PHPUnit >=12
+ */
+#[RequiresPhpunit('>=12')]
+#[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
+#[RequiresPhp('>= 8.4')]
 final class AutoRefreshTest extends AutoRefreshTestCase
 {
     use RequiresMongo;
@@ -35,10 +43,10 @@ final class AutoRefreshTest extends AutoRefreshTestCase
         return 'mongo';
     }
 
-    protected function updateObject(GenericModel $object): void
+    protected function updateObject(mixed $objectId): void
     {
         $this->documentManager()->getDocumentCollection(GenericDocument::class)
-            ->updateOne(['_id' => $object->id], ['$set' => ['prop1' => 'foo']])
+            ->updateOne(['_id' => $objectId], ['$set' => ['prop1' => 'foo']])
         ;
     }
 

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -14,27 +14,39 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Proxy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnorePhpunitWarnings;
+use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy\PersistedObjectsTracker;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineCascadeRelationship\ChangesEntityRelationshipCascadePersist;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineCascadeRelationship\UsingRelationships;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
-use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
+use function Zenstruck\Foundry\Persistence\refresh_all;
+
+/**
+ * @requires PHPUnit >=12
+ */
+#[RequiresPhpunit('>=12')]
+#[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
+#[RequiresPhp('>= 8.4')]
 final class AutoRefreshTest extends AutoRefreshTestCase
 {
-    use RequiresORM;
+    use ChangesEntityRelationshipCascadePersist, RequiresORM;
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function tracker_keeps_reference_only_for_objects_in_current_scope(): void
     {
         [$genericEntity] = GenericEntityFactory::new()->many(2)->create();
@@ -65,6 +77,63 @@ final class AutoRefreshTest extends AutoRefreshTestCase
         self::assertSame(0, PersistedObjectsTracker::countObjects());
     }
 
+    #[Test]
+    #[IgnorePhpunitWarnings(EdgeCasesRelationshipTest::DATA_PROVIDER_WARNING_REGEX)]
+    #[UsingRelationships(Contact::class, ['category', 'address'])]
+    #[DataProvider('provideCascadeRelationshipsCombinations')]
+    public function it_can_refresh_objects_with_relationships(): void
+    {
+        $contact = ContactFactory::createOne([
+            'address' => AddressFactory::new(['city' => 'city']),
+            'category' => CategoryFactory::new(['name' => 'name']),
+            'name' => 'name'
+        ]);
+
+        $address = $contact->getAddress();
+        $category = $contact->getCategory();
+
+        refresh_all();
+
+        self::assertTrue((new \ReflectionClass($contact))->isUninitializedLazyObject($contact));
+        self::assertTrue((new \ReflectionClass($address))->isUninitializedLazyObject($address));
+
+        self::assertNotNull($category);
+        self::assertTrue((new \ReflectionClass($category))->isUninitializedLazyObject($category));
+
+        self::assertSame($address, $contact->getAddress());
+        self::assertSame($category, $contact->getCategory());
+
+        self::assertSame('name', $contact->getCategory()->getName());
+        self::assertSame('city', $contact->getAddress()->getCity());
+    }
+
+    #[Test]
+    #[IgnorePhpunitWarnings(EdgeCasesRelationshipTest::DATA_PROVIDER_WARNING_REGEX)]
+    public function it_can_refresh_with_doctrine_proxies(): void
+    {
+        $contact = ContactFactory::createOne();
+
+        $address = $contact->getAddress();
+        $category = $contact->getCategory();
+
+        self::ensureKernelShutdown();
+
+        self::assertTrue((new \ReflectionClass($contact))->isUninitializedLazyObject($contact));
+        self::assertTrue((new \ReflectionClass($address))->isUninitializedLazyObject($address));
+
+        self::assertNotNull($category);
+        self::assertTrue((new \ReflectionClass($category))->isUninitializedLazyObject($category));
+
+        self::assertInstanceOf(Proxy::class, $contact->getAddress());
+        self::assertInstanceOf(Proxy::class, $contact->getCategory());
+
+        self::assertNotSame($address, $contact->getAddress());
+        self::assertNotSame($category, $contact->getCategory());
+
+        self::assertSame($address->getCity(), $contact->getAddress()->getCity());
+        self::assertSame($category->getName(), $contact->getCategory()->getName());
+    }
+
     protected static function factory(): PersistentObjectFactory
     {
         return GenericEntityFactory::new();
@@ -75,9 +144,12 @@ final class AutoRefreshTest extends AutoRefreshTestCase
         return 'orm';
     }
 
-    protected function updateObject(GenericModel $object): void
+    protected function updateObject(mixed $objectId): void
     {
-        $this->em()->getConnection()->executeQuery('UPDATE generic_entity SET prop1 = \'foo\' WHERE id = ?', [$object->id]);
+        $this->em()->getConnection()->executeQuery(
+            'UPDATE generic_entity SET prop1 = \'foo\' WHERE id = ?',
+            [$objectId]
+        );
     }
 
     private function em(): EntityManagerInterface

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -47,6 +47,23 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     use ChangesEntityRelationshipCascadePersist, RequiresORM;
 
     #[Test]
+    public function it_can_refresh_after_services_reset(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        self::assertSame('foo', $object->getProp1());
+
+        // service reset did clear the EM, thus the object is not managed anymore
+        self::assertFalse($this->objectManager()->contains($object));
+    }
+
+    #[Test]
     public function tracker_keeps_reference_only_for_objects_in_current_scope(): void
     {
         [$genericEntity] = GenericEntityFactory::new()->many(2)->create();
@@ -66,12 +83,11 @@ final class AutoRefreshTest extends AutoRefreshTestCase
         // after gc collect, all entities created by ContactFactory are removed from tracker
         self::assertSame(1, PersistedObjectsTracker::countObjects());
 
-        // refreshing again won't clear the tracked object because a reference still exists incurrent scope
+        // refreshing again won't clear the tracked object because a reference still exists in current scope
         Configuration::instance()->persistedObjectsTracker?->refresh();
         self::assertSame(1, PersistedObjectsTracker::countObjects());
 
         unset($genericEntity);
-        Configuration::instance()->persistedObjectsTracker?->refresh();
 
         // unsetting the generic entity will remove it from the tracker as well
         self::assertSame(0, PersistedObjectsTracker::countObjects());
@@ -86,7 +102,7 @@ final class AutoRefreshTest extends AutoRefreshTestCase
         $contact = ContactFactory::createOne([
             'address' => AddressFactory::new(['city' => 'city']),
             'category' => CategoryFactory::new(['name' => 'name']),
-            'name' => 'name'
+            'name' => 'name',
         ]);
 
         $address = $contact->getAddress();
@@ -115,13 +131,15 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 
         $address = $contact->getAddress();
         $category = $contact->getCategory();
+        self::assertNotNull($category);
+
+        $this->objectManager()->getConnection()->executeQuery('UPDATE address SET city = \'foo\' WHERE id = ?', [$address->id]);
+        $this->objectManager()->getConnection()->executeQuery('UPDATE category SET name = \'foo\' WHERE id = ?', [$category->id]);
 
         self::ensureKernelShutdown();
 
         self::assertTrue((new \ReflectionClass($contact))->isUninitializedLazyObject($contact));
         self::assertTrue((new \ReflectionClass($address))->isUninitializedLazyObject($address));
-
-        self::assertNotNull($category);
         self::assertTrue((new \ReflectionClass($category))->isUninitializedLazyObject($category));
 
         self::assertInstanceOf(Proxy::class, $contact->getAddress());
@@ -132,6 +150,9 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 
         self::assertSame($address->getCity(), $contact->getAddress()->getCity());
         self::assertSame($category->getName(), $contact->getCategory()->getName());
+
+        self::assertSame('foo', $address->getCity());
+        self::assertSame('foo', $category->getName());
     }
 
     protected static function factory(): PersistentObjectFactory
@@ -146,13 +167,13 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 
     protected function updateObject(mixed $objectId): void
     {
-        $this->em()->getConnection()->executeQuery(
+        $this->objectManager()->getConnection()->executeQuery(
             'UPDATE generic_entity SET prop1 = \'foo\' WHERE id = ?',
             [$objectId]
         );
     }
 
-    private function em(): EntityManagerInterface
+    protected function objectManager(): EntityManagerInterface
     {
         return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
     }

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -39,7 +39,6 @@ use Zenstruck\Foundry\Tests\Integration\ORM\EdgeCasesRelationshipTest;
 use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\Persistence\flush_after;
 use function Zenstruck\Foundry\Persistence\refresh;
-use function Zenstruck\Foundry\Persistence\unproxy;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -11,12 +11,14 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\Persistence;
 
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -46,20 +48,6 @@ abstract class AutoRefreshTestCase extends WebTestCase
     use Factories, ResetDatabase;
 
     #[Test]
-    public function it_can_refresh_after_services_reset(): void
-    {
-        $object = $this->factory()->create();
-        $objectId = $object->id;
-
-        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
-        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
-
-        $this->updateObject($objectId);
-
-        self::assertSame('foo', $object->getProp1());
-    }
-
-    #[Test]
     public function it_can_refresh_after_kernel_shutdown(): void
     {
         $object = $this->factory()->create();
@@ -71,6 +59,9 @@ abstract class AutoRefreshTestCase extends WebTestCase
         $this->updateObject($objectId);
 
         self::assertSame('foo', $object->getProp1());
+
+        // service reset did clear the EM, thus the object is not managed anymore
+        self::assertFalse($this->objectManager()->contains($object));
     }
 
     #[Test]
@@ -92,7 +83,7 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
-    public function it_can_refresh_objects_with_php84_proxies(): void
+    public function it_can_refresh_after_update_with_browser(): void
     {
         $client = self::createClient();
 
@@ -103,6 +94,8 @@ abstract class AutoRefreshTestCase extends WebTestCase
         $client->request('GET', "/{$this->dbms()}/update/{$object->id}");
         self::assertResponseIsSuccessful();
 
+        self::assertTrue($this->objectManager()->contains($object));
+
         self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
         assert_persisted($object);
         self::assertSame('foo', $object->getProp1());
@@ -110,15 +103,38 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
-    #[Depends('it_can_refresh_objects_with_php84_proxies')]
-    public function it_can_refresh_objects_with_php84_tracker_is_empty_after_test(): void
+    public function it_can_refresh_twice_after_update_with_browser(): void
+    {
+        $client = self::createClient();
+
+        $object = $this->factory()->create();
+        self::assertSame('default1', $object->getProp1());
+
+        $client->request('GET', "/{$this->dbms()}/update/{$object->id}/foo");
+        self::assertResponseIsSuccessful();
+        self::assertSame('foo', $object->getProp1());
+
+        $client->request('GET', "/{$this->dbms()}/update/{$object->id}/bar");
+        self::assertResponseIsSuccessful();
+        self::assertSame('bar', $object->getProp1());
+    }
+
+    #[Test]
+    #[Depends('it_can_refresh_after_update_with_browser')]
+    public function tracker_is_empty_after_test(): void
     {
         self::assertSame(0, PersistedObjectsTracker::countObjects());
     }
 
     #[Test]
-    public function deleting_an_object_does_not_create_a_refresh_error(): void
+    #[TestWith(['deleteDirectlyInDb' => false, 'clearOM' => true])]
+    #[TestWith(['deleteDirectlyInDb' => false, 'clearOM' => false])]
+    #[TestWith(['deleteDirectlyInDb' => true, 'clearOM' => true])]
+    #[TestWith(['deleteDirectlyInDb' => true, 'clearOM' => false])]
+    public function deleting_an_object_does_not_create_a_refresh_error(bool $deleteDirectlyInDb, bool $clearOM): void
     {
+        $client = self::createClient();
+
         $object = $this->factory()->create();
         $prop1 = $object->getProp1();
         assert_persisted($object);
@@ -126,11 +142,15 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertSame('default1', $object->getProp1());
         self::assertFalse((new \ReflectionClass($object))->isUninitializedLazyObject($object));
 
-        self::ensureKernelShutdown();
-
-        $client = self::createClient();
-        $client->request('GET', "/{$this->dbms()}/delete/{$object->id}");
+        $client->request(
+            'DELETE',
+            $deleteDirectlyInDb ? "/{$this->dbms()}/db/delete/{$object->id}" : "/{$this->dbms()}/delete/{$object->id}"
+        );
         self::assertResponseIsSuccessful();
+
+        if ($clearOM) {
+            $this->objectManager()->clear();
+        }
 
         self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
         self::assertSame($prop1, $object->getProp1());
@@ -140,10 +160,10 @@ abstract class AutoRefreshTestCase extends WebTestCase
     #[Test]
     public function it_can_refresh_the_same_object_multiple_times(): void
     {
-        $object = $this->factory()->create();
-        self::ensureKernelShutdown();
-
         $client = self::createClient();
+
+        $object = $this->factory()->create();
+
         $client->request('GET', "/{$this->dbms()}/update/{$object->id}");
         self::assertResponseIsSuccessful();
 
@@ -279,6 +299,8 @@ abstract class AutoRefreshTestCase extends WebTestCase
     abstract protected function dbms(): string;
 
     abstract protected function updateObject(mixed $objectId): void;
+
+    abstract protected function objectManager(): ObjectManager;
 
     protected static function createKernel(array $options = []): KernelInterface
     {

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -31,6 +31,7 @@ use Zenstruck\Foundry\Tests\Fixture\TestKernel;
 
 use function Zenstruck\Foundry\Persistence\assert_not_persisted;
 use function Zenstruck\Foundry\Persistence\assert_persisted;
+use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\refresh_all;
 
 /**
@@ -39,45 +40,66 @@ use function Zenstruck\Foundry\Persistence\refresh_all;
  */
 #[RequiresPhpunit('>=12')]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
+#[RequiresPhp('>= 8.4')]
 abstract class AutoRefreshTestCase extends WebTestCase
 {
     use Factories, ResetDatabase;
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function it_can_refresh_after_services_reset(): void
     {
         $object = $this->factory()->create();
-        self::ensureKernelShutdown();
-
-        $this->updateObject($object);
-
-        self::assertSame('default1', $object->getProp1());
+        $objectId = $object->id;
 
         self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
 
         self::assertSame('foo', $object->getProp1());
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
+    public function it_can_refresh_after_kernel_shutdown(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        self::ensureKernelShutdown();
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        self::assertSame('foo', $object->getProp1());
+    }
+
+    #[Test]
+    public function it_can_refresh_many_objects(): void
+    {
+        [$object1, $object2] = $this->factory()->many(2)->create();
+        $objectId1 = $object1->id;
+        $objectId2 = $object2->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object1))->isUninitializedLazyObject($object1));
+        self::assertTrue((new \ReflectionClass($object2))->isUninitializedLazyObject($object2));
+
+        $this->updateObject($objectId1);
+        $this->updateObject($objectId2);
+
+        self::assertSame('foo', $object1->getProp1());
+        self::assertSame('foo', $object2->getProp1());
+    }
+
+    #[Test]
     public function it_can_refresh_objects_with_php84_proxies(): void
     {
+        $client = self::createClient();
+
         $object = $this->factory()->create();
         self::assertSame('default1', $object->getProp1());
         self::assertFalse((new \ReflectionClass($object))->isUninitializedLazyObject($object));
 
-        self::ensureKernelShutdown();
-
-        $client = self::createClient();
         $client->request('GET', "/{$this->dbms()}/update/{$object->id}");
         self::assertResponseIsSuccessful();
 
@@ -87,28 +109,18 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertFalse((new \ReflectionClass($object))->isUninitializedLazyObject($object));
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     * @depends it_can_refresh_objects_with_php84_proxies
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     #[Depends('it_can_refresh_objects_with_php84_proxies')]
     public function it_can_refresh_objects_with_php84_tracker_is_empty_after_test(): void
     {
         self::assertSame(0, PersistedObjectsTracker::countObjects());
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function deleting_an_object_does_not_create_a_refresh_error(): void
     {
         $object = $this->factory()->create();
+        $prop1 = $object->getProp1();
         assert_persisted($object);
 
         self::assertSame('default1', $object->getProp1());
@@ -121,15 +133,11 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertResponseIsSuccessful();
 
         self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+        self::assertSame($prop1, $object->getProp1());
         assert_not_persisted($object);
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function it_can_refresh_the_same_object_multiple_times(): void
     {
         $object = $this->factory()->create();
@@ -151,12 +159,7 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertFalse((new \ReflectionClass($object))->isUninitializedLazyObject($object));
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function it_can_refresh_after_command_terminated(): void
     {
         $object = $this->factory()->create();
@@ -172,37 +175,23 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertSame('foo', $object->getProp1());
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function it_can_refresh_all_objects(): void
     {
         [$object1, $object2] = $this->factory()->many(2)->create();
-
-        self::ensureKernelShutdown();
-
-        $this->updateObject($object1);
-        $this->updateObject($object2);
-
-        self::assertSame('default1', $object1->getProp1());
-        self::assertSame('default1', $object2->getProp1());
+        $objectId1 = $object1->id;
+        $objectId2 = $object2->id;
 
         refresh_all();
+
+        $this->updateObject($objectId1);
+        $this->updateObject($objectId2);
 
         self::assertSame('foo', $object1->getProp1());
         self::assertSame('foo', $object2->getProp1());
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     * @dataProvider provideRepositoryMethod
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     #[DataProvider('provideRepositoryMethod')]
     public function it_can_refresh_objects_fetched_from_repository_decorator(string $methodName, array $params): void
     {
@@ -210,7 +199,7 @@ abstract class AutoRefreshTestCase extends WebTestCase
 
         $objectTracker = Configuration::instance()->persistedObjectsTracker;
         self::assertNotNull($objectTracker);
-        $objectTracker->reset();
+        PersistedObjectsTracker::reset();
 
         $objects = \call_user_func([$this->factory()::repository(), $methodName], ...$params); // @phpstan-ignore argument.type
         if (!\is_array($objects)) {
@@ -219,11 +208,10 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertGreaterThan(0, \count($objects));
         self::assertContainsOnlyInstancesOf(GenericModel::class, $objects);
 
-        self::ensureKernelShutdown();
+        $ids = \array_column($objects, 'id');
 
-        foreach ($objects as $object) {
-            $this->updateObject($object);
-            self::assertSame('default1', $object->getProp1());
+        foreach ($ids as $id) {
+            $this->updateObject($id);
         }
 
         refresh_all();
@@ -243,19 +231,14 @@ abstract class AutoRefreshTestCase extends WebTestCase
         yield ['findAll', []];
     }
 
-    /**
-     * @test
-     * @requires PHP >= 8.4
-     */
     #[Test]
-    #[RequiresPhp('>= 8.4')]
     public function it_can_refresh_object_fetched_find_and_id(): void
     {
         $id = $this->factory()->create()->id;
 
         $objectTracker = Configuration::instance()->persistedObjectsTracker;
         self::assertNotNull($objectTracker);
-        $objectTracker->reset();
+        PersistedObjectsTracker::reset();
 
         self::assertNull(
             $this->factory()::repository()->find(42)
@@ -264,13 +247,26 @@ abstract class AutoRefreshTestCase extends WebTestCase
         $object = $this->factory()::repository()->find($id);
         self::assertInstanceOf(GenericModel::class, $object);
 
-        self::ensureKernelShutdown();
-
-        $this->updateObject($object);
-
-        self::assertSame('default1', $object->getProp1());
+        $this->updateObject($id);
 
         refresh_all();
+
+        self::assertSame('foo', $object->getProp1());
+    }
+
+    #[Test]
+    public function it_can_refresh_lazy_object(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        refresh($object);
+        self::assertFalse((new \ReflectionClass($object))->isUninitializedLazyObject($object));
 
         self::assertSame('foo', $object->getProp1());
     }
@@ -282,7 +278,7 @@ abstract class AutoRefreshTestCase extends WebTestCase
 
     abstract protected function dbms(): string;
 
-    abstract protected function updateObject(GenericModel $object): void;
+    abstract protected function updateObject(mixed $objectId): void;
 
     protected static function createKernel(array $options = []): KernelInterface
     {

--- a/tests/Integration/Persistence/GenericRepositoryDecoratorTestCase.php
+++ b/tests/Integration/Persistence/GenericRepositoryDecoratorTestCase.php
@@ -22,7 +22,6 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 
 use function Zenstruck\Foundry\Persistence\repository;
-use function Zenstruck\Foundry\Persistence\unproxy;
 
 abstract class GenericRepositoryDecoratorTestCase extends KernelTestCase
 {

--- a/utils/rector/tests/RemovePhpDocProxyTypeHint/RemovePhpDocProxyTypeHintRectorTest.php
+++ b/utils/rector/tests/RemovePhpDocProxyTypeHint/RemovePhpDocProxyTypeHintRectorTest.php
@@ -28,7 +28,6 @@ final class RemovePhpDocProxyTypeHintRectorTest extends AbstractRectorTestCase
 
     public static function provideData(): \Iterator
     {
-        // todo
         return self::yieldFilesFromDirectory(__DIR__.'/Fixtures');
     }
 


### PR DESCRIPTION
Lazy ghost do not create identity problems, so they are more suited for our purpose.

I've also added a lot of tests, based on the different errors I had when testing the feature on a real life project