### PR TITLE
feat: add `make-factory` and `make-story` AI skills for ai-mate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,9 @@
         },
         "symfony": {
             "allow-contrib": false
+        },
+        "ai-mate": {
+            "skills": ["skills"]
         }
     },
     "scripts": {

--- a/skills/make-factory/SKILL.md
+++ b/skills/make-factory/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: make-factory
+description: Create a Zenstruck Foundry model factory for a Doctrine entity (or a plain object), with default values guessed from the entity's mapping
+---
+
+# Make Factory
+
+Generate a Zenstruck Foundry factory class for a Doctrine entity/document or a plain object. It
+picks the right base factory class, guesses `defaults()` from the entity's Doctrine mapping, and
+adds the standard hint scaffolding.
+
+## Arguments
+
+- `<Class>`: The entity/class to create a factory for — a short name (`Post`) or a fully-qualified
+  class name (`App\Entity\Post`). The `Factory` suffix is appended to the generated class name
+  automatically.
+- No args: prompt the user (list entities under `<src>/Entity/`, or accept an FQCN for a
+  non-persisted object).
+
+## Workflow
+
+### Step 0 — Detect project conventions
+
+Read `composer.json` for the PSR-4 roots:
+- `autoload.psr-4` root + source path (e.g. `"App\\"` → `"src/"`).
+- `autoload-dev.psr-4` test root (e.g. `"App\\Tests\\"` → `"tests/"`).
+
+Defaults if absent: namespace `App` / `src/`, test namespace `App\Tests` / `tests/`.
+
+Foundry's default factory namespace is `Factory` (override: `make_factory.default_namespace` in
+`config/packages/zenstruck_foundry.yaml`). Also honour `make_factory.add_hints` (default **true**).
+
+Determine the **PHP version** from `composer.json` `require.php` — it selects the base class
+(below). This project requires `>=8.4`.
+
+Derived paths:
+- **App factory** (default): `<src>/Factory/`, namespace `<RootNamespace>\Factory`
+- **Test factory** (`--test`): `<testDir>/Factory/`, namespace `<RootNamespace>\Tests\Factory`
+
+If the user passes `--namespace <NS>`, use it in place of `Factory` (still relative to the root
+namespace, still prefixed with `Tests\` when `--test`). For an entity in a sub-namespace
+(`App\Entity\Blog\Post`), mirror the suffix under the factory namespace (`App\Factory\Blog`).
+
+### Step 1 — Resolve the target class
+
+- If a short name was given, resolve it to `<src>/Entity/<Name>.php`. If that file doesn't exist,
+  ask the user for the full class (it may be a non-Doctrine object → treat as `--no-persistence`).
+- If no argument, list the entity classes under `<src>/Entity/` and let the user choose, or let
+  them type an FQCN for a plain object.
+- The generated factory class name is `<ShortName>Factory` (e.g. `Post` → `PostFactory`).
+
+### Step 2 — Persistence & options
+
+Decide whether the target is **persisted** (a Doctrine entity — its class has an `#[ORM\Entity]`
+attribute / is a managed class) or **not persisted** (`--no-persistence`). This selects the base
+class:
+
+| Case | Base class (FQCN) |
+|------|-------------------|
+| Persisted, PHP ≥ 8.4 | `Zenstruck\Foundry\Persistence\PersistentObjectFactory` |
+| Persisted, PHP < 8.4 | `Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory` |
+| Not persisted (`--no-persistence`) | `Zenstruck\Foundry\ObjectFactory` |
+
+Ask the user (offer sensible defaults) about these options:
+- **`--test`** — generate under `tests/` instead of `src/`.
+- **`--all-fields`** — generate defaults for *all* columns, not only required (non-nullable) ones.
+  Default: only required fields.
+- **Hints** — include the beginner hint scaffolding (constructor, `initialize()`, todo phpdocs).
+  Defaults to the `add_hints` config value (true).
+- **`--with-phpdoc`** — add `@method`/`@phpstan-method` phpdoc. **Discouraged** and off by default;
+  only include it if the user explicitly asks.
+
+Resolve the factory path `<factoryDir>/<ShortName>Factory.php`. If it already exists, show the user
+and ask whether to overwrite before continuing — do not silently clobber.
+
+### Step 3 — Guess `defaults()` from the mapping
+
+For a **persisted** entity, read the entity file and build the `defaults()` array by walking its
+mapped fields **in declaration order**:
+
+- **Skip** the identifier (`id`) and any field that is nullable — *unless* `--all-fields` is set.
+- Map each Doctrine column `type` to a faker default (length `N` substituted from `length:`):
+
+  | Doctrine type | Generated value |
+  |---------------|-----------------|
+  | `string`, `text`, `ascii_string` | `self::faker()->text(N),` (omit `N` if no length) |
+  | `boolean` | `self::faker()->boolean(),` |
+  | `integer`, `int`, `bigint` | `self::faker()->randomNumber(),` |
+  | `smallint` | `self::faker()->numberBetween(1, 32767),` |
+  | `float`, `decimal` | `self::faker()->randomFloat(),` |
+  | `datetime`, `datetime_mutable`, `date`, `time` | `self::faker()->dateTime(),` |
+  | `datetime_immutable`, `date_immutable` | `\DateTimeImmutable::createFromMutable(self::faker()->dateTime()),` |
+  | `json`, `array`, `simple_array` | `[],` |
+  | `guid` | `self::faker()->uuid(),` |
+  | `uuid` | `Uuid::fromString(self::faker()->uuid()),` (add `use Symfony\Component\Uid\Uuid;`) |
+  | *unknown* | `null, // TODO add <TYPE> type manually` |
+
+- **Enum columns** (`enumType:`): generate a random case, e.g.
+  `self::faker()->randomElement(<Enum>::cases()),` and import the enum.
+- **Required (non-nullable) to-one relations** (`ManyToOne`/`OneToOne` owning, join column not
+  nullable): add `'<field>' => <TargetShortName>Factory::new(),` and note the related factory must
+  exist. Skip to-many relations. Nullable relations are only included with `--all-fields`.
+
+For a **non-persisted** object, generate an empty `defaults()` (return `[]`) with a todo hint — a
+plain class has no mapping to introspect.
+
+Emit the array keys in field declaration order.
+
+### Step 4 — Present plan
+
+Print a summary and ask the user to confirm:
+- Factory class: `<factoryDir>/<ShortName>Factory.php` (new, or **overwrite** if it exists)
+- Target class + base factory class
+- Options: test / all-fields / hints / with-phpdoc
+- The computed `defaults()` entries (field → value)
+- Any imports that will be added (entity, `Uuid`, related factories, enums)
+- Warn about referenced factories/entities that don't exist yet
+
+### Step 5 — Generate the factory
+
+Write `<factoryDir>/<ShortName>Factory.php` in this shape:
+
+```php
+<?php
+
+namespace <FactoryNamespace>;
+
+use <Target FQCN>;
+use <Base factory FQCN>;
+<...any extra uses: Uuid, related factories, enums...>
+
+/**
+ * @extends <BaseFactoryShortName><<TargetShortName>>
+ */
+final class <ShortName>Factory extends <BaseFactoryShortName>
+{
+    #[\Override]
+    public static function class(): string
+    {
+        return <TargetShortName>::class;
+    }
+
+    #[\Override]
+    protected function defaults(): array|callable
+    {
+        return [
+            // guessed defaults, one per line: '<field>' => <value>,
+        ];
+    }
+
+    #[\Override]
+    protected function initialize(): static
+    {
+        return $this
+            // ->afterInstantiate(function(<TargetShortName> $<var>): void {})
+        ;
+    }
+}
+```
+
+Rules for generation:
+- Class is always `final` and extends the resolved base factory class.
+- Always include the `@extends <Base><Target>` phpdoc and the `class()` method.
+- **`#[\Override]`** on `class()`, `defaults()`, and `initialize()` only when PHP ≥ 8.3 (true here).
+- **Hints on** (default): also emit the `__construct()` hint block, the `// @todo add your default
+  values here` phpdoc, `initialize()`, and the `defaults(): array|callable` return type. **Hints
+  off**: omit `__construct()` and `initialize()`, and use `defaults(): array` (no `|callable`), and
+  drop the todo phpdocs.
+- `--with-phpdoc` (only if requested): add the `@method`/`@phpstan-method` lines above the class
+  (e.g. `@method Post create(...)`, static + instance variants).
+- Import only what is used; group the entity/object and base class first, extra uses after.
+- Always end the file with a trailing newline.
+
+### Step 6 — Post-generation instructions
+
+Tell the user:
+1. Open the factory and refine `defaults()` / add named states in `initialize()`.
+2. Make sure any **related factories** referenced in `defaults()` exist (generate them with this
+   skill).
+3. Use it: `<ShortName>Factory::createOne([...])`, `::createMany(n)`,
+   `::new()->withoutPersisting()`, etc. Reference it from stories (see the `make-story` skill).
+4. Docs: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#factories
+
+## Rules
+
+- Pick the base class from persistence + PHP version (see the table); never hardcode one.
+- Guess `defaults()` from the actual entity mapping — skip `id` and nullable fields unless
+  `--all-fields`.
+- The factory class name is always `<ShortName>Factory`; the class is always `final`.
+- Do not import unused classes; add `Uuid`/enum/related-factory imports only when referenced.
+- Respect the `add_hints` config for the hint scaffolding; omit `--with-phpdoc` unless requested
+  (it is deprecated).
+- If the factory file already exists, confirm an overwrite — there is no partial "add" mode.

--- a/skills/make-story/SKILL.md
+++ b/skills/make-story/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: make-story
+description: Interactively create a Zenstruck Foundry story (fixture-building class), or add build logic to an existing one
+---
+
+# Make Story
+
+Generate a Zenstruck Foundry `Story` class — a reusable set of fixtures assembled by calling
+factories — or add build logic to an existing story.
+
+## Arguments
+
+- `<StoryName>`: The PascalCase story name (e.g., `make-story DefaultCategories`). The `Story`
+  suffix is optional — it is appended automatically if missing.
+- No args: prompt the user for the story name first.
+
+## Workflow
+
+### Step 0 — Detect project conventions
+
+Before anything else, read `composer.json` to find the PSR-4 autoload roots:
+- The `autoload.psr-4` root namespace and source path (e.g. `"App\\"` → `"src/"`).
+- The `autoload-dev.psr-4` test root (e.g. `"App\\Tests\\"` → `"tests/"`).
+
+If no PSR-4 entry exists, default to namespace `App` / source path `src/`, and test namespace
+`App\Tests` / path `tests/`.
+
+Foundry's default story namespace is `Story` (configurable via
+`make_story.default_namespace` in `config/packages/zenstruck_foundry.yaml`). Check that file for
+an override before falling back to `Story`.
+
+Derived paths:
+- **App story** (default): directory `<src>/Story/`, namespace `<RootNamespace>\Story`
+- **Test story** (`--test`): directory `<testDir>/Story/`, namespace `<RootNamespace>\Tests\Story`
+
+If the user passes a `--namespace <NS>` value, use it in place of `Story` (still relative to the
+root namespace, and still prefixed with `Tests\` when `--test` is given).
+
+### Step 1 — Gather story name
+
+If no argument was given, ask the user for the story name. Validate it is PascalCase with no
+namespace prefix (just the class name, e.g. `DefaultCategories` or `DefaultCategoriesStory`).
+
+Normalise the name so it ends with `Story` — append the suffix if the user did not include it
+(`DefaultCategories` → `DefaultCategoriesStory`).
+
+### Step 2 — Choose location
+
+Ask whether this is:
+- An **application story** (default) → `<src>/Story/` — used for real fixtures / dev data.
+- A **test story** (`--test`) → `<testDir>/Story/` — used only in the test suite.
+
+Resolve the target directory and namespace from Step 0 accordingly.
+
+After resolving the name and location, check whether `<storyDir>/<StoryName>.php` exists:
+
+- **File does not exist** → proceed to Step 3 (create mode).
+- **File exists** → switch to **add-build mode**: read the existing story, show the user the
+  current `build()` body, then proceed to Step 3 to collect only the *new* fixture logic to
+  append. Skip repository-style boilerplate — you are only editing the `build()` method (and
+  imports).
+
+### Step 3 — Interview for the story build
+
+A story's job is to assemble fixtures by calling factories inside `build()`. Interactively gather
+what the story should create. Ask about:
+
+- **Which factories to call** and with what attributes (e.g. `CategoryFactory::createOne(['name' => 'PHP'])`,
+  `UserFactory::createMany(10)`). Ask for the factory class name and how many objects.
+- **Named references** — objects other code should be able to fetch later. These use
+  `$this->addState('reference-name', <object>)` and are retrieved with
+  `<StoryName>::get('reference-name')`.
+- **Pools** — groups of objects for random selection. Added with
+  `$this->addToPool('pool-name', <object>)` (or the `$pool` argument of `addState`) and retrieved
+  with `<StoryName>::getRandom('pool-name')`, `getRandomSet('pool-name', n)`,
+  `getRandomRange('pool-name', min, max)`, or `getPool('pool-name')`.
+
+Keep asking "Add another factory call / reference / pool?" until the user says no. If the user is
+unsure, generate a minimal stub `build()` with a `// TODO` comment and let them fill it in later.
+
+### Step 3b — Additional customisations
+
+After collecting the build logic, ask the user once:
+
+> "Anything else? (e.g. register this story as a named fixture, or reference other stories.)"
+
+Offer these as preset options plus an "Other / none" escape:
+- `AsFixture` — add `#[AsFixture(name: '...')]` (optionally `groups: [...]`) so the story is
+  loadable by name via the fixtures system. Ask for the fixture name (and any groups). This is
+  the convention used elsewhere in this project.
+- `Depend on another story` — call `OtherStory::load()` at the top of `build()` so its fixtures
+  exist first, then reference them via `OtherStory::get(...)`.
+- `None / done` — no extras.
+
+Allow multiple selections. If the user picks "Other", read their free-text note and incorporate it.
+
+### Step 4 — Present plan
+
+Before writing files, print a summary and ask the user to confirm.
+
+**Create mode:**
+- Story class: `<storyDir>/<StoryName>.php` (new)
+- Namespace: `<resolved namespace>`
+- Factory calls listed (factory | count | attributes)
+- Named references listed
+- Pools listed
+- Extras listed (`AsFixture`, story dependencies, etc.)
+
+**Add-build mode:**
+- Story class: `<storyDir>/<StoryName>.php` (will be edited)
+- New factory calls / references / pools listed
+- Extras listed
+
+### Step 5 — Generate / Update the Story
+
+**Create mode** — write `<storyDir>/<StoryName>.php`.
+
+**Base skeleton:**
+
+```php
+<?php
+
+namespace <Namespace>;
+
+use Zenstruck\Foundry\Story;
+
+final class <StoryName> extends Story
+{
+    public function build(): void
+    {
+        // ... fixture logic
+    }
+}
+```
+
+**Rules for the generated class:**
+- Always `final`.
+- Extends `Zenstruck\Foundry\Story`.
+- Implements the abstract `build(): void` method.
+- Import each factory class actually referenced in `build()` (from its own namespace, commonly
+  `<RootNamespace>\Factory\<X>Factory`). Only import what is used.
+- Use `$this->addState('name', <object>)` for named references and `$this->addToPool('pool', <object>)`
+  (or `addState('name', <object>, 'pool')`) for pools.
+- If the `AsFixture` extra was chosen, add `use Zenstruck\Foundry\Attribute\AsFixture;` and place
+  `#[AsFixture(name: '<name>')]` (with `groups: [...]` if given) directly above the class.
+- If depending on another story, call `<OtherStory>::load();` first inside `build()` and import it.
+- If the user gave no build logic, emit a single `// TODO build your story here` comment inside
+  `build()`.
+- Always end the file with a newline.
+
+**Add-build mode** — edit the existing `<storyDir>/<StoryName>.php`:
+1. Read the current file.
+2. Insert the new statements inside the existing `build()` method, after the current body (remove a
+   lone `// TODO ...` placeholder if present).
+3. Add any missing `use` statements (factory classes, `AsFixture`, other stories) to the import block.
+4. If `AsFixture` was chosen and no attribute exists yet, add it above the class declaration.
+5. Make targeted edits — do not rewrite the whole file from scratch.
+
+**Example generated story:**
+
+```php
+<?php
+
+namespace App\Story;
+
+use App\Factory\CategoryFactory;
+use Zenstruck\Foundry\Attribute\AsFixture;
+use Zenstruck\Foundry\Story;
+
+#[AsFixture(name: 'default-categories')]
+final class DefaultCategoriesStory extends Story
+{
+    public function build(): void
+    {
+        $this->addState('php', CategoryFactory::createOne(['name' => 'PHP']));
+
+        CategoryFactory::createMany(5); // adds 5 random categories
+
+        foreach (['Books', 'Movies', 'Music'] as $name) {
+            $this->addToPool('media', CategoryFactory::createOne(['name' => $name]));
+        }
+    }
+}
+```
+
+### Step 6 — Post-generation instructions
+
+After writing the file, tell the user:
+
+1. Review the story and adjust factory attributes / counts.
+2. Make sure the referenced factories exist — generate any missing ones with the `make-factory`
+   skill.
+3. Load / use the story:
+   - In tests: add the `#[WithStory(<StoryName>::class)]` attribute (`use Zenstruck\Foundry\Attribute\WithStory;`)
+     to the test class/method, or call `<StoryName>::load()` directly.
+   - As a named fixture (if `#[AsFixture]` was added): load it via the fixtures system /
+     `foundry:load-story` and fetch objects with `<StoryName>::get('...')`,
+     `<StoryName>::getRandom('...')`, etc.
+
+## Rules
+
+- If `<storyDir>/<StoryName>.php` already exists, switch to add-build mode — never overwrite the whole file.
+- In add-build mode, make surgical inserts into `build()`; never rewrite the file from scratch.
+- Always append the `Story` suffix to the class name if the user omitted it.
+- The class is always `final` and extends `Zenstruck\Foundry\Story`.
+- Do not import unused classes.
+- Do not add comments unless something is non-obvious (or the user asked for a TODO stub).
+- Named references use `addState` / `get`; random pools use `addToPool` / `getRandom` &
+  `getRandomSet` / `getRandomRange`.


### PR DESCRIPTION
The latest version of Symfony AI Mate include a way for 3rd party packages to [distribute *skills*](https://github.com/symfony/ai/pull/2213).

This is an experiment to replace Foundry's maker's with skills.