### PR TITLE
Fix: Add defensive check to RepositoryDecorator::random() method

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -199,7 +199,13 @@ class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Coun
             $offset = \random_int(0, $count - 1);
         }
 
-        return $this->findBy($criteria, limit: 1, offset: $offset)[0];
+        $result = $this->findBy($criteria, limit: 1, offset: $offset);
+
+        if (!\count($result)) {
+            throw new NotEnoughObjects(\sprintf('At least %d "%s" object(s) must have been persisted (%d persisted).', 1, $this->getClassName(), 0));
+        }
+
+        return $result[0];
     }
 
     /**


### PR DESCRIPTION
- Add safety check to ensure findBy query returns results before accessing first element
- Prevent potential runtime errors in edge cases with race conditions
- Maintain consistent NotEnoughObjects exception handling
- No breaking changes to existing API or behavior

This enhancement improves the robustness of the random method by adding a defensive check that verifies the actual query results, not just the count, before attempting to access the first element. This prevents potential runtime errors in scenarios where count() might indicate objects exist but the actual query returns no results.