### PR TITLE
fix(autorefresh): return fresh data from RepositoryDecorator methods

### DIFF
--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -95,4 +95,32 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
 
         return $uow->isScheduledForInsert($object) || $uow->isScheduledForUpsert($object);
     }
+
+    public function findBy(string $class, array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+    {
+        $qb = $this->objectManagerFor($class)
+            ->getRepository($class)
+            ->createQueryBuilder()
+            ->refresh();
+
+        foreach ($criteria as $field => $value) {
+            $qb->field($field)->equals($value);
+        }
+
+        if ($orderBy) {
+            foreach ($orderBy as $field => $direction) {
+                $qb->sort($field, $direction);
+            }
+        }
+
+        if ($limit) {
+            $qb->limit($limit);
+        }
+
+        if ($offset) {
+            $qb->skip($offset);
+        }
+
+        return $qb->getQuery()->execute()->toArray(); // @phpstan-ignore method.nonObject
+    }
 }

--- a/src/ORM/AbstractORMPersistenceStrategy.php
+++ b/src/ORM/AbstractORMPersistenceStrategy.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\ORM;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
+use Doctrine\ORM\Query;
 use Doctrine\Persistence\Mapping\MappingException;
 use Zenstruck\Foundry\Persistence\PersistenceStrategy;
 
@@ -95,5 +96,34 @@ abstract class AbstractORMPersistenceStrategy extends PersistenceStrategy
         }
 
         return \array_values(\array_merge(...$namespaces));
+    }
+
+    final public function findBy(string $class, array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+    {
+        $qb = $this->objectManagerFor($class)->getRepository($class)->createQueryBuilder('o');
+
+        foreach ($criteria as $field => $value) {
+            $paramName = str_replace('.', '_', $field);
+            $qb->andWhere('o.'.$field.' = :'.$paramName);
+            $qb->setParameter($paramName, $value);
+        }
+
+        if ($orderBy) {
+            foreach ($orderBy as $field => $direction) {
+                $qb->addOrderBy('o.'.$field, $direction);
+            }
+        }
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        if ($offset) {
+            $qb->setFirstResult($offset);
+        }
+
+        return $qb->getQuery()
+            ->setHint(Query::HINT_REFRESH, true)
+            ->getResult();
     }
 }

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -413,6 +413,23 @@ final class PersistenceManager
         })();
     }
 
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     * @param array<string, mixed> $criteria
+     * @param array<string, string>|null $orderBy
+     * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'>|null $orderBy
+     *
+     * @return list<T>
+     */
+    public function findBy(string $class, array $criteria = [], ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+    {
+        $class = ProxyGenerator::unwrap($class);
+
+        return $this->strategyFor($class)->findBy($class, $criteria, $orderBy, $limit, $offset);
+    }
+
     private function flushAllStrategies(): void
     {
         foreach ($this->strategies as $strategy) {

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -93,6 +93,20 @@ abstract class PersistenceStrategy
     abstract public function managedNamespaces(): array;
 
     /**
+     * Uses a query builder to be able to pass hints to UoW and to force Doctrine to return fresh objects
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     * @param array<string, mixed> $criteria
+     * @param array<string, string>|null $orderBy
+     * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'>|null $orderBy
+     *
+     * @return list<T>
+     */
+    abstract public function findBy(string $class, array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array;
+
+    /**
      * @param class-string $owner
      *
      * @return array<string,mixed>|null

--- a/src/Persistence/Proxy/PersistedObjectsTracker.php
+++ b/src/Persistence/Proxy/PersistedObjectsTracker.php
@@ -21,9 +21,14 @@ final class PersistedObjectsTracker
     /**
      * This buffer of objects needs to be static to be kept between two kernel.reset events.
      *
-     * @var list<\WeakReference<object>>
+     * @var \WeakMap<object, bool>
      */
-    private static $buffer = [];
+    private static \WeakMap $buffer;
+
+    public function __construct()
+    {
+        self::$buffer ??= new \WeakMap();
+    }
 
     public function refresh(): void
     {
@@ -33,46 +38,37 @@ final class PersistedObjectsTracker
     public function add(object ...$objects): void
     {
         foreach ($objects as $object) {
-            self::$buffer[] = \WeakReference::create($object);
+            if (self::$buffer->offsetExists($object)) {
+                continue;
+            }
+
+            self::$buffer[$object] = true;
         }
     }
 
     public static function reset(): void
     {
-        self::$buffer = [];
+        self::$buffer = new \WeakMap();
     }
 
     public static function countObjects(): int
     {
-        return \count(
-            \array_filter(self::$buffer, static fn(\WeakReference $weakRef) => null !== $weakRef->get())
-        );
+        return \count(self::$buffer);
     }
 
     private static function proxifyObjects(): void
     {
-        self::$buffer = \array_values(
-            \array_map(
-                static function(\WeakReference $weakRef) {
-                    $object = $weakRef->get() ?? throw new \LogicException('Object cannot be null.');
+        foreach (self::$buffer as $object => $_) {
+            $reflector = new \ReflectionClass($object);
 
-                    $reflector = new \ReflectionClass($object);
+            if ($reflector->isUninitializedLazyObject($object)) {
+                continue;
+            }
 
-                    if ($reflector->isUninitializedLazyObject($object)) {
-                        return \WeakReference::create($object);
-                    }
-
-                    $clone = clone $object;
-                    $reflector->resetAsLazyGhost($object, function($object) use ($clone) {
-                        Configuration::instance()->persistence()->autorefresh($object, $clone);
-                    });
-
-                    return \WeakReference::create($object);
-                },
-
-                // remove all empty references
-                \array_filter(self::$buffer, static fn(\WeakReference $weakRef) => null !== $weakRef->get()),
-            )
-        );
+            $clone = clone $object;
+            $reflector->resetAsLazyGhost($object, function($object) use ($clone) {
+                Configuration::instance()->persistence()->autorefresh($object, $clone);
+            });
+        }
     }
 }

--- a/src/Persistence/RepositoryAssertions.php
+++ b/src/Persistence/RepositoryAssertions.php
@@ -113,7 +113,8 @@ final class RepositoryAssertions
 
     public function exists(mixed $criteria, string $message = 'Expected {entity} to exist but it does not.'): self
     {
-        Assert::that($this->repository->find($criteria))->isNotEmpty($message, [
+        Assert::that($this->repository->count($criteria))
+            ->isGreaterThan(0, $message, [
             'entity' => $this->repository->getClassName(),
             'criteria' => $criteria,
         ]);
@@ -123,10 +124,11 @@ final class RepositoryAssertions
 
     public function notExists(mixed $criteria, string $message = 'Expected {entity} to not exist but it does.'): self
     {
-        Assert::that($this->repository->find($criteria))->isEmpty($message, [
-            'entity' => $this->repository->getClassName(),
-            'criteria' => $criteria,
-        ]);
+        Assert::that($this->repository->count($criteria))
+            ->is(0, $message, [
+                'entity' => $this->repository->getClassName(),
+                'criteria' => $criteria,
+            ]);
 
         return $this;
     }

--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -100,7 +100,7 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
         /** @var T|null $object */
         $object = $this->inner()->find(ProxyGenerator::unwrap($id));
 
-        if ($object) {
+        if ($object && !$this instanceof ProxyRepositoryDecorator) {
             Configuration::instance()->persistedObjectsTracker?->add($object);
         }
 
@@ -120,14 +120,12 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
      */
     public function findAll(): array
     {
-        $objects = \array_values($this->inner()->findAll());
-
-        Configuration::instance()->persistedObjectsTracker?->add(...$objects);
-
-        return $objects;
+        return $this->findBy([]);
     }
 
     /**
+     * @param array<string, string>|null $orderBy
+     * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'>|null $orderBy
      * @param ?int $limit
      * @param ?int $offset
      *
@@ -135,9 +133,17 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
     {
-        $objects = \array_values($this->inner()->findBy($this->normalize($criteria), $orderBy, $limit, $offset));
+        if ($this->inMemory) {
+            $results = $this->inner()->findBy($this->normalize($criteria), $orderBy, $limit, $offset);
+        } else {
+            $results = Configuration::instance()->persistence()->findBy($this->class, $this->normalize($criteria), $orderBy, $limit, $offset);
+        }
 
-        Configuration::instance()->persistedObjectsTracker?->add(...$objects);
+        $objects = \array_values($results);
+
+        if (!$this instanceof ProxyRepositoryDecorator) {
+            Configuration::instance()->persistedObjectsTracker?->add(...$objects);
+        }
 
         return $objects;
     }
@@ -147,13 +153,7 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
      */
     public function findOneBy(array $criteria): ?object
     {
-        $object = $this->inner()->findOneBy($this->normalize($criteria));
-
-        if ($object) {
-            Configuration::instance()->persistedObjectsTracker?->add($object);
-        }
-
-        return $object;
+        return $this->findBy($criteria, limit: 1)[0] ?? null;
     }
 
     public function getClassName(): string
@@ -173,7 +173,7 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
             return $inner->count($this->normalize($criteria));
         }
 
-        return \count($this->findBy($criteria));
+        return \count($this->inner()->findBy($criteria));
     }
 
     public function truncate(): void

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -321,6 +321,30 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertSame('foo', $object->getProp1());
     }
 
+    #[Test]
+    public function repository_method_returns_up_to_date_objects(): void
+    {
+        [$object1, $object2] = $this->factory()->many(2)->create();
+
+        self::assertSame(2, PersistedObjectsTracker::countObjects());
+
+        $this->updateObject($object1->id);
+        $this->updateObject($object2->id);
+
+        [$newObject1, $newObject2] = $this->factory()::all();
+
+        self::assertSame(2, PersistedObjectsTracker::countObjects());
+
+        self::assertSame($object1, $newObject1);
+        self::assertSame($object2, $newObject2);
+
+        self::assertSame('foo', $newObject1->getProp1());
+        self::assertSame('foo', $newObject2->getProp1());
+
+        self::assertSame('foo', $object1->getProp1());
+        self::assertSame('foo', $object2->getProp1());
+    }
+
     /**
      * @return PersistentObjectFactory<GenericModel>
      */


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/975

The problem did exist before autorefresh with lazy objects, but we just never noticed it, and it was hidden by proxy mechanism :shrug: 

The root problem here is that `EntityRepository::findBy()` (and all other related methods like `findAll()`, etc..) do not actually return a fresh object if the object is already managed.

What's surprising is that Doctrine actually performs the query to the db, but it just don't hydrate the object, unless a hint is passed. This optimization is just here to prevent hydration. The behavior is the same [in ORM](https://github.com/doctrine/orm/blob/3.5.x/src/UnitOfWork.php#L2400) and [in ODM](https://github.com/doctrine/mongodb-odm/blob/2.13.x/lib/Doctrine/ODM/MongoDB/UnitOfWork.php#L2799) 

This is annoying, because hints can only be passed if a query builder is used. So we cannot use anymore `ObjectRepository::findBy()` and other nice helper methods 

