### PR TITLE
Accept as story any descendants of Story, not only direct descendants

### DIFF
--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -445,7 +445,7 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
             AsFixture::class,
             // @phpstan-ignore argument.type
             static function(ChildDefinition $definition, AsFixture $attribute, \ReflectionClass $reflector) {
-                if (false === $reflector->getParentClass() || Story::class !== $reflector->getParentClass()->getName()) {
+                if (false === $reflector->isSubclassOf(Story::class)) {
                     throw new LogicException(\sprintf('Only stories can be marked with "%s" attribute, class "%s" is not a story.', AsFixture::class, $reflector->getName()));
                 }
 


### PR DESCRIPTION
This small change will let users create an abstract Story class, for example, and use this abstract class for their own Stories.