### PR TITLE
chore: skip legacy proxy tests using #[RequiresMethod]

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -88,10 +88,6 @@ case ${PHPUNIT_VERSION} in
     if [ "${WITH_LOWEST_DEPENDENCIES:-0}" = "1" ]; then
       PHPUNIT_EXEC="${PHPUNIT_EXEC} --do-not-fail-on-deprecation --do-not-fail-on-phpunit-deprecation"
     fi
-
-    if [ "$(can_use_legacy_proxies)" = "0" ]; then
-      PHPUNIT_EXEC="${PHPUNIT_EXEC} --exclude-group legacy-proxy"
-    fi
     ;;
 esac
 

--- a/phpunit-deprecation-baseline.xml
+++ b/phpunit-deprecation-baseline.xml
@@ -7,6 +7,7 @@
             <issue><![CDATA[Since symfony/var-exporter 7.3: Generating lazy proxy for class "Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage\SomeObject" is deprecated; leverage native lazy objects instead.]]></issue>
             <issue><![CDATA[Since symfony/var-exporter 7.3: Using ProxyHelper::generateLazyGhost() is deprecated, use native lazy objects instead.]]></issue>
             <issue><![CDATA[Since symfony/var-exporter 7.3: The "Symfony\Component\VarExporter\LazyGhostTrait" trait is deprecated, use native lazy objects instead.]]></issue>
+            <issue><![CDATA[Since symfony/var-exporter 7.3: The "Symfony\Component\VarExporter\LazyProxyTrait" trait is deprecated, use native lazy objects instead.]]></issue>
 
             <issue><![CDATA[Since zenstruck/foundry 2.7: Proxy usage is deprecated in PHP 8.4. Use directly PersistentObjectFactory, Foundry now leverages the native PHP lazy system to auto-refresh objects.]]></issue>
             <issue><![CDATA[Since zenstruck/foundry 2.7: Proxy usage is deprecated in PHP 8.4. You should extend directly PersistentObjectFactory in your factories.

--- a/tests/Integration/DataProvider/DataProviderWithPersistentFactoryInKernelTestCase.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentFactoryInKernelTestCase.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Tests\Integration\DataProvider;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
@@ -46,7 +47,7 @@ abstract class DataProviderWithPersistentFactoryInKernelTestCase extends KernelT
 
     #[Test]
     #[DataProvider('createOneProxyObjectInDataProvider')]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
     {
         static::proxyFactory()::assert()->count(1);
@@ -58,12 +59,6 @@ abstract class DataProviderWithPersistentFactoryInKernelTestCase extends KernelT
 
     public static function createOneProxyObjectInDataProvider(): iterable
     {
-        if (!TestKernel::canUseLegacyProxy()) {
-            yield [null];
-
-            return;
-        }
-
         yield 'createOne()' => [
             static::proxyFactory()::createOne(['prop1' => 'value set in data provider']),
         ];
@@ -75,7 +70,7 @@ abstract class DataProviderWithPersistentFactoryInKernelTestCase extends KernelT
 
     #[Test]
     #[DataProvider('createMultipleObjectsInDataProvider')]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
     {
         self::assertIsArray($providedData);
@@ -86,12 +81,6 @@ abstract class DataProviderWithPersistentFactoryInKernelTestCase extends KernelT
 
     public static function createMultipleObjectsInDataProvider(): iterable
     {
-        if (!TestKernel::canUseLegacyProxy()) {
-            yield [[]];
-
-            return;
-        }
-
         yield 'createSequence()' => [
             static::proxyFactory()::createSequence([
                 ['prop1' => 'prop 1'],
@@ -109,7 +98,7 @@ abstract class DataProviderWithPersistentFactoryInKernelTestCase extends KernelT
 
     #[Test]
     #[DataProvider('useGetterOnProxyObjectCreatedInDataProvider')]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function assert_using_getter_proxy_object_created_in_a_data_provider_throws(?\Throwable $e): void
     {
         self::assertInstanceOf(\LogicException::class, $e);

--- a/tests/Integration/DataProvider/GenericEntityProxyFactoryTest.php
+++ b/tests/Integration/DataProvider/GenericEntityProxyFactoryTest.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Tests\Integration\DataProvider;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
@@ -28,7 +29,7 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[RequiresPhpunit('>=11.4')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class GenericEntityProxyFactoryTest extends DataProviderWithPersistentFactoryInKernelTestCase
 {
     use RequiresORM;

--- a/tests/Integration/ForceFactoriesTraitUsage/ClassExtendingBaseTestCaseNotUsingFactoriesTest.php
+++ b/tests/Integration/ForceFactoriesTraitUsage/ClassExtendingBaseTestCaseNotUsingFactoriesTest.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -28,7 +29,7 @@ final class ClassExtendingBaseTestCaseNotUsingFactoriesTest extends AnotherBaseT
 
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function using_foundry_should_trigger_deprecation(): void
     {
         $this->assertDeprecation();

--- a/tests/Integration/ForceFactoriesTraitUsage/ClassExtendingBaseTestCaseUsingFactoriesTest.php
+++ b/tests/Integration/ForceFactoriesTraitUsage/ClassExtendingBaseTestCaseUsingFactoriesTest.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Tests\Integration\ForceFactoriesTraitUsage;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -26,7 +27,7 @@ use function Zenstruck\Foundry\Persistence\proxy;
 final class ClassExtendingBaseTestCaseUsingFactoriesTest extends KernelTestCaseWithFactoriesTraitBaseTestCase
 {
     #[Test]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function not_using_foundry_should_not_throw(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
+++ b/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Tests\Integration\InMemory;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
@@ -183,7 +184,7 @@ final class DoctrineInMemoryDecoratorTest extends KernelTestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function it_can_find_by_entity_proxified(): void
     {
         ContactFactory::createMany(2, fn() => ['category' => CategoryFactory::createOne()]);

--- a/tests/Integration/Mongo/GenericDocumentProxyFactoryTest.php
+++ b/tests/Integration/Mongo/GenericDocumentProxyFactoryTest.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Tests\Integration\Mongo;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericProxyDocumentFactory;
@@ -25,7 +26,7 @@ use function Zenstruck\Foundry\Persistence\proxy_factory;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class GenericDocumentProxyFactoryTest extends GenericProxyFactoryTestCase
 {
     use RequiresMongo;

--- a/tests/Integration/ORM/EntityRelationship/ProxyEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/EntityRelationship/ProxyEntityFactoryRelationshipTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\IgnorePhpunitWarnings;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
@@ -39,7 +40,7 @@ use Zenstruck\Foundry\Tests\Integration\ORM\EdgeCasesRelationshipTest;
  */
 #[RequiresPhpunit('>=11.4')]
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class ProxyEntityFactoryRelationshipTest extends EntityFactoryRelationshipTestCase
 {
     /** @test */

--- a/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
+++ b/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
@@ -26,7 +27,7 @@ use function Zenstruck\Foundry\Persistence\proxy_factory;
  * @group legacy
  */
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class GenericEntityProxyFactoryTest extends GenericProxyFactoryTestCase
 {
     use RequiresORM;

--- a/tests/Integration/ORM/ProxyGenericEntityRepositoryDecoratorTest.php
+++ b/tests/Integration/ORM/ProxyGenericEntityRepositoryDecoratorTest.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
 
@@ -22,7 +23,7 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
  * @group legacy
  */
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class ProxyGenericEntityRepositoryDecoratorTest extends GenericEntityRepositoryDecoratorTest
 {
     protected function factory(): PersistentObjectFactory

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Tests\Unit;
 use Faker;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Configuration;
@@ -84,7 +85,7 @@ final class FactoryTest extends TestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function can_use_user_defined_proxy_persistent_factory_in_unit_test(): void
     {
         $object = GenericProxyEntityFactory::createOne();
@@ -99,7 +100,7 @@ final class FactoryTest extends TestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function can_use_user_anonymous_proxy_persistent_factory_in_unit_test(): void
     {
         $object = proxy_factory(GenericEntity::class, ['prop1' => 'prop1'])->create();
@@ -130,7 +131,7 @@ final class FactoryTest extends TestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function proxy_attributes_can_be_used_in_unit_test(): void
     {
         $object = ProxyContactFactory::createOne([
@@ -160,7 +161,7 @@ final class FactoryTest extends TestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function instantiating_with_proxy_attribute_normalizes_to_underlying_object(): void
     {
         $object = ProxyContactFactory::createOne([

--- a/tests/Unit/Persistence/ProxyGeneratorTest.php
+++ b/tests/Unit/Persistence/ProxyGeneratorTest.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Tests\Unit\Persistence;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
@@ -26,7 +27,7 @@ use Zenstruck\Foundry\Test\Factories;
  * @group legacy
  */
 #[IgnoreDeprecations]
-#[Group('legacy-proxy')]
+#[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class ProxyGeneratorTest extends TestCase
 {
     use Factories;

--- a/tests/Unit/ReuseEntityTest.php
+++ b/tests/Unit/ReuseEntityTest.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Test\Factories;
@@ -51,7 +52,7 @@ final class ReuseEntityTest extends TestCase
      */
     #[Test]
     #[IgnoreDeprecations]
-    #[Group('legacy-proxy')]
+    #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
     public function it_can_reuse_a_proxy_object(): void
     {
         $address = AddressFactory::createOne();


### PR DESCRIPTION
I just discovered `#[RequiresMethod]`. I think it is cleaner to use this attribute than the current solution used to skip those tests along with SF 8 (currently, we automatically add `--exclude-group legacy-proxy` when SF 8 is detected)