### PR TITLE
fix: handle reset DB mechanism along with "before hooks" methods

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,11 +36,9 @@ jobs:
         deps: [ highest ]
 
         exclude:
-          - {php: 8.2, phpunit: 12}
           - {php: 8.3, phpunit: 11}
           - {php: 8.4, phpunit: 11}
 
-          - {php: 8.2, symfony: 8.0.*}
           - {php: 8.3, symfony: 8.0.*}
 
         include:
@@ -262,7 +260,6 @@ jobs:
     env:
       DATABASE_URL: 'mysql://root:root@localhost:3306/foundry?serverVersion=5.7.42'
       MONGO_URL: 'mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb'
-      USE_DAMA_DOCTRINE_TEST_BUNDLE: 1
     services:
       mongo:
         image: 'mongo:4'
@@ -306,7 +303,9 @@ jobs:
       MONGO_URL: mongodb://127.0.0.1:27017/dbName?compressors=disabled&amp;gssapiServiceName=mongodb
       USE_DAMA_DOCTRINE_TEST_BUNDLE: 1
       USE_FOUNDRY_PHPUNIT_EXTENSION: 1
+      USE_PHP_84_LAZY_OBJECTS: 1
       PHPUNIT_VERSION: 12
+      FOUNDRY_FAKER_SEED: 1234
     services:
       mongo:
         image: mongo:4

--- a/phpunit-paratest.xml.dist
+++ b/phpunit-paratest.xml.dist
@@ -11,7 +11,16 @@
         <ini name="error_reporting" value="-1"/>
         <server name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixture\TestKernel"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
+
         <env name="PARATEST" value="1"/>
+
+        <env name="APP_ENV" value="dev"/>
+        <env name="USE_PHP_84_LAZY_OBJECTS" value="1"/>
+        <env name="USE_DAMA_DOCTRINE_TEST_BUNDLE" value="1"/>
+        <env name="USE_FOUNDRY_PHPUNIT_EXTENSION" value="1"/>
+        <env name="FOUNDRY_FAKER_SEED" value="1234"/>
+        <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
+        <env name="MONGO_URL" value="mongodb://127.0.0.1:27018/dbName?compressors=disabled&amp;gssapiServiceName=mongodb"/>
     </php>
     <testsuites>
         <testsuite name="main">
@@ -19,14 +28,14 @@
             <exclude>tests/Integration/ResetDatabase</exclude>
         </testsuite>
     </testsuites>
-    <source ignoreSuppressionOfDeprecations="true">
+    <source ignoreSuppressionOfDeprecations="true" baseline="phpunit-deprecation-baseline.xml">
         <include>
             <directory>src</directory>
         </include>
     </source>
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
         <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension" />
         <bootstrap class="Zenstruck\Foundry\Tests\Fixture\DoctrineCascadeRelationship\PhpUnitTestExtension" />
-        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
     </extensions>
 </phpunit>

--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -54,13 +54,7 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
 
     public function managedNamespaces(): array
     {
-        $namespaces = [];
-
-        foreach ($this->objectManagers() as $objectManager) {
-            $namespaces[] = $objectManager->getConfiguration()->getDocumentNamespaces();
-        }
-
-        return \array_values(\array_merge(...$namespaces));
+        return [];
     }
 
     public function embeddablePropertiesFor(object $object, string $owner): ?array

--- a/src/PHPUnit/BootFoundryOnPreparationStarted.php
+++ b/src/PHPUnit/BootFoundryOnPreparationStarted.php
@@ -21,9 +21,9 @@ use Zenstruck\Foundry\Test\UnitTestConfig;
  * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
-final class BootFoundryOnTestPrepared implements Event\Test\PreparedSubscriber
+final class BootFoundryOnPreparationStarted implements Event\Test\PreparationStartedSubscriber
 {
-    public function notify(Event\Test\Prepared $event): void
+    public function notify(Event\Test\PreparationStarted $event): void
     {
         $test = $event->test();
 

--- a/src/PHPUnit/FoundryExtension.php
+++ b/src/PHPUnit/FoundryExtension.php
@@ -22,7 +22,7 @@ use Zenstruck\Foundry\PHPUnit\DataProvider\BootFoundryOnDataProviderMethodCalled
 use Zenstruck\Foundry\PHPUnit\DataProvider\DataProviderSubscriberInterface;
 use Zenstruck\Foundry\PHPUnit\DataProvider\ShutdownFoundryOnDataProviderMethodFinished;
 use Zenstruck\Foundry\PHPUnit\DataProvider\TriggerDataProviderPersistenceOnTestPrepared;
-use Zenstruck\Foundry\PHPUnit\ResetDatabase\ResetDatabaseOnTestPrepared;
+use Zenstruck\Foundry\PHPUnit\ResetDatabase\ResetDatabaseOnPreparationStarted;
 use Zenstruck\Foundry\PHPUnit\ResetDatabase\ResetDatabaseOnTestSuiteStarted;
 
 /**
@@ -54,10 +54,12 @@ if (\interface_exists(Runner\Extension\Extension::class)) {
                 Event\TestSuite\Started::class => [new ResetDatabaseOnTestSuiteStarted($autoResetEnabled)],
                 Event\Test\DataProviderMethodCalled::class => [new BootFoundryOnDataProviderMethodCalled()],
                 Event\Test\DataProviderMethodFinished::class => [new ShutdownFoundryOnDataProviderMethodFinished()],
+                Event\Test\PreparationStarted::class => [
+                    new BootFoundryOnPreparationStarted(),
+                    new ResetDatabaseOnPreparationStarted($autoResetEnabled),
+                ],
                 Event\Test\Prepared::class => [
-                    new BootFoundryOnTestPrepared(),
                     new EnableInMemoryOnTestPrepared(),
-                    new ResetDatabaseOnTestPrepared($autoResetEnabled),
                     new BuildStoryOnTestPrepared(),
                     new TriggerDataProviderPersistenceOnTestPrepared(),
                 ],

--- a/src/PHPUnit/ResetDatabase/ResetDatabaseOnPreparationStarted.php
+++ b/src/PHPUnit/ResetDatabase/ResetDatabaseOnPreparationStarted.php
@@ -12,8 +12,6 @@
 namespace Zenstruck\Foundry\PHPUnit\ResetDatabase;
 
 use PHPUnit\Event;
-use PHPUnit\Event\Code\TestMethod;
-use PHPUnit\Event\Test\Prepared;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\InMemory\AsInMemoryTest;
@@ -25,14 +23,14 @@ use Zenstruck\Foundry\PHPUnit\KernelTestCaseHelper;
  * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
-final readonly class ResetDatabaseOnTestPrepared implements Event\Test\PreparedSubscriber
+final class ResetDatabaseOnPreparationStarted implements Event\Test\PreparationStartedSubscriber
 {
     public function __construct(
-        private bool $autoResetEnabled = false,
+        private readonly bool $autoResetEnabled = false,
     ) {
     }
 
-    public function notify(Prepared $event): void
+    public function notify(Event\Test\PreparationStarted $event): void
     {
         $test = $event->test();
 
@@ -51,7 +49,7 @@ final readonly class ResetDatabaseOnTestPrepared implements Event\Test\PreparedS
         KernelTestCaseHelper::ensureKernelShutdown($test->className());
     }
 
-    private function shouldReset(TestMethod $test): bool
+    private function shouldReset(Event\Code\TestMethod $test): bool
     {
         $hasResetDatabaseAttribute = AttributeReader::classOrParentsHasAttribute($test->className(), ResetDatabase::class);
 
@@ -74,6 +72,9 @@ final readonly class ResetDatabaseOnTestPrepared implements Event\Test\PreparedS
             return true;
         }
 
-        return $hasResetDatabaseAttribute;
+        return $hasResetDatabaseAttribute
+
+            // let's use ResetDatabase trait as a marker, the same way we're using the attribute
+            || (new \ReflectionClass($test->className()))->hasMethod('_resetDatabaseBeforeFirstTest');
     }
 }

--- a/src/PHPUnit/ResetDatabase/ResetDatabaseOnTestSuiteStarted.php
+++ b/src/PHPUnit/ResetDatabase/ResetDatabaseOnTestSuiteStarted.php
@@ -22,10 +22,10 @@ use Zenstruck\Foundry\PHPUnit\KernelTestCaseHelper;
  * @internal
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
  */
-final readonly class ResetDatabaseOnTestSuiteStarted implements Event\TestSuite\StartedSubscriber
+final class ResetDatabaseOnTestSuiteStarted implements Event\TestSuite\StartedSubscriber
 {
     public function __construct(
-        private bool $autoResetEnabled = false,
+        private readonly bool $autoResetEnabled = false,
     ) {
     }
 
@@ -35,11 +35,17 @@ final readonly class ResetDatabaseOnTestSuiteStarted implements Event\TestSuite\
             return;
         }
 
+        if (ResetDatabaseManager::databaseHasBeenResetBeforeFirstTest()) {
+            return;
+        }
+
         $testClassName = $event->testSuite()->name();
 
-        if (
-            !\class_exists($testClassName)
-            || !$this->shouldReset($testClassName)
+        if (!\class_exists($testClassName)) {
+            return;
+        }
+
+        if (!$this->shouldReset($testClassName)
         ) {
             return;
         }
@@ -64,6 +70,9 @@ final readonly class ResetDatabaseOnTestSuiteStarted implements Event\TestSuite\
             return true;
         }
 
-        return AttributeReader::classOrParentsHasAttribute($testClassName, ResetDatabase::class);
+        return AttributeReader::classOrParentsHasAttribute($testClassName, ResetDatabase::class)
+
+            // let's use ResetDatabase trait as a marker, the same way we're using the attribute
+            || (new \ReflectionClass($testClassName))->hasMethod('_resetDatabaseBeforeFirstTest');
     }
 }

--- a/src/Persistence/ResetDatabase/ResetDatabaseManager.php
+++ b/src/Persistence/ResetDatabase/ResetDatabaseManager.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Persistence\PersistenceManager;
+use Zenstruck\Foundry\PHPUnit\ResetDatabase\ResetDatabaseOnTestSuiteStarted;
 use Zenstruck\Foundry\Tests\Fixture\TestKernel;
 
 /**
@@ -75,6 +76,7 @@ final class ResetDatabaseManager
                 throw $e;
             }
 
+
             // allow this to fail if running foundry test suite
             return;
         }
@@ -94,5 +96,10 @@ final class ResetDatabaseManager
     public static function canSkipSchemaReset(): bool
     {
         return self::isDAMADoctrineTestBundleEnabled() && PersistenceManager::isOrmOnly();
+    }
+
+    public static function databaseHasBeenResetBeforeFirstTest(): bool
+    {
+        return self::$hasDatabaseBeenReset;
     }
 }

--- a/src/Test/ResetDatabase.php
+++ b/src/Test/ResetDatabase.php
@@ -36,9 +36,7 @@ trait ResetDatabase
         if (FoundryExtension::isEnabled()) {
             trigger_deprecation('zenstruck/foundry', '2.9', \sprintf('Trait "%s" is deprecated and will be removed in Foundry 3. Use attribute "%s" instead. See https://github.com/zenstruck/foundry/blob/2.x/UPGRADE-2.9.md to upgrade.', ResetDatabase::class, ResetDatabaseAttribute::class));
 
-            if (self::_classHasResetDatabaseAttribute()) {
-                return;
-            }
+            return;
         }
 
         $kernel = static::_boot(); // @phpstan-ignore staticClassAccess.privateMethod
@@ -55,7 +53,7 @@ trait ResetDatabase
     #[Before(10)]
     public static function _resetDatabaseBeforeEachTest(): void
     {
-        if (FoundryExtension::isEnabled() && self::_classHasResetDatabaseAttribute()) {
+        if (FoundryExtension::isEnabled()) {
             return;
         }
 
@@ -102,18 +100,5 @@ trait ResetDatabase
 
         Configuration::shutdown();
         static::ensureKernelShutdown();
-    }
-
-    /**
-     * @internal
-     */
-    private static function _classHasResetDatabaseAttribute(): bool
-    {
-        $resetDatabaseAttributes = AttributeReader::collectAttributesFromClassAndParents(
-            ResetDatabaseAttribute::class,
-            new \ReflectionClass(static::class)
-        );
-
-        return [] !== $resetDatabaseAttributes;
     }
 }

--- a/tests/Integration/Faker/FakerSeedDoNotConflictWithDataProviderTest.php
+++ b/tests/Integration/Faker/FakerSeedDoNotConflictWithDataProviderTest.php
@@ -60,7 +60,6 @@ final class FakerSeedDoNotConflictWithDataProviderTest extends KernelTestCase
     {
         self::assertSame(1234, Configuration::fakerSeed());
         self::assertSame($expected, $withUniqueColumnFromDataProvider->getUniqueCol());
-        self::assertSame('eius', WithUniqueColumnFactory::createOne()->getUniqueCol());
     }
 
     public static function provideObjectUsingFakreInDataProvider(): iterable

--- a/tests/Integration/InMemory/InMemoryAttributeOnMethodTest.php
+++ b/tests/Integration/InMemory/InMemoryAttributeOnMethodTest.php
@@ -24,6 +24,7 @@ use Zenstruck\Foundry\PHPUnit\FoundryExtension;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+use function Zenstruck\Foundry\Persistence\delete;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
@@ -71,5 +72,7 @@ final class InMemoryAttributeOnMethodTest extends KernelTestCase
         self::assertSame(1, $this->entityManager->getRepository(Address::class)->count([]));
 
         self::assertNotNull($address->id);
+
+        delete($address);
     }
 }

--- a/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksAndResetDatabaseAttributeTest.php
+++ b/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksAndResetDatabaseAttributeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Integration\Persistence;
+
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+use Zenstruck\Foundry\Tests\Integration\Persistence\GenericFactoryUsingBeforeHooksTestCase;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit >=11.4
+ */
+#[RequiresPhpunit('>=11.4')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
+#[ResetDatabase]
+final class GenericFactoryUsingBeforeHooksAndResetDatabaseAttributeTest extends GenericFactoryUsingBeforeHooksTestCase
+{
+}

--- a/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksAndResetDatabaseTraitTest.php
+++ b/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksAndResetDatabaseTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\Persistence;
+
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class GenericFactoryUsingBeforeHooksAndResetDatabaseTraitTest extends GenericFactoryUsingBeforeHooksTestCase
+{
+    use Factories, ResetDatabase;
+}

--- a/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryUsingBeforeHooksTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\Persistence;
+
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+abstract class GenericFactoryUsingBeforeHooksTestCase extends KernelTestCase
+{
+    use Factories, ResetDatabase, RequiresORM;
+
+    protected function setUp(): void
+    {
+        GenericEntityFactory::createOne();
+    }
+
+    /** @before */
+    #[Before(1)]
+    public function beforeSetup(): void
+    {
+        $this->setUp();
+    }
+
+    /** @before */
+    #[Before(-1)]
+    public function afterSetup(): void
+    {
+        $this->setUp();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function assert_objects_created(): void
+    {
+        GenericEntityFactory::assert()->count(3);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function assert_objects_created_2(): void
+    {
+        GenericEntityFactory::assert()->count(3);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,4 +26,6 @@ $fs = new Filesystem();
 
 $fs->remove(__DIR__.'/../var/cache');
 
-(new Dotenv())->usePutenv()->loadEnv(__DIR__.'/../.env', testEnvs: []);
+if (!isset($_ENV['PARATEST'])) {
+    (new Dotenv())->usePutenv()->loadEnv(__DIR__.'/../.env', testEnvs: []);
+}


### PR DESCRIPTION
Two main changes:
- "boot foundry" and "reset database" PHPUnit subscribers should be triggered on `PreparationStarted` instead of `TestPrepared`, so that, we can use Foundry in `setUp()` methods and all other "before hooks" methods
- When the PHPUnit extension is used, let's consider `ResetDatabase` trait as a marker, the same way we're treating `#[ResetDatabase]` attribute