### PR TITLE
fix: auto-refresh with Mongo after DoctrineMongoDBBundle 5.4.3

### DIFF
--- a/src/Persistence/Proxy/PersistedObjectsTracker.php
+++ b/src/Persistence/Proxy/PersistedObjectsTracker.php
@@ -51,6 +51,11 @@ final class PersistedObjectsTracker
     public function updateIds(): void
     {
         foreach (self::$buffer as $object => $id) {
+            if (is_array($id)) {
+                // in mongodb, id can be an array with null values, which is not a valid id and must be updated
+                $id = array_filter($id);
+            }
+
             if ($id) {
                 continue;
             }

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -37,22 +37,6 @@ final class AutoRefreshTest extends AutoRefreshTestCase
 {
     use RequiresMongo;
 
-    #[Test]
-    public function it_can_refresh_after_services_reset(): void
-    {
-        $object = $this->factory()->create();
-        $objectId = $object->id;
-
-        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
-        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
-
-        $this->updateObject($objectId);
-
-        self::assertSame('foo', $object->getProp1());
-
-        self::assertTrue($this->objectManager()->contains($object));
-    }
-
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -50,23 +50,6 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     use ChangesEntityRelationshipCascadePersist, RequiresORM;
 
     #[Test]
-    public function it_can_refresh_after_services_reset(): void
-    {
-        $object = $this->factory()->create();
-        $objectId = $object->id;
-
-        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
-        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
-
-        $this->updateObject($objectId);
-
-        self::assertSame('foo', $object->getProp1());
-
-        // service reset did clear the EM, thus the object is not managed anymore
-        self::assertFalse($this->objectManager()->contains($object));
-    }
-
-    #[Test]
     public function tracker_keeps_reference_only_for_objects_in_current_scope(): void
     {
         [$genericEntity] = GenericEntityFactory::new()->many(2)->create();

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -53,6 +53,23 @@ abstract class AutoRefreshTestCase extends WebTestCase
     use Factories, ResetDatabase;
 
     #[Test]
+    public function it_can_refresh_after_services_reset(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        self::assertSame('foo', $object->getProp1());
+
+        // service reset did clear the EM, thus the object is not managed anymore
+        self::assertFalse($this->objectManager()->contains($object));
+    }
+
+    #[Test]
     public function it_can_refresh_after_kernel_shutdown(): void
     {
         $object = $this->factory()->create();


### PR DESCRIPTION
https://github.com/doctrine/DoctrineMongoDBBundle/releases/tag/5.4.3 did introduce some problems with auto refresh and Mongo