### PR TITLE
fix: only use PersistedObjectsTracker when auto-refresh is enabled

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -140,6 +140,10 @@ final class Configuration
         self::$instance->bootedForDataProvider = true;
     }
 
+    /**
+     * /!\ Until PHPUnit 9 support is not dropped, this method MUST NOT call Configuration::instance()
+     * Otherwise, it will reboot the kernel, leading to complex bugs
+     */
     public static function shutdown(): void
     {
         PersistedObjectsTracker::reset();

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -86,7 +86,9 @@ final class PersistenceManager
             $this->flush($om);
         }
 
-        PersistedObjectsTracker::updateIds();
+        if (Configuration::instance()->autoRefreshWithLazyObjectsIsEnabled()) {
+            Configuration::instance()->persistedObjectsTracker?->updateIds();
+        }
 
         return $object;
     }
@@ -426,7 +428,10 @@ final class PersistenceManager
                 $this->flush($om);
             }
         }
-        PersistedObjectsTracker::updateIds();
+
+        if (Configuration::instance()->autoRefreshWithLazyObjectsIsEnabled()) {
+            Configuration::instance()->persistedObjectsTracker?->updateIds();
+        }
     }
 
     /**

--- a/src/Persistence/Proxy/PersistedObjectsTracker.php
+++ b/src/Persistence/Proxy/PersistedObjectsTracker.php
@@ -48,7 +48,7 @@ final class PersistedObjectsTracker
         }
     }
 
-    public static function updateIds(): void
+    public function updateIds(): void
     {
         foreach (self::$buffer as $object => $id) {
             if ($id) {

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -460,7 +460,9 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
 
         if (null === $enableAutoRefreshWithLazyObjects && \PHP_VERSION_ID >= 80400) {
             trigger_deprecation('zenstruck/foundry', '2.7', 'Not setting a value for "zenstruck_foundry.enable_auto_refresh_with_lazy_objects" is deprecated. This option will be forced to true in 3.0.');
+        }
 
+        if ($container->has('.foundry.persistence.objects_tracker') && !$enableAutoRefreshWithLazyObjects) {
             $container->removeDefinition('.foundry.persistence.objects_tracker');
         }
     }


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/1012