### PR TITLE
fix: fixes after deprecating `Factories` trait

### DIFF
--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -11,8 +11,10 @@
 
 namespace Zenstruck\Foundry;
 
+use Zenstruck\Assert;
 use Zenstruck\Foundry\Object\Event\AfterInstantiate;
 use Zenstruck\Foundry\Object\Event\BeforeInstantiate;
+use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 
@@ -83,6 +85,15 @@ abstract class ObjectFactory extends Factory
         $clone->instantiator = $instantiator;
 
         return $clone;
+    }
+
+    /**
+     * @internal
+     * @phpstan-return InstantiatorCallable
+     */
+    final public function instantiator(): callable
+    {
+        return $this->instantiator ?? Configuration::instance()->instantiator;
     }
 
     /**

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -241,7 +241,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         if ($configuration->inADataProvider()
             && \PHP_VERSION_ID >= 80400
-            && $this->isPersisting()
+            && ($this->isPersisting() || $configuration->isInMemoryEnabled())
         ) {
             return ProxyGenerator::wrapFactory($this->with($attributes));
         }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Persistence;
 
 use Doctrine\Persistence\ObjectRepository;
 use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
+use Zenstruck\Assert;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\FoundryNotBooted;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;

--- a/src/Persistence/ProxyGenerator.php
+++ b/src/Persistence/ProxyGenerator.php
@@ -76,13 +76,18 @@ final class ProxyGenerator
                 throw new \LogicException('Cannot access to a persisted object inside a data provider.');
             }
 
-            $createdObject = $factory->withoutPersisting()->create();
+            $instantiator = $factory->instantiator();
 
-            Hydrator::hydrateFromOtherObject($ghost, $createdObject);
+            $factory
+                // small hack to instantiate into the ghost object
+                ->instantiateWith(
+                    static function (array $parameters, string $class) use ($instantiator, $ghost): object {
+                        $object = $instantiator($parameters, $class);
+                        Hydrator::hydrateFromOtherObject($ghost, $object);
 
-            if ($factory->isPersisting()) {
-                Configuration::instance()->persistence()->save($ghost);
-            }
+                        return $ghost;
+                    }
+                )->create();
         });
     }
 

--- a/tests/Fixture/Entity/EdgeCases/EntityWithReadonly/EntityWithReadonly.php
+++ b/tests/Fixture/Entity/EdgeCases/EntityWithReadonly/EntityWithReadonly.php
@@ -21,7 +21,7 @@ class EntityWithReadonly
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    public int $id;
+    public ?int $id = null;
 
     public function __construct(
         #[ORM\Column()]

--- a/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
@@ -89,30 +89,28 @@ final class DataProviderWithInMemoryTest extends KernelTestCase
         }
     }
 
-    // todo: fixMe !
-    //    #[Test]
-    //    #[DataProvider('provideContact')]
-    //    #[AsInMemoryTest]
-    //    public function it_can_create_in_memory_objects_in_data_provider(?Contact $contact = null): void
-    //    {
-    //        self::assertInstanceOf(Contact::class, $contact);
-    //
-    //        if (TestKernel::canUseLegacyProxy()) {
-    //            self::assertSame([ProxyGenerator::unwrap($contact)], $this->contactRepository->_all());
-    //        } else {
-    //            self::assertSame([$contact], $this->contactRepository->_all());
-    //        }
-    //
-    //        self::assertSame(0, $this->entityManager->getRepository(Contact::class)->count());
-    //    }
-    //
-    //    public static function provideContact(): iterable
-    //    {
-    //        if (!TestKernel::canUseLegacyProxy()) {
-    //            yield [];
-    //            return;
-    //        }
-    //
-    //        yield [ProxyContactFactory::createOne()];
-    //    }
+    #[Test]
+    #[DataProvider('provideContact')]
+    #[AsInMemoryTest]
+    public function it_can_create_in_memory_objects_in_data_provider(?Contact $contact = null): void
+    {
+        self::assertInstanceOf(Contact::class, $contact);
+
+        if (TestKernel::canUseLegacyProxy()) {
+            self::assertSame([ProxyGenerator::unwrap($contact)], $this->contactRepository->_all());
+        } else {
+            self::assertSame([$contact], $this->contactRepository->_all());
+        }
+
+        self::assertSame(0, $this->entityManager->getRepository(Contact::class)->count());
+    }
+
+    public static function provideContact(): iterable
+    {
+        yield [ContactFactory::createOne()];
+
+        if (TestKernel::canUseLegacyProxy()) {
+            yield [ProxyContactFactory::createOne()];
+        }
+    }
 }

--- a/tests/Integration/DataProvider/DataProviderWithPersistentDocumentFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentDocumentFactoryTest.php
@@ -17,8 +17,11 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
+use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -35,5 +38,17 @@ final class DataProviderWithPersistentDocumentFactoryTest extends DataProviderWi
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();
+    }
+
+    /**
+     * @return PersistentObjectFactory<DocumentWithReadonly>
+     */
+    protected static function objectWithReadonlyFactory(): PersistentObjectFactory
+    {
+        return persistent_factory(DocumentWithReadonly::class, [
+            'prop' => 1,
+            'embedded' => new Embeddable('value1'),
+            'date' => new \DateTimeImmutable(),
+        ]);
     }
 }

--- a/tests/Integration/DataProvider/DataProviderWithPersistentEntityFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentEntityFactoryTest.php
@@ -17,8 +17,11 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -35,5 +38,17 @@ final class DataProviderWithPersistentEntityFactoryTest extends DataProviderWith
     protected static function factory(): PersistentObjectFactory
     {
         return GenericEntityFactory::new();
+    }
+
+    /**
+     * @return PersistentObjectFactory<EntityWithReadonly>
+     */
+    protected static function objectWithReadonlyFactory(): PersistentObjectFactory
+    {
+        return persistent_factory(EntityWithReadonly::class, [
+            'prop' => 1,
+            'embedded' => new Embeddable('value1'),
+            'date' => new \DateTimeImmutable(),
+        ]);
     }
 }

--- a/tests/Integration/DataProvider/DataProviderWithPersistentFactoryTestCase.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentFactoryTestCase.php
@@ -26,207 +26,205 @@ abstract class DataProviderWithPersistentFactoryTestCase extends KernelTestCase
 {
     use ResetDatabase;
 
+//    #[Test]
+//    #[DataProvider('createOneObjectInDataProvider')]
+//    public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
+//    {
+//        static::factory()::assert()->count(1);
+//
+//        self::assertNotNull($providedData);
+//        self::assertSame('value set in data provider', $providedData->getProp1());
+//
+//        assert_persisted($providedData);
+//    }
+//
+//    #[Test]
+//    #[DataProvider('createOneObjectInDataProvider')]
+//    public function assert_it_provided_instance_is_the_same_than_returned_by_repository(?GenericModel $providedData): void
+//    {
+//        static::factory()::assert()->count(1);
+//
+//        self::assertNotNull($providedData);
+//        self::assertSame(static::factory()::repository()->firstOrFail(), $providedData);
+//    }
+//
+//    public static function createOneObjectInDataProvider(): iterable
+//    {
+//        yield 'createOne()' => [
+//            static::factory()::createOne(['prop1' => 'value set in data provider']),
+//        ];
+//
+//        yield 'create()' => [
+//            static::factory()->create(['prop1' => 'value set in data provider']),
+//        ];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('createOneObjectInDataProvider')]
+//    public function assert_multiple_tests_can_use_the_same_data_provider(?GenericModel $providedData): void
+//    {
+//        $this->assert_it_can_create_one_object_in_data_provider($providedData);
+//    }
+//
+//    #[Test]
+//    #[DataProvider('createOneObjectInDataProvider')]
+//    public function assert_it_can_use_the_same_object_in_several_data_sets(?GenericModel $providedData): void
+//    {
+//        $this->assert_it_can_create_one_object_in_data_provider($providedData);
+//    }
+//
+//    public static function canUseSameObjectInSeveralDataSetsProvider(): iterable
+//    {
+//        yield 'create object' => [
+//            $object = static::factory()::createOne(['prop1' => 'value set in data provider']),
+//        ];
+//
+//        yield 'use same object' => [
+//            $object,
+//        ];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('createMultipleObjectsInDataProvider')]
+//    public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
+//    {
+//        self::assertIsArray($providedData);
+//        static::factory()::assert()->count(2);
+//
+//        self::assertSame('prop 1', $providedData[0]->getProp1());
+//        self::assertSame('prop 2', $providedData[1]->getProp1());
+//    }
+//
+//    public static function createMultipleObjectsInDataProvider(): iterable
+//    {
+//        yield 'createSequence()' => [
+//            static::factory()::createSequence([
+//                ['prop1' => 'prop 1'],
+//                ['prop1' => 'prop 2'],
+//            ]),
+//        ];
+//
+//        yield 'sequence()->create()' => [
+//            static::factory()->sequence([
+//                ['prop1' => 'prop 1'],
+//                ['prop1' => 'prop 2'],
+//            ])->create(),
+//        ];
+//
+//        yield 'createMany()' => [
+//            static::factory()::createMany(2, static fn(int $i) => ['prop1' => "prop {$i}"]),
+//        ];
+//
+//        yield 'many()->create()' => [
+//            static::factory()->many(2)->create(static fn(int $i) => ['prop1' => "prop {$i}"]),
+//        ];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('dataProviderRetuningArray')]
+//    public function assert_it_can_use_data_provider_returning_array(?GenericModel $providedData): void
+//    {
+//        static::factory()::assert()->count(1);
+//
+//        self::assertNotNull($providedData);
+//        self::assertSame('value set in data provider', $providedData->getProp1());
+//    }
+//
+//    public static function dataProviderRetuningArray(): array
+//    {
+//        return [
+//            [
+//                static::factory()::createOne(['prop1' => 'value set in data provider']),
+//            ],
+//            [
+//                static::factory()->create(['prop1' => 'value set in data provider']),
+//            ],
+//        ];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('multipleDataProviders1')]
+//    #[DataProvider('multipleDataProviders2')]
+//    public function assert_it_can_use_multiple_data_providers(array $providedData, int $expectedCount): void
+//    {
+//        static::factory()::assert()->count($expectedCount);
+//
+//        foreach ($providedData as $providedDatum) {
+//            self::assertNotNull($providedDatum);
+//            self::assertSame('value set in data provider', $providedDatum->getProp1());
+//        }
+//    }
+//
+//    public static function multipleDataProviders1(): iterable
+//    {
+//        yield [
+//            static::factory()::createMany(1, ['prop1' => 'value set in data provider']),
+//            1,
+//        ];
+//    }
+//
+//    public static function multipleDataProviders2(): iterable
+//    {
+//        yield [
+//            static::factory()::createMany(2, ['prop1' => 'value set in data provider']),
+//            2,
+//        ];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('useGetterOnPersistedObjectCreatedInDataProvider')]
+//    public function assert_using_getter_on_persisted_object_created_in_a_data_provider_throws(?\Throwable $e): void
+//    {
+//        self::assertInstanceOf(\LogicException::class, $e);
+//        self::assertStringStartsWith('Cannot access to a persisted object inside a data provider.', $e->getMessage());
+//    }
+//
+//    public static function useGetterOnPersistedObjectCreatedInDataProvider(): iterable
+//    {
+//        try {
+//            static::factory()::createOne()->getProp1();
+//        } catch (\Throwable $e) {
+//        }
+//
+//        yield [$e ?? null];
+//    }
+//
+//    #[Test]
+//    #[DataProvider('useGetterOnObjectCreatedInDataProvider')]
+//    public function assert_it_can_use_getter_on_non_persisted_object_created_in_data_provider(
+//        string $providedData,
+//        mixed $expectedData,
+//    ): void {
+//        self::assertEquals($expectedData, ProxyGenerator::unwrap($providedData));
+//    }
+//
+//    public static function useGetterOnObjectCreatedInDataProvider(): iterable
+//    {
+//        yield 'object factory' => [Object1Factory::createOne()->getProp1(), 'router-constructor'];
+//        yield 'persistent factory' => [static::factory()->withoutPersisting()->create()->getProp1(), 'default1'];
+//        yield 'persistent factory using many' => [
+//            static::factory()->withoutPersisting()->many(1)->create()[0]->getProp1(),
+//            'default1',
+//        ];
+//    }
+
     #[Test]
-    #[DataProvider('createOneObjectInDataProvider')]
-    public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
+    #[DataProvider('createOneObjectInDataProviderWithAfterPersistCallback')]
+    public function assert_after_persist_callbacks_are_triggered(?GenericModel $providedData): void
     {
         static::factory()::assert()->count(1);
 
-        self::assertNotNull($providedData);
-        self::assertSame('value set in data provider', $providedData->getProp1());
-
-        assert_persisted($providedData);
+        self::assertSame('after persist callback', $providedData?->getProp1());
     }
 
-    #[Test]
-    #[DataProvider('createOneObjectInDataProvider')]
-    public function assert_it_provided_instance_is_the_same_than_returned_by_repository(?GenericModel $providedData): void
-    {
-        static::factory()::assert()->count(1);
-
-        self::assertNotNull($providedData);
-        self::assertSame(static::factory()::repository()->firstOrFail(), $providedData);
-    }
-
-    public static function createOneObjectInDataProvider(): iterable
-    {
-        yield 'createOne()' => [
-            static::factory()::createOne(['prop1' => 'value set in data provider']),
-        ];
-
-        yield 'create()' => [
-            static::factory()->create(['prop1' => 'value set in data provider']),
-        ];
-    }
-
-    #[Test]
-    #[DataProvider('createOneObjectInDataProvider')]
-    public function assert_multiple_tests_can_use_the_same_data_provider(?GenericModel $providedData): void
-    {
-        $this->assert_it_can_create_one_object_in_data_provider($providedData);
-    }
-
-    #[Test]
-    #[DataProvider('createOneObjectInDataProvider')]
-    public function assert_it_can_use_the_same_object_in_several_data_sets(?GenericModel $providedData): void
-    {
-        $this->assert_it_can_create_one_object_in_data_provider($providedData);
-    }
-
-    public static function canUseSameObjectInSeveralDataSetsProvider(): iterable
-    {
-        yield 'create object' => [
-            $object = static::factory()::createOne(['prop1' => 'value set in data provider']),
-        ];
-
-        yield 'use same object' => [
-            $object,
-        ];
-    }
-
-    #[Test]
-    #[DataProvider('createMultipleObjectsInDataProvider')]
-    public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
-    {
-        self::assertIsArray($providedData);
-        static::factory()::assert()->count(2);
-
-        self::assertSame('prop 1', $providedData[0]->getProp1());
-        self::assertSame('prop 2', $providedData[1]->getProp1());
-    }
-
-    public static function createMultipleObjectsInDataProvider(): iterable
-    {
-        yield 'createSequence()' => [
-            static::factory()::createSequence([
-                ['prop1' => 'prop 1'],
-                ['prop1' => 'prop 2'],
-            ]),
-        ];
-
-        yield 'sequence()->create()' => [
-            static::factory()->sequence([
-                ['prop1' => 'prop 1'],
-                ['prop1' => 'prop 2'],
-            ])->create(),
-        ];
-
-        yield 'createMany()' => [
-            static::factory()::createMany(2, static fn(int $i) => ['prop1' => "prop {$i}"]),
-        ];
-
-        yield 'many()->create()' => [
-            static::factory()->many(2)->create(static fn(int $i) => ['prop1' => "prop {$i}"]),
-        ];
-    }
-
-    #[Test]
-    #[DataProvider('dataProviderRetuningArray')]
-    public function assert_it_can_use_data_provider_returning_array(?GenericModel $providedData): void
-    {
-        static::factory()::assert()->count(1);
-
-        self::assertNotNull($providedData);
-        self::assertSame('value set in data provider', $providedData->getProp1());
-    }
-
-    public static function dataProviderRetuningArray(): array
-    {
-        return [
-            [
-                static::factory()::createOne(['prop1' => 'value set in data provider']),
-            ],
-            [
-                static::factory()->create(['prop1' => 'value set in data provider']),
-            ],
-        ];
-    }
-
-    #[Test]
-    #[DataProvider('multipleDataProviders1')]
-    #[DataProvider('multipleDataProviders2')]
-    public function assert_it_can_use_multiple_data_providers(array $providedData, int $expectedCount): void
-    {
-        static::factory()::assert()->count($expectedCount);
-
-        foreach ($providedData as $providedDatum) {
-            self::assertNotNull($providedDatum);
-            self::assertSame('value set in data provider', $providedDatum->getProp1());
-        }
-    }
-
-    public static function multipleDataProviders1(): iterable
+    public static function createOneObjectInDataProviderWithAfterPersistCallback(): iterable
     {
         yield [
-            static::factory()::createMany(1, ['prop1' => 'value set in data provider']),
-            1,
+            static::factory()
+                ->afterPersist(fn(GenericModel $object) => $object->setProp1('after persist callback'))
+                ->create()
         ];
     }
-
-    public static function multipleDataProviders2(): iterable
-    {
-        yield [
-            static::factory()::createMany(2, ['prop1' => 'value set in data provider']),
-            2,
-        ];
-    }
-
-    #[Test]
-    #[DataProvider('useGetterOnPersistedObjectCreatedInDataProvider')]
-    public function assert_using_getter_on_persisted_object_created_in_a_data_provider_throws(?\Throwable $e): void
-    {
-        self::assertInstanceOf(\LogicException::class, $e);
-        self::assertStringStartsWith('Cannot access to a persisted object inside a data provider.', $e->getMessage());
-    }
-
-    public static function useGetterOnPersistedObjectCreatedInDataProvider(): iterable
-    {
-        try {
-            static::factory()::createOne()->getProp1();
-        } catch (\Throwable $e) {
-        }
-
-        yield [$e ?? null];
-    }
-
-    #[Test]
-    #[DataProvider('useGetterOnObjectCreatedInDataProvider')]
-    public function assert_it_can_use_getter_on_non_persisted_object_created_in_data_provider(
-        string $providedData,
-        mixed $expectedData,
-    ): void {
-        self::assertEquals($expectedData, ProxyGenerator::unwrap($providedData));
-    }
-
-    public static function useGetterOnObjectCreatedInDataProvider(): iterable
-    {
-        yield 'object factory' => [Object1Factory::createOne()->getProp1(), 'router-constructor'];
-        yield 'persistent factory' => [static::factory()->withoutPersisting()->create()->getProp1(), 'default1'];
-        yield 'persistent factory using many' => [
-            static::factory()->withoutPersisting()->many(1)->create()[0]->getProp1(),
-            'default1',
-        ];
-    }
-
-    // todo: FixMe! this is a known bug, currently the afterPersist callback is not called when creating objects in data provider
-    //
-    //    #[Test]
-    //    #[DataProvider('createOneObjectInDataProviderWithAfterPersistCallback')]
-    //    public function assert_after_persist_callbacks_are_triggered(?GenericModel $providedData): void
-    //    {
-    //        static::factory()::assert()->count(1);
-    //
-    //        self::assertSame('after persist callback', $providedData->getProp1());
-    //    }
-    //
-    //    public static function createOneObjectInDataProviderWithAfterPersistCallback(): iterable
-    //    {
-    //        yield [
-    //            static::factory()
-    //                ->afterPersist(fn(GenericModel $object) => $object->setProp1('after persist callback'))
-    //                ->create()
-    //        ];
-    //    }
 
     /**
      * @return PersistentObjectFactory<GenericModel>

--- a/tests/Integration/DataProvider/DataProviderWithPersistentFactoryTestCase.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentFactoryTestCase.php
@@ -17,6 +17,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Object1Factory;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 
@@ -26,187 +28,187 @@ abstract class DataProviderWithPersistentFactoryTestCase extends KernelTestCase
 {
     use ResetDatabase;
 
-//    #[Test]
-//    #[DataProvider('createOneObjectInDataProvider')]
-//    public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
-//    {
-//        static::factory()::assert()->count(1);
-//
-//        self::assertNotNull($providedData);
-//        self::assertSame('value set in data provider', $providedData->getProp1());
-//
-//        assert_persisted($providedData);
-//    }
-//
-//    #[Test]
-//    #[DataProvider('createOneObjectInDataProvider')]
-//    public function assert_it_provided_instance_is_the_same_than_returned_by_repository(?GenericModel $providedData): void
-//    {
-//        static::factory()::assert()->count(1);
-//
-//        self::assertNotNull($providedData);
-//        self::assertSame(static::factory()::repository()->firstOrFail(), $providedData);
-//    }
-//
-//    public static function createOneObjectInDataProvider(): iterable
-//    {
-//        yield 'createOne()' => [
-//            static::factory()::createOne(['prop1' => 'value set in data provider']),
-//        ];
-//
-//        yield 'create()' => [
-//            static::factory()->create(['prop1' => 'value set in data provider']),
-//        ];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('createOneObjectInDataProvider')]
-//    public function assert_multiple_tests_can_use_the_same_data_provider(?GenericModel $providedData): void
-//    {
-//        $this->assert_it_can_create_one_object_in_data_provider($providedData);
-//    }
-//
-//    #[Test]
-//    #[DataProvider('createOneObjectInDataProvider')]
-//    public function assert_it_can_use_the_same_object_in_several_data_sets(?GenericModel $providedData): void
-//    {
-//        $this->assert_it_can_create_one_object_in_data_provider($providedData);
-//    }
-//
-//    public static function canUseSameObjectInSeveralDataSetsProvider(): iterable
-//    {
-//        yield 'create object' => [
-//            $object = static::factory()::createOne(['prop1' => 'value set in data provider']),
-//        ];
-//
-//        yield 'use same object' => [
-//            $object,
-//        ];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('createMultipleObjectsInDataProvider')]
-//    public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
-//    {
-//        self::assertIsArray($providedData);
-//        static::factory()::assert()->count(2);
-//
-//        self::assertSame('prop 1', $providedData[0]->getProp1());
-//        self::assertSame('prop 2', $providedData[1]->getProp1());
-//    }
-//
-//    public static function createMultipleObjectsInDataProvider(): iterable
-//    {
-//        yield 'createSequence()' => [
-//            static::factory()::createSequence([
-//                ['prop1' => 'prop 1'],
-//                ['prop1' => 'prop 2'],
-//            ]),
-//        ];
-//
-//        yield 'sequence()->create()' => [
-//            static::factory()->sequence([
-//                ['prop1' => 'prop 1'],
-//                ['prop1' => 'prop 2'],
-//            ])->create(),
-//        ];
-//
-//        yield 'createMany()' => [
-//            static::factory()::createMany(2, static fn(int $i) => ['prop1' => "prop {$i}"]),
-//        ];
-//
-//        yield 'many()->create()' => [
-//            static::factory()->many(2)->create(static fn(int $i) => ['prop1' => "prop {$i}"]),
-//        ];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('dataProviderRetuningArray')]
-//    public function assert_it_can_use_data_provider_returning_array(?GenericModel $providedData): void
-//    {
-//        static::factory()::assert()->count(1);
-//
-//        self::assertNotNull($providedData);
-//        self::assertSame('value set in data provider', $providedData->getProp1());
-//    }
-//
-//    public static function dataProviderRetuningArray(): array
-//    {
-//        return [
-//            [
-//                static::factory()::createOne(['prop1' => 'value set in data provider']),
-//            ],
-//            [
-//                static::factory()->create(['prop1' => 'value set in data provider']),
-//            ],
-//        ];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('multipleDataProviders1')]
-//    #[DataProvider('multipleDataProviders2')]
-//    public function assert_it_can_use_multiple_data_providers(array $providedData, int $expectedCount): void
-//    {
-//        static::factory()::assert()->count($expectedCount);
-//
-//        foreach ($providedData as $providedDatum) {
-//            self::assertNotNull($providedDatum);
-//            self::assertSame('value set in data provider', $providedDatum->getProp1());
-//        }
-//    }
-//
-//    public static function multipleDataProviders1(): iterable
-//    {
-//        yield [
-//            static::factory()::createMany(1, ['prop1' => 'value set in data provider']),
-//            1,
-//        ];
-//    }
-//
-//    public static function multipleDataProviders2(): iterable
-//    {
-//        yield [
-//            static::factory()::createMany(2, ['prop1' => 'value set in data provider']),
-//            2,
-//        ];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('useGetterOnPersistedObjectCreatedInDataProvider')]
-//    public function assert_using_getter_on_persisted_object_created_in_a_data_provider_throws(?\Throwable $e): void
-//    {
-//        self::assertInstanceOf(\LogicException::class, $e);
-//        self::assertStringStartsWith('Cannot access to a persisted object inside a data provider.', $e->getMessage());
-//    }
-//
-//    public static function useGetterOnPersistedObjectCreatedInDataProvider(): iterable
-//    {
-//        try {
-//            static::factory()::createOne()->getProp1();
-//        } catch (\Throwable $e) {
-//        }
-//
-//        yield [$e ?? null];
-//    }
-//
-//    #[Test]
-//    #[DataProvider('useGetterOnObjectCreatedInDataProvider')]
-//    public function assert_it_can_use_getter_on_non_persisted_object_created_in_data_provider(
-//        string $providedData,
-//        mixed $expectedData,
-//    ): void {
-//        self::assertEquals($expectedData, ProxyGenerator::unwrap($providedData));
-//    }
-//
-//    public static function useGetterOnObjectCreatedInDataProvider(): iterable
-//    {
-//        yield 'object factory' => [Object1Factory::createOne()->getProp1(), 'router-constructor'];
-//        yield 'persistent factory' => [static::factory()->withoutPersisting()->create()->getProp1(), 'default1'];
-//        yield 'persistent factory using many' => [
-//            static::factory()->withoutPersisting()->many(1)->create()[0]->getProp1(),
-//            'default1',
-//        ];
-//    }
+    #[Test]
+    #[DataProvider('createOneObjectInDataProvider')]
+    public function assert_it_can_create_one_object_in_data_provider(?GenericModel $providedData): void
+    {
+        static::factory()::assert()->count(1);
+
+        self::assertNotNull($providedData);
+        self::assertSame('value set in data provider', $providedData->getProp1());
+
+        assert_persisted($providedData);
+    }
+
+    #[Test]
+    #[DataProvider('createOneObjectInDataProvider')]
+    public function assert_it_provided_instance_is_the_same_than_returned_by_repository(?GenericModel $providedData): void
+    {
+        static::factory()::assert()->count(1);
+
+        self::assertNotNull($providedData);
+        self::assertSame(static::factory()::repository()->firstOrFail(), $providedData);
+    }
+
+    public static function createOneObjectInDataProvider(): iterable
+    {
+        yield 'createOne()' => [
+            static::factory()::createOne(['prop1' => 'value set in data provider']),
+        ];
+
+        yield 'create()' => [
+            static::factory()->create(['prop1' => 'value set in data provider']),
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('createOneObjectInDataProvider')]
+    public function assert_multiple_tests_can_use_the_same_data_provider(?GenericModel $providedData): void
+    {
+        $this->assert_it_can_create_one_object_in_data_provider($providedData);
+    }
+
+    #[Test]
+    #[DataProvider('createOneObjectInDataProvider')]
+    public function assert_it_can_use_the_same_object_in_several_data_sets(?GenericModel $providedData): void
+    {
+        $this->assert_it_can_create_one_object_in_data_provider($providedData);
+    }
+
+    public static function canUseSameObjectInSeveralDataSetsProvider(): iterable
+    {
+        yield 'create object' => [
+            $object = static::factory()::createOne(['prop1' => 'value set in data provider']),
+        ];
+
+        yield 'use same object' => [
+            $object,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('createMultipleObjectsInDataProvider')]
+    public function assert_it_can_create_multiple_objects_in_data_provider(?array $providedData): void
+    {
+        self::assertIsArray($providedData);
+        static::factory()::assert()->count(2);
+
+        self::assertSame('prop 1', $providedData[0]->getProp1());
+        self::assertSame('prop 2', $providedData[1]->getProp1());
+    }
+
+    public static function createMultipleObjectsInDataProvider(): iterable
+    {
+        yield 'createSequence()' => [
+            static::factory()::createSequence([
+                ['prop1' => 'prop 1'],
+                ['prop1' => 'prop 2'],
+            ]),
+        ];
+
+        yield 'sequence()->create()' => [
+            static::factory()->sequence([
+                ['prop1' => 'prop 1'],
+                ['prop1' => 'prop 2'],
+            ])->create(),
+        ];
+
+        yield 'createMany()' => [
+            static::factory()::createMany(2, static fn(int $i) => ['prop1' => "prop {$i}"]),
+        ];
+
+        yield 'many()->create()' => [
+            static::factory()->many(2)->create(static fn(int $i) => ['prop1' => "prop {$i}"]),
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('dataProviderRetuningArray')]
+    public function assert_it_can_use_data_provider_returning_array(?GenericModel $providedData): void
+    {
+        static::factory()::assert()->count(1);
+
+        self::assertNotNull($providedData);
+        self::assertSame('value set in data provider', $providedData->getProp1());
+    }
+
+    public static function dataProviderRetuningArray(): array
+    {
+        return [
+            [
+                static::factory()::createOne(['prop1' => 'value set in data provider']),
+            ],
+            [
+                static::factory()->create(['prop1' => 'value set in data provider']),
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('multipleDataProviders1')]
+    #[DataProvider('multipleDataProviders2')]
+    public function assert_it_can_use_multiple_data_providers(array $providedData, int $expectedCount): void
+    {
+        static::factory()::assert()->count($expectedCount);
+
+        foreach ($providedData as $providedDatum) {
+            self::assertNotNull($providedDatum);
+            self::assertSame('value set in data provider', $providedDatum->getProp1());
+        }
+    }
+
+    public static function multipleDataProviders1(): iterable
+    {
+        yield [
+            static::factory()::createMany(1, ['prop1' => 'value set in data provider']),
+            1,
+        ];
+    }
+
+    public static function multipleDataProviders2(): iterable
+    {
+        yield [
+            static::factory()::createMany(2, ['prop1' => 'value set in data provider']),
+            2,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('useGetterOnPersistedObjectCreatedInDataProvider')]
+    public function assert_using_getter_on_persisted_object_created_in_a_data_provider_throws(?\Throwable $e): void
+    {
+        self::assertInstanceOf(\LogicException::class, $e);
+        self::assertStringStartsWith('Cannot access to a persisted object inside a data provider.', $e->getMessage());
+    }
+
+    public static function useGetterOnPersistedObjectCreatedInDataProvider(): iterable
+    {
+        try {
+            static::factory()::createOne()->getProp1();
+        } catch (\Throwable $e) {
+        }
+
+        yield [$e ?? null];
+    }
+
+    #[Test]
+    #[DataProvider('useGetterOnObjectCreatedInDataProvider')]
+    public function assert_it_can_use_getter_on_non_persisted_object_created_in_data_provider(
+        string $providedData,
+        mixed $expectedData,
+    ): void {
+        self::assertEquals($expectedData, ProxyGenerator::unwrap($providedData));
+    }
+
+    public static function useGetterOnObjectCreatedInDataProvider(): iterable
+    {
+        yield 'object factory' => [Object1Factory::createOne()->getProp1(), 'router-constructor'];
+        yield 'persistent factory' => [static::factory()->withoutPersisting()->create()->getProp1(), 'default1'];
+        yield 'persistent factory using many' => [
+            static::factory()->withoutPersisting()->many(1)->create()[0]->getProp1(),
+            'default1',
+        ];
+    }
 
     #[Test]
     #[DataProvider('createOneObjectInDataProviderWithAfterPersistCallback')]
@@ -226,8 +228,27 @@ abstract class DataProviderWithPersistentFactoryTestCase extends KernelTestCase
         ];
     }
 
+    #[Test]
+    #[DataProvider('createObjectWithReadonlyProperties')]
+    public function assert_it_can_create_objects_with_readonly_properties(DocumentWithReadonly|EntityWithReadonly|null $providedData): void
+    {
+        static::objectWithReadonlyFactory()::assert()->count(1);
+
+        self::assertSame(1, $providedData?->prop);
+    }
+
+    public static function createObjectWithReadonlyProperties(): iterable
+    {
+        yield [static::objectWithReadonlyFactory()->create()];
+    }
+
     /**
      * @return PersistentObjectFactory<GenericModel>
      */
     abstract protected static function factory(): PersistentObjectFactory;
+
+    /**
+     * @return PersistentObjectFactory<DocumentWithReadonly|EntityWithReadonly>
+     */
+    abstract protected static function objectWithReadonlyFactory(): PersistentObjectFactory;
 }

--- a/tests/Integration/DataProvider/DataProviderWithProxyPersistentDocumentFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithProxyPersistentDocumentFactoryTest.php
@@ -15,9 +15,15 @@ use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericProxyDocumentFactory;
+use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -34,5 +40,17 @@ final class DataProviderWithProxyPersistentDocumentFactoryTest extends DataProvi
     protected static function factory(): GenericProxyDocumentFactory
     {
         return GenericProxyDocumentFactory::new();
+    }
+
+    /**
+     * @return PersistentProxyObjectFactory<DocumentWithReadonly>
+     */
+    protected static function objectWithReadonlyFactory(): PersistentObjectFactory
+    {
+        return proxy_factory(DocumentWithReadonly::class, [
+            'prop' => 1,
+            'embedded' => new Embeddable('value1'),
+            'date' => new \DateTimeImmutable(),
+        ]);
     }
 }

--- a/tests/Integration/DataProvider/DataProviderWithProxyPersistentEntityFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithProxyPersistentEntityFactoryTest.php
@@ -19,13 +19,20 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -85,5 +92,17 @@ final class DataProviderWithProxyPersistentEntityFactoryTest extends DataProvide
     protected static function factory(): GenericProxyEntityFactory
     {
         return GenericProxyEntityFactory::new();
+    }
+
+    /**
+     * @return PersistentProxyObjectFactory<EntityWithReadonly>
+     */
+    protected static function objectWithReadonlyFactory(): PersistentObjectFactory
+    {
+        return proxy_factory(EntityWithReadonly::class, [
+            'prop' => 1,
+            'embedded' => new Embeddable('value1'),
+            'date' => new \DateTimeImmutable(),
+        ]);
     }
 }

--- a/tests/Integration/InMemory/InMemoryTest.php
+++ b/tests/Integration/InMemory/InMemoryTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\WithStory;
 use Zenstruck\Foundry\InMemory\AsInMemoryTest;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Test\Factories;
@@ -25,11 +26,14 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\InMemory\InMemoryAddressRepository;
 use Zenstruck\Foundry\Tests\Fixture\InMemory\InMemoryContactRepository;
+use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 /**
@@ -173,5 +177,14 @@ final class InMemoryTest extends KernelTestCase
 
         self::assertCount(1, ContactFactory::repository());
         self::assertCount(1, AddressFactory::repository());
+    }
+
+    #[Test]
+    #[WithStory(EntityStory::class)]
+    public function can_use_with_story_and_in_memory(): void
+    {
+        GenericEntityFactory::repository()->assert()->count(2);
+
+        self::assertSame(0, $this->entityManager->getRepository(GenericEntity::class)->count([]));
     }
 }

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -177,6 +177,24 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
+    public function it_can_refresh_readonly_object(): void
+    {
+        $object = $this->objectWithReadonlyFactory()->create([
+            'prop' => 1,
+            'embedded' => new Embeddable('value1'),
+            'date' => new \DateTimeImmutable(),
+        ]);
+        $objectId = $object->id;
+
+        self::getContainer()->get('services_resetter')->reset(); // @phpstan-ignore method.notFound
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+
+        $this->updateObject($objectId);
+
+        self::assertSame(1, $object->prop);
+    }
+
+    #[Test]
     #[TestWith(['deleteDirectlyInDb' => false, 'clearOM' => true])]
     #[TestWith(['deleteDirectlyInDb' => false, 'clearOM' => false])]
     #[TestWith(['deleteDirectlyInDb' => true, 'clearOM' => true])]


### PR DESCRIPTION
- **minor: force Factory to instantiate in ghost object if using data provider**
- **minor: ensure new behaiors work with readonly properties**
- **minor: fixes PHPUnitExtension with in memory behavior**
