### PR TITLE
fix: 🐛 use isser instead of constructor to apply autorefresh setting to Factory

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -51,14 +51,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
     private bool $isRootFactory = true;
 
-    private bool $autorefreshEnabled = false;
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->autorefreshEnabled = Configuration::autoRefreshWithLazyObjectsIsEnabled();
-    }
+    private bool|null $autorefreshEnabled = null;
 
     /**
      * @phpstan-param mixed|Parameters $criteriaOrId
@@ -525,7 +518,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
                     }
 
                     if (
-                        $factoryUsed->autorefreshEnabled
+                        $factoryUsed->isAutorefreshEnabled()
                         && !$factoryUsed instanceof PersistentProxyObjectFactory
                     ) {
                         Configuration::instance()->persistedObjectsTracker?->add($object);
@@ -543,6 +536,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
                 }
             )
         ;
+    }
+
+    private function isAutorefreshEnabled(): bool
+    {
+        return $this->autorefreshEnabled ??= Configuration::autoRefreshWithLazyObjectsIsEnabled();
     }
 
     private function throwIfCannotCreateObject(): void


### PR DESCRIPTION
Although [`PersistentObjectFactory` has a constructor](https://github.com/zenstruck/foundry/blob/e5bda6bc3b19fe8eb0ab6341b5e545294ead0098/src/Persistence/PersistentObjectFactory.php#L56-L61), the template of Factory that inherit from it is missing `parent::__construct()` call. This PR adds that. Thanks.