### PR TITLE
fix: always register "inverseRelationshipCallbacks" even if Foundry is not booted

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -547,31 +547,35 @@ abstract class PersistentObjectFactory extends ObjectFactory
                 },
                 self::PRIORITY_SCHEDULE_FOR_INSERT
             )
+
+            // Always register the callback that executes inverse relationship callbacks.
+            // This is needed even when Foundry is not booted (e.g., when factories are created in data providers
+            // without the PHPUnit extension), because the callbacks are populated later during create().
+            ->afterInstantiate(
+                static function(object $object, array $parameters, self $factoryUsed): void {
+                    $tempAfterInstantiateCallbacks = $factoryUsed->inverseRelationshipCallbacks;
+                    $factoryUsed->inverseRelationshipCallbacks = [];
+                    foreach ($tempAfterInstantiateCallbacks as $tempAfterInstantiateCallback) {
+                        $tempAfterInstantiateCallback($object);
+                    }
+                },
+                priority: 1000
+            )
         ;
 
         if (!Configuration::isBooted() || !Configuration::instance()->hasEventDispatcher()) {
             return $factory;
         }
 
-        return $factory->afterInstantiate(
-            static function(object $object, array $parameters, self $factoryUsed): void {
-                $tempAfterInstantiateCallbacks = $factoryUsed->inverseRelationshipCallbacks;
-                $factoryUsed->inverseRelationshipCallbacks = [];
-                foreach ($tempAfterInstantiateCallbacks as $tempAfterInstantiateCallback) {
-                    $tempAfterInstantiateCallback($object);
-                }
-            },
-            priority: 1000
-        )
-            ->afterPersist(
-                static function(object $object, array $parameters, self $factoryUsed): bool {
-                    Configuration::instance()->eventDispatcher()->dispatch(
-                        new AfterPersist($object, $parameters, $factoryUsed)
-                    );
+        return $factory->afterPersist(
+            static function(object $object, array $parameters, self $factoryUsed): bool {
+                Configuration::instance()->eventDispatcher()->dispatch(
+                    new AfterPersist($object, $parameters, $factoryUsed)
+                );
 
-                    return false; // don't perform a flush after the hook
-                }
-            );
+                return false; // don't perform a flush after the hook
+            }
+        );
     }
 
     private function throwIfCannotCreateObject(): void

--- a/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
+++ b/tests/Integration/ORM/EntityRelationship/EntityFactoryRelationshipTestCase.php
@@ -839,6 +839,27 @@ abstract class EntityFactoryRelationshipTestCase extends KernelTestCase
         ];
     }
 
+    /**
+     * @test
+     * @dataProvider provideIsCreatesFactoryInDataProviderWithOneToManyCases
+     */
+    #[Test]
+    #[DataProvider('provideIsCreatesFactoryInDataProviderWithOneToManyCases')]
+    public function is_creates_factory_in_data_provider_with_one_to_many(CategoryFactory $categoryFactory): void
+    {
+        $category = $categoryFactory->create();
+        self::assertCount(2, $category->getContacts());
+    }
+
+    public static function provideIsCreatesFactoryInDataProviderWithOneToManyCases(): iterable
+    {
+        yield [
+            CategoryFactory::new([
+                'contacts' => ContactFactory::new()->sequence([['name' => 'foo'], ['name' => 'bar']]),
+            ])->withoutPersisting(),
+        ];
+    }
+
     /** @return PersistentObjectFactory<Contact> */
     protected static function contactFactoryWithoutCategory(): PersistentObjectFactory
     {


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/1062

ping @mvhirsch 

actually I've asked Claude to fix this bug, and even with almost no context, it managed to understand where the bug was coming from. I think I would have struggled more than ~him~ it :sweat_smile: :scream: 