### PR TITLE
fix: handle readonly when refreshing from repository decorator

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -136,7 +136,14 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
         if ($this->inMemory) {
             $results = $this->inner()->findBy($this->normalize($criteria), $orderBy, $limit, $offset);
         } else {
-            $results = Configuration::instance()->persistence()->findBy($this->class, $this->normalize($criteria), $orderBy, $limit, $offset);
+            try {
+                $results = Configuration::instance()->persistence()->findBy($this->class, $this->normalize($criteria), $orderBy, $limit, $offset);
+            } catch (\LogicException|\Error) {
+                // prevent entities/documents with readonly properties to create an error
+                // LogicException is for ORM / Error is for ODM
+                // @see https://github.com/doctrine/orm/issues/9505
+                $results = $this->inner()->findBy($this->normalize($criteria), $orderBy, $limit, $offset);
+            }
         }
 
         $objects = \array_values($results);

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -19,10 +19,14 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 /**
  * @requires PHPUnit >=12
@@ -70,5 +74,13 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     protected function objectManager(): DocumentManager
     {
         return self::getContainer()->get(DocumentManager::class); // @phpstan-ignore return.type
+    }
+
+    /**
+     * @return PersistentObjectFactory<DocumentWithReadonly>
+     */
+    protected function objectWithReadonlyFactory(): PersistentObjectFactory // @phpstan-ignore method.childReturnType
+    {
+        return persistent_factory(DocumentWithReadonly::class);
     }
 }

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -23,11 +23,14 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy\PersistedObjectsTracker;
 use Zenstruck\Foundry\Tests\Fixture\DoctrineCascadeRelationship\ChangesEntityRelationshipCascadePersist;
 use Zenstruck\Foundry\Tests\Fixture\DoctrineCascadeRelationship\UsingRelationships;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithCloneMethod;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
@@ -35,7 +38,9 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
+use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\Persistence\persistent_factory;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 use function Zenstruck\Foundry\Persistence\refresh_all;
 
 /**
@@ -209,5 +214,13 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     protected function objectManager(): EntityManagerInterface
     {
         return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
+    }
+
+    /**
+     * @return PersistentObjectFactory<EntityWithReadonly>
+     */
+    protected function objectWithReadonlyFactory(): PersistentObjectFactory // @phpstan-ignore method.childReturnType
+    {
+        return persistent_factory(EntityWithReadonly::class);
     }
 }

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -25,12 +25,17 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy\PersistedObjectsTracker;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 use Zenstruck\Foundry\Tests\Fixture\TestKernel;
 
+use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\Persistence\assert_not_persisted;
 use function Zenstruck\Foundry\Persistence\assert_persisted;
 use function Zenstruck\Foundry\Persistence\refresh;
@@ -353,6 +358,25 @@ abstract class AutoRefreshTestCase extends WebTestCase
         self::assertSame('foo', $object2->getProp1());
     }
 
+    #[Test]
+    public function repository_method_returns_up_to_date_objects_with_readonly_props(): void
+    {
+        [$object1, $object2] = $this->objectWithReadonlyFactory()->many(2)->create([
+            'prop' => 1,
+            'embedded' => factory(Embeddable::class, ['prop1' => 'value1']),
+            'date' => new \DateTimeImmutable(),
+        ]);
+
+        self::assertSame(2, PersistedObjectsTracker::countObjects());
+
+        [$newObject1, $newObject2] = $this->objectWithReadonlyFactory()::all();
+
+        self::assertSame(2, PersistedObjectsTracker::countObjects());
+
+        self::assertSame($object1, $newObject1);
+        self::assertSame($object2, $newObject2);
+    }
+
     /**
      * @return PersistentObjectFactory<GenericModel>
      */
@@ -363,6 +387,11 @@ abstract class AutoRefreshTestCase extends WebTestCase
     abstract protected function updateObject(mixed $objectId): void;
 
     abstract protected function objectManager(): ObjectManager;
+
+    /**
+     * @return PersistentObjectFactory<DocumentWithReadonly|EntityWithReadonly>
+     */
+    abstract protected function objectWithReadonlyFactory(): PersistentObjectFactory;
 
     protected static function createKernel(array $options = []): KernelInterface
     {


### PR DESCRIPTION
short story: fixes a bug with reaonly that https://github.com/zenstruck/foundry/pull/983/ introduced which @smnandre reported.

long story: the [original issue](https://github.com/zenstruck/foundry/issues/975) stated that a simple `MyFactory::all()` returns outdated entities since auto refresh with lazy objects is released.

Actually, `MyFactory::all()` (and all its siblings from `RepositoryDecorator`) always return outdated object if the object is already managed. That's because Doctrine does not refresh an already managed entity, [unless the hint `HINT_REFRESH` is passed](https://github.com/doctrine/orm/blob/3.5.x/src/UnitOfWork.php#L2400).

With the proxy autrefresh mechanism, the problem was hidden:
```php
$myObjects = MyFactory::createMany(10, ['status' => Status::DRAFT]);

// [somehow change the status of those objects]

foreach (MyFactory::all() as $row) {
    self::assertSame(Status::UPDATED, $row->getStatus());
}
```
because `$row->getStatus()` was performing a `refresh()` (and a SQL query for EACH ITEM)

But with the hint now, we hit a [known doctrine problem](https://github.com/doctrine/orm/issues/9505) which we was [already handling](https://github.com/zenstruck/foundry/blob/2.x/src/Persistence/PersistenceManager.php#L229) in another place.

I made the decision to perform an extra query when we hit the readonly problem. This is not ideal, but we cannot know in advance whether we should pass the hint or not. 

fixes #994