### PR TITLE
fix: `withoutDoctrineEvents` should do nothgin in unit tests

### DIFF
--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -239,15 +239,13 @@ abstract class PersistentObjectFactory extends ObjectFactory
      */
     public function create(callable|array $attributes = []): object
     {
-        if (null !== $this->disabledDoctrineEventClasses) {
-            $configuration = Configuration::instance();
-            if ($configuration->isPersistenceAvailable()) {
-                return $configuration->persistence()->withoutDoctrineEvents(
-                    static::class(),
-                    $this->disabledDoctrineEventClasses,
-                    fn() => $this->doCreate($attributes),
-                );
-            }
+        $configuration = Configuration::instance();
+        if (null !== $this->disabledDoctrineEventClasses && $configuration->isPersistenceAvailable()) {
+            return $configuration->persistence()->withoutDoctrineEvents(
+                static::class(),
+                $this->disabledDoctrineEventClasses,
+                fn() => $this->doCreate($attributes),
+            );
         }
 
         return $this->doCreate($attributes);

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -240,11 +240,14 @@ abstract class PersistentObjectFactory extends ObjectFactory
     public function create(callable|array $attributes = []): object
     {
         if (null !== $this->disabledDoctrineEventClasses) {
-            return Configuration::instance()->persistence()->withoutDoctrineEvents(
-                static::class(),
-                $this->disabledDoctrineEventClasses,
-                fn() => $this->doCreate($attributes),
-            );
+            $configuration = Configuration::instance();
+            if ($configuration->isPersistenceAvailable()) {
+                return $configuration->persistence()->withoutDoctrineEvents(
+                    static::class(),
+                    $this->disabledDoctrineEventClasses,
+                    fn() => $this->doCreate($attributes),
+                );
+            }
         }
 
         return $this->doCreate($attributes);

--- a/tests/Integration/ORM/WithoutDoctrineEventsUnitTest.php
+++ b/tests/Integration/ORM/WithoutDoctrineEventsUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\DoctrineEventsSubscriber;
+use Zenstruck\Foundry\Tests\Fixture\DoctrineEvents\EntityForDoctrineEventsFactory;
+
+final class WithoutDoctrineEventsUnitTest extends TestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_has_no_effect_in_unit_test_with_all_doctrine_events(): void
+    {
+        $entity = EntityForDoctrineEventsFactory::new()
+            ->withoutDoctrineEvents()
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_has_no_effect_in_unit_test_with_specific_doctrine_event_listener(): void
+    {
+        $entity = EntityForDoctrineEventsFactory::new()
+            ->withoutDoctrineEvents(DoctrineEventsSubscriber::class)
+            ->create(['name' => 'test']);
+
+        self::assertSame('test', $entity->name);
+    }
+}

--- a/tests/Unit/WithoutDoctrineEventsUnitTest.php
+++ b/tests/Unit/WithoutDoctrineEventsUnitTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Foundry\Tests\Integration\ORM;
+namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Try to fix https://github.com/zenstruck/foundry/issues/1120