### PR TITLE
feat: not persist reverse relation when `withoutPersisting()` mentioned

### DIFF
--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -53,6 +53,14 @@ final class FactoryCollection implements \IteratorAggregate
 
     /**
      * @internal
+     */
+    public function isPersisting(): bool
+    {
+        return $this->persistMode->isPersisting();
+    }
+
+    /**
+     * @internal
      * @return self<T, TFactory>
      */
     public function notRootFactory(): static

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -372,8 +372,15 @@ abstract class PersistentObjectFactory extends ObjectFactory
         }
 
         if ($value instanceof self) {
+            // TODO: Not know why, break some tests:
+            // $value = $value
+            //     ->withPersistMode($value->persistMode())
+            //     ->notRootFactory();
+            // So, store it instead
+            $isPersistingValue = $value->isPersisting();
+
             $value = $value
-                ->withPersistMode($this->persist)
+                ->withPersistMode($this->persistMode())
                 ->notRootFactory();
 
             if (null !== $this->disabledDoctrineEventClasses) {
@@ -391,7 +398,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
                 $value = $value
                     ->reuse(...$this->reusedObjects(), ...$value->reusedObjects())
                     ->withPersistMode(
-                        $this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
+                    $this->isPersisting() && $isPersistingValue ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING
                     )
                 ;
 
@@ -444,7 +451,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
                 $inverseObjects = $collection
                     ->reuse(...$this->reusedObjects())
-                    ->withPersistMode($this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING)
+                    ->withPersistMode($this->isPersisting() && $collection->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING)
                     ->create([$inverseField => $object]);
 
                 $inverseObjects = ProxyGenerator::unwrap($inverseObjects, withAutoRefresh: false);


### PR DESCRIPTION
try to fix https://github.com/zenstruck/foundry/issues/1100

On reverse relation, if the user explicitly add `withoutPersisting()`, do not persist.

and use #1104 to call adders ?