### PR TITLE
refactor: simplify ResetDatabaseManager

### DIFF
--- a/src/Persistence/ResetDatabase/ResetDatabaseManager.php
+++ b/src/Persistence/ResetDatabase/ResetDatabaseManager.php
@@ -38,17 +38,12 @@ final class ResetDatabaseManager
     ) {
     }
 
-    /**
-     * @param callable():KernelInterface $createKernel
-     * @param callable():void            $shutdownKernel
-     */
-    public static function resetBeforeFirstTest(callable $createKernel, callable $shutdownKernel): void
+    public static function resetBeforeFirstTest(KernelInterface $kernel): void
     {
         if (self::$hasDatabaseBeenReset) {
             return;
         }
 
-        $kernel = $createKernel();
         $configuration = Configuration::instance();
 
         try {
@@ -66,23 +61,11 @@ final class ResetDatabaseManager
             $databaseResetter->resetBeforeFirstTest($kernel);
         }
 
-        $shutdownKernel();
-
         self::$hasDatabaseBeenReset = true;
     }
 
-    /**
-     * @param callable():KernelInterface $createKernel
-     * @param callable():void            $shutdownKernel
-     */
-    public static function resetBeforeEachTest(callable $createKernel, callable $shutdownKernel): void
+    public static function resetBeforeEachTest(KernelInterface $kernel): void
     {
-        if (self::canSkipSchemaReset()) {
-            // can fully skip booting the kernel
-            return;
-        }
-
-        $kernel = $createKernel();
         $configuration = Configuration::instance();
 
         try {
@@ -101,8 +84,6 @@ final class ResetDatabaseManager
         }
 
         $configuration->stories->loadGlobalStories();
-
-        $shutdownKernel();
     }
 
     public static function isDAMADoctrineTestBundleEnabled(): bool
@@ -110,7 +91,7 @@ final class ResetDatabaseManager
         return \class_exists(StaticDriver::class) && StaticDriver::isKeepStaticConnections();
     }
 
-    private static function canSkipSchemaReset(): bool
+    public static function canSkipSchemaReset(): bool
     {
         return self::isDAMADoctrineTestBundleEnabled() && PersistenceManager::isOrmOnly();
     }

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -30,10 +30,11 @@ trait ResetDatabase
     #[BeforeClass]
     public static function _resetDatabaseBeforeFirstTest(): void
     {
-        ResetDatabaseManager::resetBeforeFirstTest(
-            static::_boot(...),
-            static::_shutdown(...),
-        );
+        $kernel = static::_boot(); // @phpstan-ignore staticClassAccess.privateMethod
+
+        ResetDatabaseManager::resetBeforeFirstTest($kernel);
+
+        static::_shutdown(); // @phpstan-ignore staticClassAccess.privateMethod
     }
 
     /**
@@ -43,10 +44,16 @@ trait ResetDatabase
     #[Before]
     public static function _resetDatabaseBeforeEachTest(): void
     {
-        ResetDatabaseManager::resetBeforeEachTest(
-            static::_boot(...),
-            static::_shutdown(...),
-        );
+        if (ResetDatabaseManager::canSkipSchemaReset()) {
+            // can fully skip booting the kernel
+            return;
+        }
+
+        $kernel = static::_boot(); // @phpstan-ignore staticClassAccess.privateMethod
+
+        ResetDatabaseManager::resetBeforeEachTest($kernel);
+
+        static::_shutdown(); // @phpstan-ignore staticClassAccess.privateMethod
     }
 
     /**

--- a/tests/Benchmark/KernelBench.php
+++ b/tests/Benchmark/KernelBench.php
@@ -61,10 +61,11 @@ abstract class KernelBench
      */
     public static function _resetDatabaseBeforeFirstBench(): void
     {
-        ResetDatabaseManager::resetBeforeFirstTest(
-            static fn() => static::bootKernel(),
-            static fn() => static::ensureKernelShutdown(),
-        );
+        $kernel = static::bootKernel();
+
+        ResetDatabaseManager::resetBeforeFirstTest($kernel);
+
+        static::ensureKernelShutdown();
     }
 
     /**
@@ -72,10 +73,11 @@ abstract class KernelBench
      */
     public function _resetDatabaseBeforeEachBench(): void
     {
-        ResetDatabaseManager::resetBeforeEachTest(
-            static fn() => static::bootKernel(),
-            static fn() => static::ensureKernelShutdown(),
-        );
+        $kernel = static::bootKernel();
+
+        ResetDatabaseManager::resetBeforeEachTest($kernel);
+
+        static::ensureKernelShutdown();
     }
 
     /**


### PR DESCRIPTION
I think the complexity here was not mandatory, and was very oriented for PHPUnit. Now with a future Behat extension, it is complex to manipulate