### PR TITLE
fix: ensure no error `WebTestCase::createClient()` with prior kernel boot

### DIFF
--- a/phpunit-9.xml.dist
+++ b/phpunit-9.xml.dist
@@ -19,7 +19,14 @@
 
     <testsuites>
         <testsuite name="main">
-            <directory>tests</directory>
+            <!--
+                Let's run "WebTestCase" tests in the first place, to ensure the error
+                "Booting the kernel before calling "WebTestCase::createClient()" is not supported"
+                is not hidden by the other test.
+            -->
+            <directory>tests/WebTestCase/</directory>
+            <directory>tests/Integration</directory>
+            <directory>tests/Unit</directory>
             <exclude>tests/Integration/ResetDatabase</exclude>
             <exclude>tests/Integration/ForceFactoriesTraitUsage</exclude>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,14 @@
     </php>
     <testsuites>
         <testsuite name="main">
-            <directory>tests</directory>
+            <!--
+                Let's run "WebTestCase" tests in the first place, to ensure the error
+                "Booting the kernel before calling "WebTestCase::createClient()" is not supported"
+                is not hidden by the other test.
+            -->
+            <directory>tests/WebTestCase/</directory>
+            <directory>tests/Integration</directory>
+            <directory>tests/Unit</directory>
             <exclude>tests/Integration/ResetDatabase</exclude>
         </testsuite>
         <testsuite name="reset-database">

--- a/src/PHPUnit/ResetDatabase/ResetDatabaseOnPreparationStarted.php
+++ b/src/PHPUnit/ResetDatabase/ResetDatabaseOnPreparationStarted.php
@@ -38,15 +38,19 @@ final class ResetDatabaseOnPreparationStarted implements Event\Test\PreparationS
             return;
         }
 
-        if (!$this->shouldReset($test)) {
-            return;
+        try {
+            if (!$this->shouldReset($test)) {
+                return;
+            }
+
+            ResetDatabaseManager::resetBeforeEachTest(
+                KernelTestCaseHelper::bootKernel($test->className()),
+            );
+        } finally {
+            if (\is_subclass_of($test->className(), KernelTestCase::class)) {
+                KernelTestCaseHelper::ensureKernelShutdown($test->className());
+            }
         }
-
-        ResetDatabaseManager::resetBeforeEachTest(
-            KernelTestCaseHelper::bootKernel($test->className()),
-        );
-
-        KernelTestCaseHelper::ensureKernelShutdown($test->className());
     }
 
     private function shouldReset(Event\Code\TestMethod $test): bool

--- a/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
+++ b/tests/Fixture/DoctrineCascadeRelationship/ChangesEntityRelationshipCascadePersist.php
@@ -33,6 +33,8 @@ use Zenstruck\Foundry\Tests\Integration\RequiresORM;
  *   before each test, thanks to "onLoadMetadata" doctrine event.
  *
  * This way, we can test all possible combinations of "cascade persist" on doctrine relationships.
+ *
+ * @phpstan-require-extends KernelTestCase
  */
 trait ChangesEntityRelationshipCascadePersist
 {
@@ -134,6 +136,7 @@ trait ChangesEntityRelationshipCascadePersist
         yield from DoctrineCascadeRelationshipMetadata::allCombinations($relationshipFields);
 
         Configuration::shutdown();
+        static::ensureKernelShutdown();
     }
 
     public static function setCurrentProvidedMethodName(string $methodName): void

--- a/tests/WebTestCase/GetWebTestClientIsNotBrokenTestCase.php
+++ b/tests/WebTestCase/GetWebTestClientIsNotBrokenTestCase.php
@@ -9,22 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Foundry\Tests\Integration;
+namespace Zenstruck\Foundry\Tests\WebTestCase;
 
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
-class GetWebTestClientIsNotBrokenTest extends WebTestCase
+abstract class GetWebTestClientIsNotBrokenTestCase extends WebTestCase
 {
     use Factories, RequiresORM;
 
     /**
      * @test
+     * @depends \Zenstruck\Foundry\Tests\WebTestCase\NoResetGetWebTestClientIsNotBrokenTest::class
      */
     #[Test]
+    #[DependsOnClass(NoResetGetWebTestClientIsNotBrokenTest::class)]
     public function boots_kernel_and_get_client(): void
     {
         $client = self::createClient();

--- a/tests/WebTestCase/GetWebTestClientWithResetDatabaseAttributeIsNotBrokenTest.php
+++ b/tests/WebTestCase/GetWebTestClientWithResetDatabaseAttributeIsNotBrokenTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\WebTestCase;
+
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @requires PHPUnit >=11
+ */
+#[ResetDatabase]
+#[RequiresPhpunit('>=11')]
+#[RequiresPhpunitExtension(FoundryExtension::class)]
+final class GetWebTestClientWithResetDatabaseAttributeIsNotBrokenTest extends GetWebTestClientIsNotBrokenTestCase
+{
+}

--- a/tests/WebTestCase/GetWebTestClientWithResetDatabaseTraitIsNotBrokenTest.php
+++ b/tests/WebTestCase/GetWebTestClientWithResetDatabaseTraitIsNotBrokenTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Foundry\Tests\Integration;
+namespace Zenstruck\Foundry\Tests\WebTestCase;
 
 use Zenstruck\Foundry\Test\ResetDatabase;
 
-final class GetWebTestClientWithResetDatabaseIsNotBrokenTest extends GetWebTestClientIsNotBrokenTest
+final class GetWebTestClientWithResetDatabaseTraitIsNotBrokenTest extends GetWebTestClientIsNotBrokenTestCase
 {
     use ResetDatabase;
 }

--- a/tests/WebTestCase/NoResetGetWebTestClientIsNotBrokenTest.php
+++ b/tests/WebTestCase/NoResetGetWebTestClientIsNotBrokenTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\WebTestCase;
+
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+final class NoResetGetWebTestClientIsNotBrokenTest extends WebTestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function boots_kernel_and_get_client(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', "/hello-world");
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @test
+     * @depends boots_kernel_and_get_client
+     */
+    #[Test]
+    #[Depends('boots_kernel_and_get_client')]
+    public function assert_test_starts_with_a_non_booted_kernel(): void
+    {
+        self::assertFalse(self::$booted);
+
+        // ensure we can get a client without the error:
+        // Booting the kernel before calling "WebTestCase::createClient()" is not supported
+        self::createClient();
+    }
+}

--- a/tests/bootstrap-reset-database.php
+++ b/tests/bootstrap-reset-database.php
@@ -9,39 +9,34 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Filesystem\Filesystem;
 use Zenstruck\Foundry\Tests\Fixture\FoundryTestKernel;
 use Zenstruck\Foundry\Tests\Fixture\ResetDatabase\ResetDatabaseTestKernel;
-
 use function Zenstruck\Foundry\application;
 use function Zenstruck\Foundry\runCommand;
 
-require \dirname(__DIR__).'/vendor/autoload.php';
+if (!FoundryTestKernel::usesMigrations()) {
+    return;
+}
 
 $fs = new Filesystem();
 
-$fs->remove(__DIR__.'/../var/cache');
+$fs->mkdir(__DIR__ . '/../var/cache/Migrations');
 
-(new Dotenv())->usePutenv()->loadEnv(__DIR__.'/../.env', testEnvs: []);
+$kernel = new ResetDatabaseTestKernel('test', true);
+$kernel->boot();
 
-if (FoundryTestKernel::usesMigrations()) {
-    $fs->mkdir(__DIR__.'/../var/cache/Migrations');
+$application = application($kernel);
 
-    $kernel = new ResetDatabaseTestKernel('test', true);
-    $kernel->boot();
+runCommand($application, 'doctrine:database:drop --if-exists --force', canFail: true);
+runCommand($application, 'doctrine:database:create', canFail: true);
 
-    $application = application($kernel);
-
-    runCommand($application, 'doctrine:database:drop --if-exists --force', canFail: true);
-    runCommand($application, 'doctrine:database:create', canFail: true);
-
-    $configuration = '';
-    if (\getenv('MIGRATION_CONFIGURATION_FILE')) {
-        $configuration = '--configuration '.\getcwd().'/'.\getenv('MIGRATION_CONFIGURATION_FILE');
-    }
-    runCommand($application, "doctrine:migrations:diff {$configuration}");
-    runCommand($application, 'doctrine:database:drop --force', canFail: true);
-
-    $kernel->shutdown();
+$configuration = '';
+if (\getenv('MIGRATION_CONFIGURATION_FILE')) {
+    $configuration = '--configuration ' . \getcwd() . '/' . \getenv('MIGRATION_CONFIGURATION_FILE');
 }
+runCommand($application, "doctrine:migrations:diff {$configuration}");
+runCommand($application, 'doctrine:database:drop --force', canFail: true);
+
+$kernel->shutdown();
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,21 +11,29 @@
 
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Filesystem\Filesystem;
+use function Symfony\Component\String\u;
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+$fs = new Filesystem();
+
+$fs->remove(__DIR__ . '/../var/cache');
+
+if (!isset($_ENV['PARATEST'])) {
+    (new Dotenv())->usePutenv()->loadEnv(__DIR__ . '/../.env', testEnvs: []);
+}
+
+$databaseUrl = u($_ENV['DATABASE_URL'] ?? '');
+if ($databaseUrl->startsWith('sqlite:')
+    && $fs->exists(
+        $sqliteFile = $databaseUrl->after('sqlite://')->trimStart('/')->replace('%kernel.project_dir%', dirname(__DIR__))->toString()
+    )
+) {
+    $fs->remove($sqliteFile);
+}
 
 $command = \implode(' ', $_SERVER['argv']);
 
 if (\str_contains($command, '--testsuite reset-database')) {
-    require __DIR__.'/bootstrap-reset-database.php';
-
-    return;
-}
-
-require \dirname(__DIR__).'/vendor/autoload.php';
-
-$fs = new Filesystem();
-
-$fs->remove(__DIR__.'/../var/cache');
-
-if (!isset($_ENV['PARATEST'])) {
-    (new Dotenv())->usePutenv()->loadEnv(__DIR__.'/../.env', testEnvs: []);
+    require __DIR__ . '/bootstrap-reset-database.php';
 }


### PR DESCRIPTION
fixes https://github.com/zenstruck/foundry/issues/1087