### PR TITLE
minor: remove useless `Factories` trait

### DIFF
--- a/src/PHPUnit/DisplayFakerSeedOnApplicationFinished.php
+++ b/src/PHPUnit/DisplayFakerSeedOnApplicationFinished.php
@@ -20,14 +20,14 @@ use Zenstruck\Foundry\Configuration;
  * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
-final class DisplayFakerSeedOnTestSuiteFinished implements Event\TestRunner\FinishedSubscriber
+final class DisplayFakerSeedOnApplicationFinished implements Event\Application\FinishedSubscriber
 {
-    public function notify(Event\TestRunner\Finished $event): void
+    public function notify(Event\Application\Finished $event): void
     {
         $fakerSeed = Configuration::fakerSeed();
 
         if (null !== $fakerSeed) {
-            echo "\n\nFaker seed: ".$fakerSeed; // @phpstan-ignore ekinoBannedCode.expression
+            echo "\nFaker seed used: {$fakerSeed}\n"; // @phpstan-ignore ekinoBannedCode.expression
         }
     }
 }

--- a/src/PHPUnit/FoundryExtension.php
+++ b/src/PHPUnit/FoundryExtension.php
@@ -57,7 +57,7 @@ if (\interface_exists(Runner\Extension\Extension::class)) {
                     new TriggerDataProviderPersistenceOnTestPrepared(),
                 ],
                 Event\Test\Finished::class => [new ShutdownFoundryOnTestFinished()],
-                Event\TestRunner\Finished::class => [new DisplayFakerSeedOnTestSuiteFinished()],
+                Event\TestRunner\Finished::class => [new DisplayFakerSeedOnApplicationFinished()],
             ];
 
             $subscribers = \array_merge(...\array_values($subscribers));

--- a/tests/Integration/Attribute/WithStory/ParentClassWithStoryAttributeTestCase.php
+++ b/tests/Integration/Attribute/WithStory/ParentClassWithStoryAttributeTestCase.php
@@ -15,7 +15,6 @@ namespace Zenstruck\Foundry\Tests\Integration\Attribute\WithStory;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityStory;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
@@ -26,5 +25,5 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[WithStory(EntityStory::class)]
 abstract class ParentClassWithStoryAttributeTestCase extends KernelTestCase
 {
-    use Factories, RequiresORM, ResetDatabase;
+    use RequiresORM, ResetDatabase;
 }

--- a/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnClassTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
@@ -35,7 +34,7 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[WithStory(EntityStory::class)]
 final class WithStoryOnClassTest extends KernelTestCase
 {
-    use Factories, RequiresORM, ResetDatabase;
+    use RequiresORM, ResetDatabase;
 
     #[Test]
     public function can_use_story_in_attribute(): void

--- a/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
+++ b/tests/Integration/Attribute/WithStory/WithStoryOnMethodTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\WithStory;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Stories\EntityPoolStory;
@@ -35,7 +34,7 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class WithStoryOnMethodTest extends KernelTestCase
 {
-    use Factories, RequiresORM, ResetDatabase;
+    use RequiresORM, ResetDatabase;
 
     #[Test]
     #[WithStory(EntityStory::class)]

--- a/tests/Integration/DataProvider/DataProviderForServiceFactoryInKernelTestCaseTest.php
+++ b/tests/Integration/DataProvider/DataProviderForServiceFactoryInKernelTestCaseTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Object1Factory;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
 
@@ -34,8 +33,6 @@ use function Zenstruck\Foundry\faker;
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class DataProviderForServiceFactoryInKernelTestCaseTest extends KernelTestCase
 {
-    use Factories;
-
     #[Test]
     #[DataProvider('createObjectFromServiceFactoryInDataProvider')]
     public function it_can_create_one_object_in_data_provider(?Object1 $providedData, string $expected): void

--- a/tests/Integration/DataProvider/DataProviderInUnitTest.php
+++ b/tests/Integration/DataProvider/DataProviderInUnitTest.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
@@ -41,8 +40,6 @@ use function Zenstruck\Foundry\faker;
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class DataProviderInUnitTest extends TestCase
 {
-    use Factories;
-
     #[Test]
     #[DataProvider('createObjectWithObjectFactoryInDataProvider')]
     public function assert_it_can_create_object_with_object_factory_in_data_provider(mixed $providedData, mixed $expectedData): void

--- a/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithInMemoryTest.php
@@ -26,7 +26,6 @@ use Zenstruck\Foundry\InMemory\AsInMemoryTest;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
@@ -43,7 +42,6 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class DataProviderWithInMemoryTest extends KernelTestCase
 {
-    use Factories;
     use RequiresORM; // needed to use the entity manager
     use ResetDatabase;
 

--- a/tests/Integration/DataProvider/DataProviderWithPersistentDocumentFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentDocumentFactoryTest.php
@@ -20,7 +20,6 @@ use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
 use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
-use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
 
@@ -28,14 +27,13 @@ use function Zenstruck\Foundry\Persistence\persistent_factory;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit >=12
  */
-#[RequiresPhpunit('>=12')]
 #[RequiresPhp('>=8.4')]
+#[RequiresPhpunit('>=12')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
+#[RequiresEnvironmentVariable('MONGO_URL')]
 final class DataProviderWithPersistentDocumentFactoryTest extends DataProviderWithPersistentFactoryTestCase
 {
-    use RequiresMongo;
-
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();

--- a/tests/Integration/DataProvider/DataProviderWithPersistentEntityFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithPersistentEntityFactoryTest.php
@@ -20,7 +20,6 @@ use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
-use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
 
@@ -28,14 +27,13 @@ use function Zenstruck\Foundry\Persistence\persistent_factory;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit >=12
  */
-#[RequiresPhpunit('>=12')]
 #[RequiresPhp('>=8.4')]
+#[RequiresPhpunit('>=12')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
+#[RequiresEnvironmentVariable('DATABASE_URL')]
 final class DataProviderWithPersistentEntityFactoryTest extends DataProviderWithPersistentFactoryTestCase
 {
-    use RequiresORM;
-
     protected static function factory(): PersistentObjectFactory
     {
         return GenericEntityFactory::new();

--- a/tests/Integration/DataProvider/DataProviderWithProxyPersistentEntityFactoryTest.php
+++ b/tests/Integration/DataProvider/DataProviderWithProxyPersistentEntityFactoryTest.php
@@ -37,15 +37,14 @@ use function Zenstruck\Foundry\Persistence\proxy_factory;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit >=12
  */
+#[IgnoreDeprecations]
 #[RequiresPhpunit('>=12')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '0')]
-#[IgnoreDeprecations]
+#[RequiresEnvironmentVariable('DATABASE_URL')]
 #[RequiresMethod(\Symfony\Component\VarExporter\LazyProxyTrait::class, 'createLazyProxy')]
 final class DataProviderWithProxyPersistentEntityFactoryTest extends DataProviderWithPersistentFactoryTestCase
 {
-    use RequiresORM;
-
     #[Test]
     #[DataProvider('createOneProxyObjectInDataProvider')]
     public function assert_provided_data_is_proxy(?GenericModel $providedData): void

--- a/tests/Integration/Faker/FakerSeedDoNotConflictWithDataProviderTest.php
+++ b/tests/Integration/Faker/FakerSeedDoNotConflictWithDataProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Zenstruck\Foundry\Tests\Integration\Faker;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
@@ -21,11 +22,9 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\WithUniqueColumn;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\WithUniqueColumn\WithUniqueColumnFactory;
-use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 use function Zenstruck\Foundry\faker;
 
@@ -33,12 +32,13 @@ use function Zenstruck\Foundry\faker;
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  * @requires PHPUnit >=12.0
  */
+#[RequiresPhp('^8.4')]
 #[RequiresPhpunit('>=12.0')]
 #[RequiresPhpunitExtension(FoundryExtension::class)]
-#[RequiresPhp('^8.4')]
+#[RequiresEnvironmentVariable('DATABASE_URL')]
 final class FakerSeedDoNotConflictWithDataProviderTest extends KernelTestCase
 {
-    use Factories, RequiresORM, ResetDatabase;
+    use ResetDatabase;
 
     #[Test]
     #[DataProvider('provideObject')]

--- a/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
+++ b/tests/Integration/InMemory/DoctrineInMemoryDecoratorTest.php
@@ -43,8 +43,6 @@ use function Zenstruck\Foundry\Persistence\proxy;
 #[AsInMemoryTest]
 final class DoctrineInMemoryDecoratorTest extends KernelTestCase
 {
-    use Factories;
-
     /**
      * @test
      */

--- a/tests/Integration/InMemory/InMemoryAttributeOnMethodTest.php
+++ b/tests/Integration/InMemory/InMemoryAttributeOnMethodTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\InMemory\AsInMemoryTest;
 use Zenstruck\Foundry\PHPUnit\FoundryExtension;
-use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
@@ -34,7 +33,6 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 #[RequiresPhpunitExtension(FoundryExtension::class)]
 final class InMemoryAttributeOnMethodTest extends KernelTestCase
 {
-    use Factories;
     use RequiresORM;
     use ResetDatabase;
 

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -22,20 +22,18 @@ use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
-use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
 
 /**
  * @requires PHPUnit >=12
  */
+#[RequiresPhp('>= 8.4')]
 #[RequiresPhpunit('>=12')]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
-#[RequiresPhp('>= 8.4')]
+#[RequiresEnvironmentVariable('MONGO_URL')]
 final class AutoRefreshTest extends AutoRefreshTestCase
 {
-    use RequiresMongo;
-
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -35,7 +35,6 @@ use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\AutoRefreshTestCase;
-use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
 use function Zenstruck\Foundry\Persistence\refresh_all;
@@ -43,12 +42,13 @@ use function Zenstruck\Foundry\Persistence\refresh_all;
 /**
  * @requires PHPUnit >=12
  */
+#[RequiresPhp('>= 8.4')]
 #[RequiresPhpunit('>=12')]
 #[RequiresEnvironmentVariable('USE_PHP_84_LAZY_OBJECTS', '1')]
-#[RequiresPhp('>= 8.4')]
+#[RequiresEnvironmentVariable('DATABASE_URL')]
 final class AutoRefreshTest extends AutoRefreshTestCase
 {
-    use ChangesEntityRelationshipCascadePersist, RequiresORM;
+    use ChangesEntityRelationshipCascadePersist;
 
     #[Test]
     public function tracker_keeps_reference_only_for_objects_in_current_scope(): void


### PR DESCRIPTION
We can safely remove `Factories` trait on all test with `#[RequiresPhpunitExtension(FoundryExtension::class)]` 

We can also replace `RequiresOrm` / `RequiresMongo` traits in favor of `#[RequiresEnvironmentVariable('DATABASE_URL')]` / `#[RequiresEnvironmentVariable('MONGO_URL')]` when `#[RequiresPhpunit('>=12')]` is used 