### PR TITLE
minor: use test environment

### DIFF
--- a/phpunit-10.xml.dist
+++ b/phpunit-10.xml.dist
@@ -14,6 +14,7 @@
         <server name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixture\TestKernel"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <env name="APP_ENV" value="test"/>
     </php>
     <testsuites>
         <testsuite name="main">

--- a/phpunit-paratest.xml.dist
+++ b/phpunit-paratest.xml.dist
@@ -12,6 +12,7 @@
         <server name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixture\TestKernel"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
         <env name="PARATEST" value="1"/>
+        <env name="APP_ENV" value="test"/>
     </php>
     <testsuites>
         <testsuite name="main">

--- a/phpunit-rector.xml.dist
+++ b/phpunit-rector.xml.dist
@@ -11,6 +11,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
         <env name="SHELL_VERBOSITY" value="0"/>
+        <env name="APP_ENV" value="test"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <server name="KERNEL_CLASS" value="Zenstruck\Foundry\Tests\Fixture\TestKernel" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other&amp;ignoreFile=./tests/baseline-ignore"/>
+        <env name="APP_ENV" value="test"/>
     </php>
 
     <testsuites>

--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -54,13 +54,7 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
 
     public function managedNamespaces(): array
     {
-        $namespaces = [];
-
-        foreach ($this->objectManagers() as $objectManager) {
-            $namespaces[] = $objectManager->getConfiguration()->getDocumentNamespaces();
-        }
-
-        return \array_values(\array_merge(...$namespaces));
+        return [];
     }
 
     public function embeddablePropertiesFor(object $object, string $owner): ?array

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -54,7 +54,7 @@ final class TestKernel extends FoundryTestKernel
             ],
         ]);
 
-        if ('dev' !== $this->getEnvironment()) {
+        if ('test' !== $this->getEnvironment()) {
             $loader->load(\sprintf('%s/config/%s.yaml', __DIR__, $this->getEnvironment()));
         }
 


### PR DESCRIPTION
Our testsuite was using `dev` environment, which becomes problematic with the future Behat extension