### PR TITLE
fix: defer `$em->persist()` until the object graph is wired + natural accessor directionality

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -665,6 +665,24 @@ they were added, or by priority (higher priority hooks are executed first).
 
     Hook priority were added in Foundry 2.8.
 
+``beforeInstantiate`` and ``afterInstantiate`` hooks run **before** the object graph is handed over to the
+object manager: state set by Doctrine lifecycle listeners (e.g. a field computed in a ``PrePersist``
+listener) is not yet available, even for objects created by a nested factory. To observe such state,
+register an ``afterInstantiate`` hook with a priority lower than
+``PersistentObjectFactory::PRIORITY_SCHEDULE_FOR_INSERT``: it runs once the whole object graph has been
+persisted (but not flushed yet):
+
+::
+
+    use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+    PostFactory::new()
+        ->afterInstantiate(function(Post $post): void {
+            // the "pre persist" events of the whole object graph have been triggered:
+            // any state they computed is visible here
+        }, priority: PersistentObjectFactory::PRIORITY_SCHEDULE_FOR_INSERT - 1)
+    ;
+
 You can also add hooks directly in your factory class:
 
 ::

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -218,6 +218,24 @@ final class FactoryCollection implements \IteratorAggregate
     }
 
     /**
+     * @param callable(TFactory):TFactory $callback
+     *
+     * @return self<T, TFactory>
+     *
+     * @internal
+     */
+    public function map(callable $callback): self
+    {
+        $factories = $this->all();
+
+        if ([] === $factories) {
+            return $this;
+        }
+
+        return new self($this->factory, static fn() => \array_map($callback, $factories));
+    }
+
+    /**
      * @internal
      */
     public function reuse(object ...$objects): static
@@ -226,15 +244,7 @@ final class FactoryCollection implements \IteratorAggregate
             return $this;
         }
 
-        $factories = $this->all();
-
-        return new self(
-            $this->factory,
-            static fn() => \array_map(
-                static fn(Factory $f) => $f instanceof ObjectFactory ? $f->reuse(...$objects) : $f,
-                $factories,
-            )
-        );
+        return $this->map(static fn(Factory $f) => $f instanceof ObjectFactory ? $f->reuse(...$objects) : $f);
     }
 
     /**

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -51,13 +51,13 @@ final class Hydrator
                 continue;
             }
 
-            if (true === $this->forceProperties || \in_array($parameter, $this->forceProperties, true) || $value instanceof ForceValue) {
+            if ($this->shouldForceProperty($parameter) || $value instanceof ForceValue) {
                 if ($value instanceof ForceValue) {
                     $value = $value->value;
                 }
 
                 try {
-                    self::set($object, $parameter, $value);
+                    self::forceSet($object, $parameter, $value);
                 } catch (\InvalidArgumentException $e) {
                     if (true !== $this->extraAttributes) {
                         throw $e;
@@ -67,10 +67,8 @@ final class Hydrator
                 continue;
             }
 
-            self::$accessor ??= new PropertyAccessor();
-
             try {
-                self::$accessor->setValue($object, $parameter, $value);
+                self::propertyAccessor()->setValue($object, $parameter, $value);
             } catch (NoSuchPropertyException $e) {
                 if (true !== $this->extraAttributes) {
                     throw new \InvalidArgumentException(\sprintf('Cannot set attribute "%s" for object "%s" (not public and no setter).', $parameter, $object::class), previous: $e);
@@ -97,7 +95,7 @@ final class Hydrator
         return $clone;
     }
 
-    public static function set(object $object, string $property, mixed $value, bool $catchErrors = false): void
+    public static function forceSet(object $object, string $property, mixed $value, bool $catchErrors = false): void
     {
         $value = ForceValue::unwrap($value);
 
@@ -132,8 +130,50 @@ final class Hydrator
             return;
         }
 
+        if (!$inverseValue instanceof Collection && $inverseValue instanceof \Traversable) {
+            $inverseValue = \iterator_to_array($inverseValue);
+        }
+
         $inverseValue[] = $value;
-        self::set($object, $property, $inverseValue, catchErrors: true);
+        self::forceSet($object, $property, $inverseValue, catchErrors: true);
+    }
+
+    /**
+     * Adds the given values to a collection property through its adder when one exists
+     * (so domain logic in adders runs), without ever removing already present items.
+     * Forced properties and objects without accessors fall back to raw reflection.
+     *
+     * @param list<object> $values
+     */
+    public function addAll(object $object, string $property, array $values): void
+    {
+        if ($this->shouldForceProperty($property)) {
+            self::forceSet($object, $property, $values, catchErrors: true);
+
+            return;
+        }
+
+        $currentValue = self::get($object, $property);
+        $currentItems = match (true) {
+            $currentValue instanceof Collection => $currentValue->toArray(),
+            \is_array($currentValue) => $currentValue,
+            $currentValue instanceof \Traversable => \iterator_to_array($currentValue),
+            default => [],
+        };
+
+        $newItems = \array_filter($values, static fn(object $value) => !\in_array($value, $currentItems, true));
+
+        if ([] === $newItems) {
+            return;
+        }
+
+        try {
+            self::propertyAccessor()->setValue($object, $property, [...\array_values($currentItems), ...\array_values($newItems)]);
+        } catch (NoSuchPropertyException|\TypeError) {
+            foreach ($newItems as $newItem) {
+                self::add($object, $property, $newItem);
+            }
+        }
     }
 
     public static function get(object $object, string $property): mixed
@@ -160,7 +200,7 @@ final class Hydrator
         }
 
         foreach ($properties as $property) {
-            self::set($object, $property, self::get($other, $property), catchErrors: true);
+            self::forceSet($object, $property, self::get($other, $property), catchErrors: true);
         }
     }
 
@@ -189,6 +229,16 @@ final class Hydrator
         }
 
         return null;
+    }
+
+    private function shouldForceProperty(int|string $property): bool
+    {
+        return true === $this->forceProperties || \in_array($property, $this->forceProperties, true);
+    }
+
+    private static function propertyAccessor(): PropertyAccessor
+    {
+        return self::$accessor ??= new PropertyAccessor();
     }
 
     private static function isDoctrineCollection(object $object, string $property): bool

--- a/src/Object/Instantiator.php
+++ b/src/Object/Instantiator.php
@@ -103,6 +103,14 @@ final class Instantiator
         return $clone;
     }
 
+    /**
+     * @internal
+     */
+    public function hydrator(): Hydrator
+    {
+        return $this->hydrator;
+    }
+
     public function disableHydration(): self
     {
         $clone = clone $this;

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry;
 
 use Zenstruck\Foundry\Object\Event\AfterInstantiate;
 use Zenstruck\Foundry\Object\Event\BeforeInstantiate;
+use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\Object\Instantiator;
 use Zenstruck\Foundry\Persistence\ProxyGenerator;
 
@@ -91,6 +92,16 @@ abstract class ObjectFactory extends Factory
     final public function instantiator(): callable
     {
         return $this->instantiator ?? Configuration::instance()->instantiator;
+    }
+
+    /**
+     * @internal
+     */
+    final protected function hydrator(): Hydrator
+    {
+        $instantiator = $this->instantiator();
+
+        return $instantiator instanceof Instantiator ? $instantiator->hydrator() : new Hydrator();
     }
 
     /**

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -93,7 +93,7 @@ trait IsProxy // @phpstan-ignore trait.unused
     {
         $this->_autoRefresh();
 
-        Hydrator::set($this->initializeLazyObject(), $property, $value);
+        Hydrator::forceSet($this->initializeLazyObject(), $property, $value);
 
         return $this;
     }

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -41,6 +41,9 @@ class PersistenceManager
     /** @var list<callable():bool> */
     private array $afterPersistCallbacks = [];
 
+    /** @var array<int, object> objects awaiting an object manager persist, in creation order */
+    private array $pendingForInsert = [];
+
     /**
      * @param iterable<PersistenceStrategy> $strategies
      */
@@ -78,6 +81,8 @@ class PersistenceManager
             return $object->_save();
         }
 
+        $this->persistScheduled();
+
         $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
         $om->persist($object);
         $this->flush($om);
@@ -105,12 +110,30 @@ class PersistenceManager
             $object = ProxyGenerator::unwrap($object);
         }
 
-        $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
-        $om->persist($object);
+        $this->pendingForInsert[\spl_object_id($object)] ??= $object;
 
         $this->afterPersistCallbacks = [...$this->afterPersistCallbacks, ...$afterPersistCallbacks];
 
         return $object;
+    }
+
+    /**
+     * Persists all scheduled objects, in creation order. Doing this only once the whole
+     * object graph is instantiated and wired guarantees lifecycle events (eg: "pre persist")
+     * never observe half-built objects.
+     */
+    public function persistScheduled(): void
+    {
+        // a "pre persist" listener may schedule new objects: keep draining until empty
+        while ($this->pendingForInsert) {
+            $object = \array_shift($this->pendingForInsert);
+            $this->strategyFor($object::class)->objectManagerFor($object::class)->persist($object);
+        }
+    }
+
+    public function discardScheduled(): void
+    {
+        $this->pendingForInsert = [];
     }
 
     /**
@@ -128,6 +151,7 @@ class PersistenceManager
 
         $this->flush = true;
 
+        $this->persistScheduled();
         $this->flushAllStrategies();
 
         $callbacksCalled = $this->callPostPersistCallbacks();

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -57,6 +57,9 @@ abstract class PersistentObjectFactory extends ObjectFactory
     /** @var list<callable(T):void> */
     private array $inverseRelationshipCallbacks = [];
 
+    /** @var list<string> */
+    private array $skipInverseWiringFields = [];
+
     private bool $isRootFactory = true;
 
     private ?bool $autorefreshEnabled = null;
@@ -255,6 +258,12 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         try {
             return $factory->doCreate($attributes);
+        } catch (\Throwable $e) {
+            if (null !== $ownedScope) {
+                $configuration->persistence()->discardScheduled();
+            }
+
+            throw $e;
         } finally {
             $ownedScope?->close();
         }
@@ -372,6 +381,20 @@ abstract class PersistentObjectFactory extends ObjectFactory
     }
 
     /**
+     * The inverse side of the given field will not be silently wired when this
+     * factory's object is created: the owner of the relation does the wiring itself.
+     *
+     * @internal
+     */
+    public function skipInverseWiringFor(string $field): static
+    {
+        $clone = clone $this;
+        $clone->skipInverseWiringFields[] = $field;
+
+        return $clone;
+    }
+
+    /**
      * @internal
      */
     public function notRootFactory(): static
@@ -461,22 +484,19 @@ abstract class PersistentObjectFactory extends ObjectFactory
         // scope rides on the item factories themselves, so it survives any collection
         // reconstruction (reuse(), distribute()) without FactoryCollection knowing about it
         if (null !== $scope = $this->doctrineEventsScope) {
-            $factories = \array_map(
-                static fn(Factory $f) => $f instanceof self ? $f->withDoctrineEventsScope($scope) : $f,
-                $collection->all(),
-            );
-
-            if ([] !== $factories) {
-                $collection = FactoryCollection::fromFactoriesList($factories);
-            }
+            $collection = $collection->map(static fn(Factory $f) => $f instanceof self ? $f->withDoctrineEventsScope($scope) : $f);
         }
 
         $collection = $collection->notRootFactory();
 
         if ($inverseRelationshipMetadata instanceof OneToManyRelationship) {
-            $this->inverseRelationshipCallbacks[] = function(object $object) use ($collection, $inverseRelationshipMetadata, $field) {
-                $inverseField = $inverseRelationshipMetadata->inverseField();
+            $inverseField = $inverseRelationshipMetadata->inverseField();
 
+            // this factory's accessor (see the callback below) is the single wiring agent
+            // for its own collection: children must not silently touch it from their side
+            $collection = $collection->map(static fn(Factory $f) => $f instanceof self ? $f->skipInverseWiringFor($inverseField) : $f);
+
+            $this->inverseRelationshipCallbacks[] = function(object $object) use ($collection, $inverseRelationshipMetadata, $field, $inverseField) {
                 $inverseObjects = $collection
                     ->reuse(...$this->reusedObjects())
                     ->withPersistMode($this->isPersisting() ? PersistMode::NO_PERSIST_BUT_SCHEDULE_FOR_INSERT : PersistMode::WITHOUT_PERSISTING)
@@ -484,15 +504,18 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
                 $inverseObjects = ProxyGenerator::unwrap($inverseObjects, withAutoRefresh: false);
 
-                // if the collection is indexed by a field, index the array
+                // if the collection is indexed by a field, index the array and keep a raw
+                // assignment: going through an adder would lose the keys
                 if ($inverseRelationshipMetadata->collectionIndexedBy) {
                     $inverseObjects = \array_combine(
                         \array_map(static fn($o) => get($o, $inverseRelationshipMetadata->collectionIndexedBy), $inverseObjects),
                         \array_values($inverseObjects)
                     );
-                }
 
-                set($object, $field, $inverseObjects);
+                    Hydrator::forceSet($object, $field, $inverseObjects);
+                } else {
+                    $this->hydrator()->addAll($object, $field, $inverseObjects);
+                }
             };
 
             // creation delegated to tempAfterInstantiate hook - return empty array here
@@ -527,11 +550,11 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         if ($inverseRelationship instanceof OneToOneRelationship) {
             $this->inverseRelationshipCallbacks[] = static function(object $newObject) use ($object, $inverseRelationship) {
-                Hydrator::set($object, $inverseRelationship->inverseField(), $newObject, catchErrors: true);
+                Hydrator::forceSet($object, $inverseRelationship->inverseField(), $newObject, catchErrors: true);
             };
         }
 
-        if ($inverseRelationship instanceof ManyToOneRelationship) {
+        if ($inverseRelationship instanceof ManyToOneRelationship && !\in_array($field, $this->skipInverseWiringFields, true)) {
             $this->inverseRelationshipCallbacks[] = static function(object $newObject) use ($object, $inverseRelationship) {
                 Hydrator::add($object, $inverseRelationship->inverseField(), $newObject);
             };
@@ -578,7 +601,14 @@ abstract class PersistentObjectFactory extends ObjectFactory
                         };
                     }
 
-                    Configuration::instance()->persistence()->scheduleForInsert($object, $afterPersistCallbacks);
+                    $persistenceManager = Configuration::instance()->persistence();
+                    $persistenceManager->scheduleForInsert($object, $afterPersistCallbacks);
+
+                    // the root factory's hook is the single point where the whole object graph
+                    // is guaranteed instantiated and wired: persist everything now
+                    if ($factoryUsed->isRootFactory && PersistMode::PERSIST === $factoryUsed->persistMode()) {
+                        $persistenceManager->persistScheduled();
+                    }
                 },
                 self::PRIORITY_SCHEDULE_FOR_INSERT
             )

--- a/src/functions.php
+++ b/src/functions.php
@@ -59,7 +59,7 @@ function object(string $class, array|callable $attributes = []): object
  */
 function set(object $object, string $property, mixed $value): object
 {
-    Hydrator::set($object, $property, $value);
+    Hydrator::forceSet($object, $property, $value);
 
     return $object;
 }

--- a/tests/Fixture/Entity/EdgeCases/AccessorDirectionality/CategoryEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/AccessorDirectionality/CategoryEntity.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\AccessorDirectionality;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('accessor_directionality_category')]
+class CategoryEntity extends Base
+{
+    /** @var Collection<int, ItemEntity> */
+    #[ORM\OneToMany(targetEntity: ItemEntity::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
+    private Collection $items;
+
+    public int $adderCalls = 0;
+
+    public function __construct()
+    {
+        $this->items = new ArrayCollection();
+    }
+
+    public function addItem(ItemEntity $item): void
+    {
+        ++$this->adderCalls;
+
+        if (!$this->items->contains($item)) {
+            $this->items->add($item);
+            $item->setCategory($this);
+        }
+    }
+
+    public function removeItem(ItemEntity $item): void
+    {
+        if ($this->items->removeElement($item) && $item->getCategory() === $this) {
+            $item->setCategory(null);
+        }
+    }
+
+    /**
+     * @return Collection<int, ItemEntity>
+     */
+    public function getItems(): Collection
+    {
+        return $this->items;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/AccessorDirectionality/ItemEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/AccessorDirectionality/ItemEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\AccessorDirectionality;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('accessor_directionality_item')]
+class ItemEntity extends Base
+{
+    #[ORM\ManyToOne(targetEntity: CategoryEntity::class, inversedBy: 'items')]
+    private ?CategoryEntity $category = null;
+
+    public int $setterCalls = 0;
+
+    public function getCategory(): ?CategoryEntity
+    {
+        return $this->category;
+    }
+
+    public function setCategory(?CategoryEntity $category): void
+    {
+        ++$this->setterCalls;
+        $this->category = $category;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/CascadeCtorRequiredParent/ChildEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/CascadeCtorRequiredParent/ChildEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadeCtorRequiredParent;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * The parent is required by the constructor AND the ManyToOne cascades persist:
+ * persisting the child may cascade to a parent Foundry did not persist itself yet.
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('cascade_ctor_required_child')]
+class ChildEntity extends Base
+{
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: ParentEntity::class, inversedBy: 'children', cascade: ['persist'])]
+        #[ORM\JoinColumn(nullable: false)]
+        public ParentEntity $parent,
+    ) {
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/CascadeCtorRequiredParent/ParentEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/CascadeCtorRequiredParent/ParentEntity.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadeCtorRequiredParent;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('cascade_ctor_required_parent')]
+#[ORM\HasLifecycleCallbacks]
+class ParentEntity extends Base
+{
+    /** @var Collection<int, ChildEntity> */
+    #[ORM\OneToMany(targetEntity: ChildEntity::class, mappedBy: 'parent', cascade: ['persist'])]
+    private Collection $children;
+
+    #[ORM\Column]
+    public int $childrenCountAtPrePersist = 0;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    #[ORM\PrePersist]
+    public function computeChildrenCount(): void
+    {
+        $this->childrenCountAtPrePersist = $this->children->count();
+    }
+
+    public function addChild(ChildEntity $child): void
+    {
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+        }
+    }
+
+    public function removeChild(ChildEntity $child): void
+    {
+        $this->children->removeElement($child);
+    }
+
+    /**
+     * @return Collection<int, ChildEntity>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainA.php
+++ b/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainA.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadePersistChain;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('cascade_persist_chain_a')]
+#[ORM\HasLifecycleCallbacks]
+class ChainA extends Base
+{
+    /** @var Collection<int, ChainB> */
+    #[ORM\OneToMany(targetEntity: ChainB::class, mappedBy: 'a', cascade: ['persist', 'remove'])]
+    private Collection $bs;
+
+    #[ORM\Column]
+    public int $bsCountAtPrePersist = 0;
+
+    public function __construct()
+    {
+        $this->bs = new ArrayCollection();
+    }
+
+    #[ORM\PrePersist]
+    public function computeBsCount(): void
+    {
+        $this->bsCountAtPrePersist = $this->bs->count();
+    }
+
+    public function addB(ChainB $b): void
+    {
+        if (!$this->bs->contains($b)) {
+            $this->bs->add($b);
+            $b->setA($this);
+        }
+    }
+
+    public function removeB(ChainB $b): void
+    {
+        if ($this->bs->removeElement($b) && $b->getA() === $this) {
+            $b->setA(null);
+        }
+    }
+
+    /**
+     * @return Collection<int, ChainB>
+     */
+    public function getBs(): Collection
+    {
+        return $this->bs;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainB.php
+++ b/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainB.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadePersistChain;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('cascade_persist_chain_b')]
+#[ORM\HasLifecycleCallbacks]
+class ChainB extends Base
+{
+    #[ORM\ManyToOne(targetEntity: ChainA::class, inversedBy: 'bs')]
+    private ?ChainA $a = null;
+
+    /** @var Collection<int, ChainC> */
+    #[ORM\OneToMany(targetEntity: ChainC::class, mappedBy: 'b', cascade: ['persist', 'remove'])]
+    private Collection $cs;
+
+    #[ORM\Column]
+    public int $csCountAtPrePersist = 0;
+
+    #[ORM\Column]
+    public bool $hasAAtPrePersist = false;
+
+    public function __construct()
+    {
+        $this->cs = new ArrayCollection();
+    }
+
+    #[ORM\PrePersist]
+    public function capturePrePersistState(): void
+    {
+        $this->csCountAtPrePersist = $this->cs->count();
+        $this->hasAAtPrePersist = null !== $this->a;
+    }
+
+    public function getA(): ?ChainA
+    {
+        return $this->a;
+    }
+
+    public function setA(?ChainA $a): void
+    {
+        $this->a = $a;
+    }
+
+    public function addC(ChainC $c): void
+    {
+        if (!$this->cs->contains($c)) {
+            $this->cs->add($c);
+            $c->setB($this);
+        }
+    }
+
+    public function removeC(ChainC $c): void
+    {
+        if ($this->cs->removeElement($c) && $c->getB() === $this) {
+            $c->setB(null);
+        }
+    }
+
+    /**
+     * @return Collection<int, ChainC>
+     */
+    public function getCs(): Collection
+    {
+        return $this->cs;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainC.php
+++ b/tests/Fixture/Entity/EdgeCases/CascadePersistChain/ChainC.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadePersistChain;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('cascade_persist_chain_c')]
+#[ORM\HasLifecycleCallbacks]
+class ChainC extends Base
+{
+    #[ORM\ManyToOne(targetEntity: ChainB::class, inversedBy: 'cs')]
+    private ?ChainB $b = null;
+
+    #[ORM\Column]
+    public bool $hasBAtPrePersist = false;
+
+    #[ORM\PrePersist]
+    public function capturePrePersistState(): void
+    {
+        $this->hasBAtPrePersist = null !== $this->b;
+    }
+
+    public function getB(): ?ChainB
+    {
+        return $this->b;
+    }
+
+    public function setB(?ChainB $b): void
+    {
+        $this->b = $b;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/OrphanRemoval/ChildEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/OrphanRemoval/ChildEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OrphanRemoval;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('orphan_removal_child')]
+class ChildEntity extends Base
+{
+    #[ORM\ManyToOne(targetEntity: ParentEntity::class, inversedBy: 'children')]
+    public ?ParentEntity $parent = null;
+}

--- a/tests/Fixture/Entity/EdgeCases/OrphanRemoval/ParentEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/OrphanRemoval/ParentEntity.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OrphanRemoval;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('orphan_removal_parent')]
+#[ORM\HasLifecycleCallbacks]
+class ParentEntity extends Base
+{
+    /** @var Collection<int, ChildEntity> */
+    #[ORM\OneToMany(targetEntity: ChildEntity::class, mappedBy: 'parent', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $children;
+
+    #[ORM\Column]
+    public int $childrenCount = 0;
+
+    #[ORM\Column]
+    public string $name = 'initial';
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function computeChildrenCount(): void
+    {
+        $this->childrenCount = $this->children->count();
+    }
+
+    public function addChild(ChildEntity $child): void
+    {
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+            $child->parent = $this;
+        }
+    }
+
+    public function removeChild(ChildEntity $child): void
+    {
+        if ($this->children->removeElement($child) && $child->parent === $this) {
+            $child->parent = null;
+        }
+    }
+
+    /**
+     * @return Collection<int, ChildEntity>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/Integration/ORM/AccessorDirectionalityTest.php
+++ b/tests/Integration/ORM/AccessorDirectionalityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\AccessorDirectionality\CategoryEntity;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\AccessorDirectionality\ItemEntity;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+
+/**
+ * The accessor of the side being built is used; the other side is kept
+ * consistent silently, without triggering its accessor's side effects.
+ *
+ * @see https://github.com/zenstruck/foundry/pull/1104
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class AccessorDirectionalityTest extends KernelTestCase
+{
+    use Factories, RequiresORM, ResetDatabase;
+
+    /** @test */
+    #[Test]
+    public function adder_is_used_when_creating_from_the_collection_side(): void
+    {
+        $categoryFactory = persistent_factory(CategoryEntity::class);
+        $itemFactory = persistent_factory(ItemEntity::class);
+
+        $category = $categoryFactory->create(['items' => $itemFactory->many(2)]);
+
+        self::assertSame(2, $category->adderCalls);
+        self::assertCount(2, $category->getItems());
+
+        $item = $category->getItems()->first();
+        self::assertNotFalse($item);
+        self::assertSame($category, $item->getCategory());
+        $itemFactory::assert()->count(2);
+    }
+
+    /** @test */
+    #[Test]
+    public function adder_side_effects_are_not_triggered_when_creating_from_the_owning_side(): void
+    {
+        $categoryFactory = persistent_factory(CategoryEntity::class);
+        $itemFactory = persistent_factory(ItemEntity::class);
+
+        $item = $itemFactory->create(['category' => $categoryFactory]);
+
+        $category = $item->getCategory();
+        self::assertNotNull($category);
+        self::assertSame(0, $category->adderCalls);
+        self::assertGreaterThanOrEqual(1, $item->setterCalls);
+        self::assertCount(1, $category->getItems());
+        $itemFactory::assert()->count(1);
+    }
+}

--- a/tests/Integration/ORM/DeferredPersistTest.php
+++ b/tests/Integration/ORM/DeferredPersistTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadeCtorRequiredParent;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadePersistChain;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OrphanRemoval;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+
+/**
+ * Lifecycle events must never observe a half-built object graph: em->persist() is
+ * deferred until the whole graph is instantiated and wired.
+ *
+ * @see https://github.com/zenstruck/foundry/issues/1100
+ * @see https://github.com/zenstruck/foundry/issues/1115
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class DeferredPersistTest extends KernelTestCase
+{
+    use Factories, RequiresORM, ResetDatabase;
+
+    /** @test */
+    #[Test]
+    public function pre_persist_can_access_populated_one_to_many_collection(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+        $cFactory = persistent_factory(CascadePersistChain\ChainC::class);
+
+        $a = $aFactory->create([
+            'bs' => $bFactory->with(['cs' => $cFactory->many(1)])->many(1),
+        ]);
+
+        $aFactory::assert()->count(1);
+        $bFactory::assert()->count(1);
+        $cFactory::assert()->count(1);
+
+        self::assertSame(1, $a->bsCountAtPrePersist);
+
+        $b = $a->getBs()->first();
+        self::assertNotFalse($b);
+        self::assertTrue($b->hasAAtPrePersist);
+        self::assertSame(1, $b->csCountAtPrePersist);
+
+        $c = $b->getCs()->first();
+        self::assertNotFalse($c);
+        self::assertTrue($c->hasBAtPrePersist);
+    }
+
+    /** @test */
+    #[Test]
+    public function pre_persist_sees_populated_collections_when_created_from_child_side(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+        $cFactory = persistent_factory(CascadePersistChain\ChainC::class);
+
+        $c = $cFactory->create(['b' => $bFactory->with(['a' => $aFactory])]);
+
+        $b = $c->getB();
+        self::assertNotNull($b);
+        $a = $b->getA();
+        self::assertNotNull($a);
+
+        self::assertTrue($c->hasBAtPrePersist);
+        self::assertTrue($b->hasAAtPrePersist);
+        self::assertSame(1, $b->csCountAtPrePersist);
+        self::assertSame(1, $a->bsCountAtPrePersist);
+    }
+
+    /** @test */
+    #[Test]
+    public function pre_persist_sees_populated_collection_with_unpersisted_parent_instance(): void
+    {
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+
+        $b = $bFactory->create(['a' => $a = new CascadePersistChain\ChainA()]);
+
+        self::assertTrue($b->hasAAtPrePersist);
+        self::assertSame(1, $a->bsCountAtPrePersist);
+    }
+
+    /** @test */
+    #[Test]
+    public function pre_persist_sees_children_when_child_constructor_requires_parent_with_cascade(): void
+    {
+        $parentFactory = persistent_factory(CascadeCtorRequiredParent\ParentEntity::class);
+        $childFactory = persistent_factory(CascadeCtorRequiredParent\ChildEntity::class);
+
+        $parent = $parentFactory->create(['children' => $childFactory->many(2)]);
+
+        self::assertSame(2, $parent->childrenCountAtPrePersist);
+        $parentFactory::assert()->count(1);
+        $childFactory::assert()->count(2);
+    }
+
+    /** @test */
+    #[Test]
+    public function pre_persist_sees_child_when_created_from_child_side_with_cascade(): void
+    {
+        $parentFactory = persistent_factory(CascadeCtorRequiredParent\ParentEntity::class);
+        $childFactory = persistent_factory(CascadeCtorRequiredParent\ChildEntity::class);
+
+        $child = $childFactory->create(['parent' => $parentFactory]);
+
+        self::assertSame(1, $child->parent->childrenCountAtPrePersist);
+        $childFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/zenstruck/foundry/pull/1134#issuecomment-5021148915
+     */
+    #[Test]
+    public function lifecycle_state_of_nested_objects_is_visible_below_schedule_for_insert_priority(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+        $cFactory = persistent_factory(CascadePersistChain\ChainC::class);
+
+        $hasAAtDefaultPriority = null;
+        $stateAfterInsert = null;
+
+        $cFactory
+            ->afterInstantiate(static function(CascadePersistChain\ChainC $c) use (&$hasAAtDefaultPriority): void {
+                $hasAAtDefaultPriority = $c->getB()?->hasAAtPrePersist;
+            })
+            ->afterInstantiate(static function(CascadePersistChain\ChainC $c) use (&$stateAfterInsert): void {
+                $stateAfterInsert = [
+                    'hasAAtPrePersist' => $c->getB()?->hasAAtPrePersist,
+                    'bsCountAtPrePersist' => $c->getB()?->getA()?->bsCountAtPrePersist,
+                ];
+            }, PersistentObjectFactory::PRIORITY_SCHEDULE_FOR_INSERT - 1)
+            ->create(['b' => $bFactory->with(['a' => $aFactory])]);
+
+        self::assertFalse($hasAAtDefaultPriority);
+        self::assertSame(['hasAAtPrePersist' => true, 'bsCountAtPrePersist' => 1], $stateAfterInsert);
+    }
+
+    /** @test */
+    #[Test]
+    public function lifecycle_state_of_collection_items_is_visible_below_schedule_for_insert_priority(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+
+        $hasAAtPrePersist = null;
+
+        $aFactory
+            ->afterInstantiate(static function(CascadePersistChain\ChainA $a) use (&$hasAAtPrePersist): void {
+                $first = $a->getBs()->first();
+                $hasAAtPrePersist = $first instanceof CascadePersistChain\ChainB ? $first->hasAAtPrePersist : null;
+            }, PersistentObjectFactory::PRIORITY_SCHEDULE_FOR_INSERT - 1)
+            ->create(['bs' => $bFactory->many(1)]);
+
+        self::assertTrue($hasAAtPrePersist);
+    }
+
+    /** @test */
+    #[Test]
+    public function orphan_removal_does_not_delete_children_on_subsequent_flushes(): void
+    {
+        $parentFactory = persistent_factory(OrphanRemoval\ParentEntity::class);
+        $childFactory = persistent_factory(OrphanRemoval\ChildEntity::class);
+
+        $parent = $parentFactory->create(['children' => $childFactory->many(2)]);
+
+        self::assertSame(2, $parent->childrenCount);
+        $childFactory::assert()->count(2);
+
+        $parent->name = 'updated';
+        self::entityManager()->flush();
+
+        $childFactory::assert()->count(2);
+        self::assertSame(2, $parent->childrenCount);
+    }
+
+    /** @test */
+    #[Test]
+    public function only_one_flush_per_root_create(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+        $cFactory = persistent_factory(CascadePersistChain\ChainC::class);
+
+        $eventManager = self::entityManager()->getEventManager();
+        $listener = new class {
+            public int $flushes = 0;
+
+            public function postFlush(): void
+            {
+                ++$this->flushes;
+            }
+        };
+        $eventManager->addEventListener([Events::postFlush], $listener);
+
+        try {
+            $cFactory->create(['b' => $bFactory->with(['a' => $aFactory])]);
+        } finally {
+            $eventManager->removeEventListener([Events::postFlush], $listener);
+        }
+
+        self::assertSame(1, $listener->flushes);
+    }
+
+    /** @test */
+    #[Test]
+    public function a_failing_create_does_not_leak_scheduled_objects_into_the_next_one(): void
+    {
+        $aFactory = persistent_factory(CascadePersistChain\ChainA::class);
+        $bFactory = persistent_factory(CascadePersistChain\ChainB::class);
+
+        try {
+            $aFactory
+                ->afterInstantiate(static function(): void { throw new \RuntimeException('boom'); })
+                ->create(['bs' => $bFactory->many(2)]);
+
+            self::fail('create() should have thrown');
+        } catch (\RuntimeException) {
+        }
+
+        persistent_factory(OrphanRemoval\ParentEntity::class)->create();
+
+        $aFactory::assert()->count(0);
+        $bFactory::assert()->count(0);
+    }
+
+    /** @test */
+    #[Test]
+    public function a_failing_item_in_a_flush_once_batch_does_not_leak_scheduled_objects(): void
+    {
+        $parentFactory = persistent_factory(OrphanRemoval\ParentEntity::class);
+        $count = 0;
+
+        try {
+            $parentFactory
+                ->afterInstantiate(static function() use (&$count): void {
+                    if (2 === ++$count) {
+                        throw new \RuntimeException('boom');
+                    }
+                })
+                ->many(3)
+                ->create();
+
+            self::fail('create() should have thrown');
+        } catch (\RuntimeException) {
+        }
+
+        persistent_factory(OrphanRemoval\ChildEntity::class)->create();
+
+        $parentFactory::assert()->count(0);
+    }
+
+    private static function entityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
+    }
+}

--- a/tests/Unit/Object/HydratorTest.php
+++ b/tests/Unit/Object/HydratorTest.php
@@ -37,7 +37,7 @@ class HydratorTest extends TestCase
             public string $foo = '';
         };
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertSame($value, $object->foo);
     }
@@ -54,7 +54,7 @@ class HydratorTest extends TestCase
             public array $foo = [];
         };
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertSame($value, $object->foo);
     }
@@ -76,7 +76,7 @@ class HydratorTest extends TestCase
 
         $value = new Object1('foo');
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertSame($value, $object->foo);
     }
@@ -97,7 +97,7 @@ class HydratorTest extends TestCase
             new Object1('bar'),
         ];
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertSame($value, $object->foo);
     }
@@ -123,7 +123,7 @@ class HydratorTest extends TestCase
             new Object1('bar'),
         ];
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertInstanceOf(ArrayCollection::class, $object->foo);
         $this->assertSame($value, $object->foo->toArray());
@@ -150,7 +150,7 @@ class HydratorTest extends TestCase
             new Object1('bar'),
         ];
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertInstanceOf(ArrayCollection::class, $object->foo);
         $this->assertSame($value, $object->foo->toArray());
@@ -177,7 +177,7 @@ class HydratorTest extends TestCase
             new Object1('bar'),
         ];
 
-        Hydrator::set($object, 'foo', $value);
+        Hydrator::forceSet($object, 'foo', $value);
 
         $this->assertInstanceOf(ArrayCollection::class, $object->foo);
         $this->assertSame($value, $object->foo->toArray());
@@ -218,7 +218,7 @@ class HydratorTest extends TestCase
             }
         };
 
-        Hydrator::set($object, 'foo', new ForceValue('foo'));
+        Hydrator::forceSet($object, 'foo', new ForceValue('foo'));
 
         $this->assertSame('foo', $object->getFoo());
     }


### PR DESCRIPTION
Fixes zenstruck/foundry#1100
Fixes zenstruck/foundry#1115
Supersedes zenstruck/foundry#1104 (its fixtures/tests ideas are reused, thanks @mpiot for the feedback)

`em->persist()` was called synchronously while the object graph was still being built:

- a parent's `PrePersist` listeners always observed an **empty** one-to-many collection, whatever the creation direction (#1100);
- combined with `orphanRemoval: true` and listeners triggering extra flushes, children rows could even be **deleted from the database** (#1115);
- nested factories (`ChildFactory::createOne(['parent' => ParentFactory::new()])`) triggered their own mid-graph flush.

ping @mpiot any chance that you test this PR please?