### PR TITLE
feat: add `withoutDoctrineEvents()` to suppress listeners during factory create

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1309,6 +1309,39 @@ If you'd like your factory to not persist by default, override its ``initialize(
 Now, after creating objects using this factory, you'd have to call ``\Zenstruck\Foundry\Persistence\save()`` to actually
 persist them to the database.
 
+.. _without-doctrine-events:
+
+Without Doctrine Events
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When loading fixtures, Doctrine event listeners fire as usual and can cause unwanted side effects. You can disable
+them during object creation to avoid this.
+
+::
+
+    use App\Entity\Post;
+    use App\Factory\PostFactory;
+    use function Zenstruck\Foundry\Persistence\persistent_factory;
+
+    // disable ALL Doctrine event listeners during creation
+    $post = PostFactory::new()->withoutDoctrineEvents()->create(); // returns Post
+
+    // disable only a specific listener/subscriber
+    $post = PostFactory::new()->withoutDoctrineEvents(PostListener::class)->create(); // returns Post
+
+    $posts = PostFactory::new()->withoutDoctrineEvents()->many(5)->create(); // returns Post[]
+
+If you'd like your factory to always disable Doctrine events, override its ``initialize()`` method:
+
+::
+
+    protected function initialize(): static
+    {
+        return $this
+            ->withoutDoctrineEvents()
+        ;
+    }
+
 Array factories
 ~~~~~~~~~~~~~~~
 

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Persistence;
 
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
@@ -40,6 +42,24 @@ final class PersistenceManager
     private array $afterPersistCallbacks = [];
 
     /**
+     * Event listener classes to keep disabled until the next real flush, accumulated across
+     * multiple scheduleForInsert() calls inside a flush_after() context.
+     * Keyed by spl_object_id of the ObjectManager.
+     *
+     * @var array<int, list<class-string>|null>
+     */
+    private array $pendingEventClassesToDisable = [];
+
+    /**
+     * Entity-listener overrides to apply during the next real flush, accumulated across
+     * multiple scheduleForInsert() calls inside a flush_after() context.
+     * Keyed by spl_object_id of the ObjectManager.
+     *
+     * @var array<int, list<array{entityClass: class-string, disabledClasses: list<class-string>|null}>>
+     */
+    private array $pendingEntityListenerOverrides = [];
+
+    /**
      * @param iterable<PersistenceStrategy> $strategies
      */
     public function __construct(
@@ -66,19 +86,34 @@ final class PersistenceManager
     /**
      * @template T of object
      *
-     * @param T $object
+     * @param T                       $object
+     * @param list<class-string>|null $disabledDoctrineEventClasses null = no events disabled, [] = all disabled, [Foo::class] = specific classes disabled
      *
      * @return T
      */
-    public function save(object $object): object
+    public function save(object $object, ?array $disabledDoctrineEventClasses = null): object
     {
         if ($object instanceof Proxy) {
             return $object->_save();
         }
 
         $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
+
+        // Disable for prePersist (fires during persist())
+        // Note: disableEntityListeners must be called first, as it calls getClassMetadata() which
+        // triggers the loadClassMetadata event to register #[AsEntityListener] listeners. If we
+        // disabled global events first, that event would fire without the EntityListenerRegistry
+        // handler, leaving entityListeners permanently empty in the metadata cache.
+        $entityListenerBackup = $this->disableEntityListeners($om, $object::class, $disabledDoctrineEventClasses);
+        $removedListeners = $this->disableDoctrineEvents($om, $disabledDoctrineEventClasses);
+
         $om->persist($object);
-        $this->flush($om);
+
+        $this->restoreDoctrineEvents($om, $removedListeners);
+        $this->restoreEntityListeners($om, $object::class, $entityListenerBackup);
+
+        // Disable for postPersist / preUpdate (fire during flush())
+        $this->flush($om, $disabledDoctrineEventClasses);
 
         $shouldFlush = $this->callPostPersistCallbacks();
 
@@ -94,17 +129,40 @@ final class PersistenceManager
      *
      * @param T                     $object
      * @param list<callable():bool> $afterPersistCallbacks
+     * @param list<class-string>|null $disabledDoctrineEventClasses null = no events disabled, [] = all disabled, [Foo::class] = specific classes disabled
      *
      * @return T
      */
-    public function scheduleForInsert(object $object, array $afterPersistCallbacks = []): object
+    public function scheduleForInsert(object $object, array $afterPersistCallbacks = [], ?array $disabledDoctrineEventClasses = null): object
     {
         if ($object instanceof Proxy) {
             $object = ProxyGenerator::unwrap($object);
         }
 
         $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
+
+        // Disable for prePersist (fires during persist())
+        // Note: disableEntityListeners must be called first — same reason as in save().
+        $entityListenerBackup = $this->disableEntityListeners($om, $object::class, $disabledDoctrineEventClasses);
+        $removedListeners = $this->disableDoctrineEvents($om, $disabledDoctrineEventClasses);
+
         $om->persist($object);
+
+        $this->restoreDoctrineEvents($om, $removedListeners);
+        $this->restoreEntityListeners($om, $object::class, $entityListenerBackup);
+
+        // Accumulate for postPersist / preUpdate (fire during the deferred flush())
+        if (null !== $disabledDoctrineEventClasses) {
+            $omId = spl_object_id($om);
+            $this->pendingEventClassesToDisable[$omId] = $this->mergeEventClasses(
+                $this->pendingEventClassesToDisable[$omId] ?? null,
+                $disabledDoctrineEventClasses,
+            );
+            $this->pendingEntityListenerOverrides[$omId][] = [
+                'entityClass' => $object::class,
+                'disabledClasses' => $disabledDoctrineEventClasses,
+            ];
+        }
 
         $this->afterPersistCallbacks = [...$this->afterPersistCallbacks, ...$afterPersistCallbacks];
 
@@ -137,10 +195,40 @@ final class PersistenceManager
         return $result;
     }
 
-    public function flush(ObjectManager $om): void
+    /**
+     * @param list<class-string>|null $eventClassesToDisable
+     */
+    public function flush(ObjectManager $om, ?array $eventClassesToDisable = null): void
     {
-        if ($this->flush) {
-            $om->flush();
+        if (!$this->flush) {
+            return;
+        }
+
+        $omId = spl_object_id($om);
+
+        // Merge caller-supplied classes with anything accumulated from scheduleForInsert()
+        /** @var list<class-string>|null $pendingClasses */
+        $pendingClasses = $this->pendingEventClassesToDisable[$omId] ?? null;
+        $eventClassesToDisable = $this->mergeEventClasses($eventClassesToDisable, $pendingClasses);
+        unset($this->pendingEventClassesToDisable[$omId]);
+
+        $removedListeners = $this->disableDoctrineEvents($om, $eventClassesToDisable);
+
+        // Apply entity-listener overrides accumulated from scheduleForInsert()
+        $entityListenerBackups = [];
+        foreach ($this->pendingEntityListenerOverrides[$omId] ?? [] as $override) {
+            $entityListenerBackups[] = [
+                'entityClass' => $override['entityClass'],
+                'backup' => $this->disableEntityListeners($om, $override['entityClass'], $override['disabledClasses']),
+            ];
+        }
+        unset($this->pendingEntityListenerOverrides[$omId]);
+
+        $om->flush();
+
+        $this->restoreDoctrineEvents($om, $removedListeners);
+        foreach ($entityListenerBackups as ['entityClass' => $entityClass, 'backup' => $backup]) {
+            $this->restoreEntityListeners($om, $entityClass, $backup);
         }
     }
 
@@ -467,6 +555,137 @@ final class PersistenceManager
         }
 
         return $shouldFlush;
+    }
+
+    /**
+     * Temporarily removes Doctrine event listeners from the EventManager.
+     *
+     * @param list<class-string>|null $eventClassesToDisable null = nothing removed, [] = all removed, [Foo::class] = specific classes removed
+     *
+     * @return array<string, list<object>> map of eventName => removed listeners, for later restoration
+     */
+    private function disableDoctrineEvents(ObjectManager $om, ?array $eventClassesToDisable): array
+    {
+        if (null === $eventClassesToDisable || !method_exists($om, 'getEventManager')) {
+            return [];
+        }
+
+        /** @var EventManager $eventManager */
+        $eventManager = $om->getEventManager();
+        $removed = [];
+
+        foreach ($eventManager->getAllListeners() as $eventName => $listeners) {
+            foreach ($listeners as $listener) {
+                if ([] === $eventClassesToDisable || \in_array($listener::class, $eventClassesToDisable, true)) {
+                    $eventManager->removeEventListener([$eventName], $listener);
+                    $removed[$eventName][] = $listener;
+                }
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Re-adds Doctrine event listeners previously removed by disableDoctrineEvents().
+     *
+     * @param array<string, list<object>> $removedListeners
+     */
+    private function restoreDoctrineEvents(ObjectManager $om, array $removedListeners): void
+    {
+        if ([] === $removedListeners || !method_exists($om, 'getEventManager')) {
+            return;
+        }
+
+        /** @var EventManager $eventManager */
+        $eventManager = $om->getEventManager();
+
+        foreach ($removedListeners as $eventName => $listeners) {
+            foreach ($listeners as $listener) {
+                $eventManager->addEventListener([$eventName], $listener);
+            }
+        }
+    }
+
+    /**
+     * Temporarily removes Doctrine entity listeners by modifying the entity's ClassMetadata.
+     *
+     * @param class-string            $entityClass
+     * @param list<class-string>|null $eventClassesToDisable null = nothing removed, [] = all removed, [Foo::class] = specific classes removed
+     *
+     * @return array<string, list<array{class: class-string, method: string}>> original entityListeners for later restoration
+     */
+    private function disableEntityListeners(ObjectManager $om, string $entityClass, ?array $eventClassesToDisable): array
+    {
+        if (null === $eventClassesToDisable || !$om instanceof EntityManagerInterface) {
+            return [];
+        }
+
+        $metadata = $om->getClassMetadata($entityClass);
+        $original = $metadata->entityListeners;
+
+        if ([] === $original) {
+            return [];
+        }
+
+        if ([] === $eventClassesToDisable) {
+            $metadata->entityListeners = [];
+        } else {
+            $filtered = [];
+            foreach ($original as $event => $listeners) {
+                foreach ($listeners as $listener) {
+                    if (!\in_array($listener['class'], $eventClassesToDisable, true)) {
+                        $filtered[$event][] = $listener;
+                    }
+                }
+            }
+            $metadata->entityListeners = $filtered;
+        }
+
+        return $original;
+    }
+
+    /**
+     * Restores entity listeners previously removed by disableEntityListeners().
+     *
+     * @param class-string                                                        $entityClass
+     * @param array<string, list<array{class: class-string, method: string}>>     $original
+     */
+    private function restoreEntityListeners(ObjectManager $om, string $entityClass, array $original): void
+    {
+        if ([] === $original || !$om instanceof EntityManagerInterface) {
+            return;
+        }
+
+        $om->getClassMetadata($entityClass)->entityListeners = $original;
+    }
+
+    /**
+     * Merges two sets of event classes to disable, following these rules:
+     *   - null + anything  = anything  (null means "no disabling requested")
+     *   - []   + anything  = []        ([] means "disable all", takes precedence)
+     *   - [A]  + [B]       = [A, B]    (union of specific classes)
+     *
+     * @param list<class-string>|null $a
+     * @param list<class-string>|null $b
+     *
+     * @return list<class-string>|null
+     */
+    private function mergeEventClasses(?array $a, ?array $b): ?array
+    {
+        if (null === $a) {
+            return $b;
+        }
+
+        if (null === $b) {
+            return $a;
+        }
+
+        if ([] === $a || [] === $b) {
+            return [];
+        }
+
+        return \array_values(\array_unique([...$a, ...$b]));
     }
 
     /**

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -46,6 +46,9 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
     private PersistMode $persist = PersistMode::PERSIST;
 
+    /** @var list<class-string>|null null = disabled not requested, [] = disable all, [Foo::class] = disable specific */
+    private ?array $disabledDoctrineEventClasses = null;
+
     /** @phpstan-var array<int, list<callable(T, Parameters, static):void|callable(T, Parameters, static):bool>> */
     private array $afterPersist = [];
 
@@ -261,7 +264,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
             throw new \LogicException('Persistence cannot be used in unit tests.');
         }
 
-        $configuration->persistence()->save($object);
+        $configuration->persistence()->save($object, $this->disabledDoctrineEventClasses);
 
         return $object;
     }
@@ -278,6 +281,20 @@ abstract class PersistentObjectFactory extends ObjectFactory
     {
         $clone = clone $this;
         $clone->persist = PersistMode::WITHOUT_PERSISTING;
+
+        return $clone;
+    }
+
+    /**
+     * Disable Doctrine event listeners/subscribers during object creation.
+     * Call with no arguments to disable all listeners, or pass specific class names to disable selectively.
+     *
+     * @param class-string ...$classes
+     */
+    final public function withoutDoctrineEvents(string ...$classes): static
+    {
+        $clone = clone $this;
+        $clone->disabledDoctrineEventClasses = \array_values($classes);
 
         return $clone;
     }
@@ -377,6 +394,10 @@ abstract class PersistentObjectFactory extends ObjectFactory
             $value = $value
                 ->withPersistMode($this->persist)
                 ->notRootFactory();
+
+            if (null !== $this->disabledDoctrineEventClasses) {
+                $value = $value->withoutDoctrineEvents(...$this->disabledDoctrineEventClasses);
+            }
 
             $pm = Configuration::instance()->persistence();
 
@@ -541,7 +562,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
                         };
                     }
 
-                    Configuration::instance()->persistence()->scheduleForInsert($object, $afterPersistCallbacks);
+                    Configuration::instance()->persistence()->scheduleForInsert($object, $afterPersistCallbacks, $factoryUsed->disabledDoctrineEventClasses);
                 },
                 self::PRIORITY_SCHEDULE_FOR_INSERT
             )

--- a/tests/Fixture/DoctrineEvents/AsEntityListenerListener.php
+++ b/tests/Fixture/DoctrineEvents/AsEntityListenerListener.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithAsEntityListener;
+
+#[AsEntityListener(event: Events::prePersist, entity: EntityWithAsEntityListener::class)]
+final class AsEntityListenerListener
+{
+    public function prePersist(EntityWithAsEntityListener $entity, PrePersistEventArgs $eventArgs): void
+    {
+        $entity->name .= ' (from AsEntityListener)';
+    }
+}

--- a/tests/Fixture/DoctrineEvents/DoctrineEventsSubscriber.php
+++ b/tests/Fixture/DoctrineEvents/DoctrineEventsSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityForDoctrineEvents;
+
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+final class DoctrineEventsSubscriber
+{
+    public function prePersist(PrePersistEventArgs $eventArgs): void
+    {
+        $object = $eventArgs->getObject();
+
+        if (!$object instanceof EntityForDoctrineEvents) {
+            return;
+        }
+
+        $object->name .= ' (from Doctrine event)';
+    }
+
+    public function preUpdate(PreUpdateEventArgs $eventArgs): void
+    {
+        $object = $eventArgs->getObject();
+
+        if (!$object instanceof EntityForDoctrineEvents) {
+            return;
+        }
+
+        $eventArgs->setNewValue('name', $object->name . ' (from Doctrine preUpdate event)');
+    }
+}

--- a/tests/Fixture/DoctrineEvents/EntityForDoctrineEventsFactory.php
+++ b/tests/Fixture/DoctrineEvents/EntityForDoctrineEventsFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityForDoctrineEvents;
+
+/**
+ * @extends PersistentObjectFactory<EntityForDoctrineEvents>
+ */
+final class EntityForDoctrineEventsFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return EntityForDoctrineEvents::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+}

--- a/tests/Fixture/DoctrineEvents/EntityWithAsEntityListenerFactory.php
+++ b/tests/Fixture/DoctrineEvents/EntityWithAsEntityListenerFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithAsEntityListener;
+
+/**
+ * @extends PersistentObjectFactory<EntityWithAsEntityListener>
+ */
+final class EntityWithAsEntityListenerFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return EntityWithAsEntityListener::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+}

--- a/tests/Fixture/DoctrineEvents/EntityWithOrmEntityListenerFactory.php
+++ b/tests/Fixture/DoctrineEvents/EntityWithOrmEntityListenerFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithOrmEntityListener;
+
+/**
+ * @extends PersistentObjectFactory<EntityWithOrmEntityListener>
+ */
+final class EntityWithOrmEntityListenerFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return EntityWithOrmEntityListener::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+}

--- a/tests/Fixture/DoctrineEvents/OrmEntityListener.php
+++ b/tests/Fixture/DoctrineEvents/OrmEntityListener.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\DoctrineEvents;
+
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithOrmEntityListener;
+
+final class OrmEntityListener
+{
+    public function prePersist(EntityWithOrmEntityListener $entity, PrePersistEventArgs $eventArgs): void
+    {
+        $entity->name .= ' (from ORM entity listener)';
+    }
+}

--- a/tests/Fixture/Entity/EntityForDoctrineEvents.php
+++ b/tests/Fixture/Entity/EntityForDoctrineEvents.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+class EntityForDoctrineEvents extends Base
+{
+    public function __construct(
+        #[ORM\Column]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Fixture/Entity/EntityWithAsEntityListener.php
+++ b/tests/Fixture/Entity/EntityWithAsEntityListener.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+class EntityWithAsEntityListener extends Base
+{
+    public function __construct(
+        #[ORM\Column]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Fixture/Entity/EntityWithOrmEntityListener.php
+++ b/tests/Fixture/Entity/EntityWithOrmEntityListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\OrmEntityListener;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+#[ORM\EntityListeners([OrmEntityListener::class])]
+class EntityWithOrmEntityListener extends Base
+{
+    public function __construct(
+        #[ORM\Column]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -21,6 +21,12 @@ use Zenstruck\Foundry\Tests\Fixture\App\Controller\CreateContact;
 use Zenstruck\Foundry\Tests\Fixture\App\Controller\DeleteGenericModel;
 use Zenstruck\Foundry\Tests\Fixture\App\Controller\HelloWorld;
 use Zenstruck\Foundry\Tests\Fixture\App\Controller\UpdateGenericModel;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\AsEntityListenerListener;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\DoctrineEventsSubscriber;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityForDoctrineEventsFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityWithAsEntityListenerFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityWithOrmEntityListenerFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\OrmEntityListener;
 use Zenstruck\Foundry\Tests\Fixture\Events\FoundryEventListener;
 use Zenstruck\Foundry\Tests\Fixture\Factories\ArrayFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Object1Factory;
@@ -65,6 +71,12 @@ final class TestKernel extends FoundryTestKernel
         $c->register(InMemoryContactRepository::class)->setAutowired(true)->setAutoconfigured(true);
 
         $c->register(FoundryEventListener::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(DoctrineEventsSubscriber::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(EntityForDoctrineEventsFactory::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(OrmEntityListener::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(EntityWithOrmEntityListenerFactory::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(AsEntityListenerListener::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(EntityWithAsEntityListenerFactory::class)->setAutowired(true)->setAutoconfigured(true);
 
         $c->register(DeleteGenericModel::class)->setAutowired(true)->setAutoconfigured(true)->addTag('controller.service_arguments');
         $c->register(UpdateGenericModel::class)->setAutowired(true)->setAutoconfigured(true)->addTag('controller.service_arguments');

--- a/tests/Integration/WithoutDoctrineEventsTest.php
+++ b/tests/Integration/WithoutDoctrineEventsTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\AsEntityListenerListener;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\DoctrineEventsSubscriber;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityForDoctrineEventsFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityWithAsEntityListenerFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityWithOrmEntityListenerFactory;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\OrmEntityListener;
+
+use function Zenstruck\Foundry\Persistence\flush_after;
+
+final class WithoutDoctrineEventsTest extends KernelTestCase
+{
+    use Factories, RequiresORM, ResetDatabase;
+
+    #[Test]
+    public function testDoctrineEventsAreCalledByDefault(): void
+    {
+        $entity = EntityForDoctrineEventsFactory::createOne(['name' => 'test']);
+
+        self::assertSame('test (from Doctrine event)', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableAllDoctrineEvents(): void
+    {
+        $entity = EntityForDoctrineEventsFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableSpecificDoctrineEventListener(): void
+    {
+        $entity = EntityForDoctrineEventsFactory::new()
+            ->withoutDoctrineEvents(DoctrineEventsSubscriber::class)
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testDoctrineEventsAreRestoredAfterCreation(): void
+    {
+        EntityForDoctrineEventsFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'first']);
+
+        // Events must be restored for subsequent factories
+        $entity = EntityForDoctrineEventsFactory::createOne(['name' => 'second']);
+
+        self::assertSame('second (from Doctrine event)', $entity->name);
+    }
+
+    // --- flush_after() ---
+
+    #[Test]
+    public function testItCanDisableAllDoctrineEventsInsideFlushAfter(): void
+    {
+        $entity = flush_after(static function(): mixed {
+            return EntityForDoctrineEventsFactory::new()
+                ->withoutDoctrineEvents()
+                ->create(['name' => 'test']);
+        });
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableSpecificListenerInsideFlushAfter(): void
+    {
+        $entity = flush_after(static function(): mixed {
+            return EntityForDoctrineEventsFactory::new()
+                ->withoutDoctrineEvents(DoctrineEventsSubscriber::class)
+                ->create(['name' => 'test']);
+        });
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testDoctrineEventsAreRestoredAfterFlushAfter(): void
+    {
+        flush_after(static function(): void {
+            EntityForDoctrineEventsFactory::new()
+                ->withoutDoctrineEvents()
+                ->create(['name' => 'first']);
+        });
+
+        // Events must be restored for subsequent factories
+        $entity = EntityForDoctrineEventsFactory::createOne(['name' => 'second']);
+
+        self::assertSame('second (from Doctrine event)', $entity->name);
+    }
+
+    // --- #[ORM\EntityListeners] ---
+
+    #[Test]
+    public function testOrmEntityListenerIsCalledByDefault(): void
+    {
+        $entity = EntityWithOrmEntityListenerFactory::createOne(['name' => 'test']);
+
+        self::assertSame('test (from ORM entity listener)', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableAllOrmEntityListeners(): void
+    {
+        $entity = EntityWithOrmEntityListenerFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableSpecificOrmEntityListener(): void
+    {
+        $entity = EntityWithOrmEntityListenerFactory::new()
+            ->withoutDoctrineEvents(OrmEntityListener::class)
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testOrmEntityListenerIsRestoredAfterCreation(): void
+    {
+        EntityWithOrmEntityListenerFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'first']);
+
+        $entity = EntityWithOrmEntityListenerFactory::createOne(['name' => 'second']);
+
+        self::assertSame('second (from ORM entity listener)', $entity->name);
+    }
+
+    // --- #[AsEntityListener] ---
+
+    #[Test]
+    public function testAsEntityListenerIsCalledByDefault(): void
+    {
+        $entity = EntityWithAsEntityListenerFactory::createOne(['name' => 'test']);
+
+        self::assertSame('test (from AsEntityListener)', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableAllAsEntityListeners(): void
+    {
+        $entity = EntityWithAsEntityListenerFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testItCanDisableSpecificAsEntityListener(): void
+    {
+        $entity = EntityWithAsEntityListenerFactory::new()
+            ->withoutDoctrineEvents(AsEntityListenerListener::class)
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    #[Test]
+    public function testAsEntityListenerIsRestoredAfterCreation(): void
+    {
+        EntityWithAsEntityListenerFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'first']);
+
+        $entity = EntityWithAsEntityListenerFactory::createOne(['name' => 'second']);
+
+        self::assertSame('second (from AsEntityListener)', $entity->name);
+    }
+}


### PR DESCRIPTION
## Motivation

When Foundry factories create entities during fixture loading, Doctrine event listeners attached to those entities fire as usual. This can cause unwanted side effects in tests — for example, sending emails, dispatching messages, or calling external services on every persist.

Related #216.

## What this PR adds

A `withoutDoctrineEvents()` method on `PersistentObjectFactory` that temporarily removes Doctrine event listeners from the `EventManager` around the `flush()` call, then restores them immediately after.

## API

```php
// Disable ALL Doctrine event listeners during create()
PostFactory::new()->withoutDoctrineEvents()->create([...]);

// Disable specific listeners only
PostFactory::new()
    ->withoutDoctrineEvents(MyEventListener::class)
    ->create([...]);
```

I have 2 failing checks, but both are pre-existing issues unrelated to this PR.

fixes #957