### PR TITLE
fix: RepositoryAssertion::exist() $criteria should allow mixed

### DIFF
--- a/src/Persistence/RepositoryAssertions.php
+++ b/src/Persistence/RepositoryAssertions.php
@@ -113,22 +113,20 @@ final class RepositoryAssertions
 
     public function exists(mixed $criteria, string $message = 'Expected {entity} to exist but it does not.'): self
     {
-        Assert::that($this->repository->count($criteria))
-            ->isGreaterThan(0, $message, [
-                'entity' => $this->repository->getClassName(),
-                'criteria' => $criteria,
-            ]);
+        Assert::that($this->repository->find($criteria))->isNotEmpty($message, [
+            'entity' => $this->repository->getClassName(),
+            'criteria' => $criteria,
+        ]);
 
         return $this;
     }
 
     public function notExists(mixed $criteria, string $message = 'Expected {entity} to not exist but it does.'): self
     {
-        Assert::that($this->repository->count($criteria))
-            ->is(0, $message, [
-                'entity' => $this->repository->getClassName(),
-                'criteria' => $criteria,
-            ]);
+        Assert::that($this->repository->find($criteria))->isEmpty($message, [
+            'entity' => $this->repository->getClassName(),
+            'criteria' => $criteria,
+        ]);
 
         return $this;
     }

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -490,7 +490,7 @@ abstract class GenericFactoryTestCase extends KernelTestCase
         $assert->empty();
         $assert->empty(['prop1' => 'a']);
 
-        static::factory()::createOne(['prop1' => 'a']);
+        $object = static::factory()::createOne(['prop1' => 'a']);
         static::factory()::createOne(['prop1' => 'b']);
         static::factory()::createOne(['prop1' => 'b']);
 
@@ -508,6 +508,9 @@ abstract class GenericFactoryTestCase extends KernelTestCase
         $assert->countLessThanOrEqual(2, ['prop1' => 'b']);
         $assert->exists(['prop1' => 'a']);
         $assert->notExists(['prop1' => 'c']);
+
+        $assert->exists($object->id);
+        $assert->notExists(999);
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/1004