### PR TITLE
Fix edge case with Doctrine Middleware & early kernel boot

### DIFF
--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -37,7 +37,7 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
 {
     public function boot(): void
     {
-        if ($this->container && !Configuration::isBooted()) {
+        if ($this->container) {
             Configuration::boot($this->container->get('.zenstruck_foundry.configuration')); // @phpstan-ignore argument.type
         }
     }

--- a/tests/Fixture/ResetDatabase/DoctrineMiddleware.php
+++ b/tests/Fixture/ResetDatabase/DoctrineMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\ResetDatabase;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class DoctrineMiddleware implements Middleware
+{
+    public function __construct(
+        private KernelInterface $kernel, // @phpstan-ignore property.onlyWritten
+    ) {
+    }
+
+    public function wrap(Driver $driver): Driver
+    {
+        return $driver;
+    }
+}

--- a/tests/Fixture/ResetDatabase/ResetDatabaseTestKernel.php
+++ b/tests/Fixture/ResetDatabase/ResetDatabaseTestKernel.php
@@ -64,6 +64,10 @@ final class ResetDatabaseTestKernel extends FoundryTestKernel
 
         $c->register(GlobalInvokableService::class);
 
+        $c->register(DoctrineMiddleware::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true);
+
         if (self::hasORM()) {
             $c->register(OrmResetterDecorator::class)->setAutowired(true)->setAutoconfigured(true);
         }

--- a/tests/Integration/ResetDatabase/EarlyBootedKernelTest.php
+++ b/tests/Integration/ResetDatabase/EarlyBootedKernelTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ResetDatabase;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\ResetDatabase\DoctrineMiddleware;
+
+/**
+ * @requires PHPUnit >=11.3
+ */
+#[RequiresPhpunit('>=11.3')]
+final class EarlyBootedKernelTest extends ResetDatabaseTestCase
+{
+    /**
+     * Needs to happen before {@see ResetDatabase::_resetDatabaseBeforeFirstTest()}.
+     */
+    #[BeforeClass(10)]
+    public static function before(): void
+    {
+        self::bootKernel();
+    }
+
+    #[Test]
+    public function connection_uses_doctrine_middleware(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        self::assertContains(
+            DoctrineMiddleware::class,
+            \array_map(static fn(Middleware $middleware) => $middleware::class, $connection->getConfiguration()->getMiddlewares())
+        );
+    }
+}


### PR DESCRIPTION
This fixes an edge case that occurs when Doctrine requires the `kernel` service (or any other synthetic one) and the kernel is booted before `ResetDatabase::_resetDatabaseBeforeFirstTest()`.

Error example:

> 1) Zenstruck\Foundry\Tests\Integration\ResetDatabase\EarlyBootedKernelTest
> Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The "kernel" service is synthetic, it needs to be set at boot time before it can be used.

This happens because when [`ResetDatabaseManager` calls `self::bootKernel()`](https://github.com/zenstruck/foundry/blob/2c84cb0c2e09679562cd33e90e66559dae014d7b/src/Test/ResetDatabase.php#L36), the old [kernel is shut down](https://github.com/symfony/symfony/blob/944969c20417aa6421b555c08833540d368f3752/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php#L72), but a reference to its container (which no longer has the `kernel` service) remains. The new container instance is never used because of `Configuration::isBooted()`.
