### PR TITLE
fix: factory template formatting

### DIFF
--- a/skeleton/Factory.tpl.php
+++ b/skeleton/Factory.tpl.php
@@ -25,7 +25,7 @@ if (count($makeFactoryData->getMethodsPHPDoc())) {
 }
 ?>
  */
-final class <?php echo $class_name; ?> extends <?php echo $makeFactoryData->getFactoryClassShortName(); ?>
+final class <?php echo $class_name; ?> extends <?php echo $makeFactoryData->getFactoryClassShortName(); ?><?= "\n" ?>
 {
 <?php if ($makeFactoryData->shouldAddHints()): ?>    /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
@@ -34,21 +34,22 @@ final class <?php echo $class_name; ?> extends <?php echo $makeFactoryData->getF
      */
     public function __construct()
     {
+        parent::__construct();
     }
 
-<?php endif ?><?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?php endif ?>
+<?php endif ?><?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?= "\n" ?><?php endif ?>
     public static function class(): string
     {
         return <?php echo $makeFactoryData->getObjectShortName(); ?>::class;
     }
 
-<?php if ($makeFactoryData->shouldAddHints()): ?>        /**
+<?php if ($makeFactoryData->shouldAddHints()): ?>    /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
      *
      * @todo add your default values here
      */
-<?php endif ?><?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?php endif ?>
-    protected function defaults(): array<?php if ($makeFactoryData->shouldAddHints()): ?>|callable<?php endif ?>
+<?php endif ?><?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?= "\n" ?><?php endif ?>
+    protected function defaults(): array<?php if ($makeFactoryData->shouldAddHints()): ?>|callable<?= "\n" ?><?php endif ?>
     {
         return [
 <?php
@@ -59,10 +60,10 @@ foreach ($makeFactoryData->getDefaultProperties() as $propertyName => $value) {
         ];
     }
 
-<?php if ($makeFactoryData->shouldAddHints()): ?>        /**
+<?php if ($makeFactoryData->shouldAddHints()): ?>    /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
      */
-<?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?php endif ?>
+<?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?= "\n" ?><?php endif ?>
     protected function initialize(): static
     {
         return $this

--- a/skeleton/Factory.tpl.php
+++ b/skeleton/Factory.tpl.php
@@ -34,7 +34,6 @@ final class <?php echo $class_name; ?> extends <?php echo $makeFactoryData->getF
      */
     public function __construct()
     {
-        parent::__construct();
     }
 
 <?php endif ?><?php if ($makeFactoryData->shouldAddOverrideAttributes()): ?>    #[\Override]<?= "\n" ?><?php endif ?>


### PR DESCRIPTION
Because of how php tag works the output of `make:factory` generates some "not so pretty" PHP code. It lacks some carriage returns that place `Override` attributes where they shouldn't be and has more spaces than needed in some places.

Generated code:

```php
<?php

namespace App\Factory;

use App\Entity\User;
use App\Repository\UserRepository;
use Doctrine\ORM\EntityRepository;
use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
use Zenstruck\Foundry\Persistence\Proxy;
use Zenstruck\Foundry\Persistence\ProxyRepositoryDecorator;

/**
 * @extends PersistentObjectFactory<User>
 */
final class UserFactory extends PersistentObjectFactory{
    /**
     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories-as-services
     *
     * @todo inject services if required
     */
    public function __construct()
    {
    }

    #[\Override]    public static function class(): string
    {
        return User::class;
    }

        /**
     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#model-factories
     *
     * @todo add your default values here
     */
    #[\Override]    protected function defaults(): array|callable    {
        return [
            'name' => self::faker()->text(10),
        ];
    }

        /**
     * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization
     */
    #[\Override]    protected function initialize(): static
    {
        return $this
            // ->afterInstantiate(function(User $user): void {})
        ;
    }
}

```