### PR TITLE
feat(behat): follow foundry tags and mark the integration as experimental

### DIFF
--- a/.github/workflows/behat-subtree-split.yaml
+++ b/.github/workflows/behat-subtree-split.yaml
@@ -3,6 +3,7 @@ name: 'Packages Split'
 on:
   push:
     branches: [2.x]
+    tags: ['v*']
   workflow_dispatch: ~
 
 jobs:
@@ -11,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: danharrin/monorepo-split-github-action@v2.4.5
+      - if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: danharrin/monorepo-split-github-action@v2.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.SPLIT_FOUNDRY_BEHAT }}
         with:
@@ -19,5 +21,18 @@ jobs:
           repository_organization: 'zenstruck'
           repository_name: 'foundry-behat'
           user_name: 'nikophil'
-          user_email: 'nicolas.philippe@mapado.com'
-          branch: '0.x'
+          user_email: 'nikophil@gmail.com'
+          branch: '2.x'
+
+      - if: "startsWith(github.ref, 'refs/tags/')"
+        uses: danharrin/monorepo-split-github-action@v2.4.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.SPLIT_FOUNDRY_BEHAT }}
+        with:
+          tag: ${{ github.ref_name }}
+          package_directory: 'src/Test/Behat'
+          repository_organization: 'zenstruck'
+          repository_name: 'foundry-behat'
+          user_name: 'nikophil'
+          user_email: 'nikophil@gmail.com'
+          branch: '2.x'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2748,6 +2748,15 @@ This extension provides the following features:
 Behat Integration
 -----------------
 
+.. warning::
+
+    The Behat integration is experimental. It is not covered by the backward compatibility promise and may
+    change in any minor version.
+
+.. versionadded:: 2.11
+
+    The Behat integration was added in Foundry 2.11.
+
 Foundry provides a Behat extension that correctly boots the Foundry for you.
 
 Installation

--- a/src/Test/Behat/README.md
+++ b/src/Test/Behat/README.md
@@ -2,6 +2,10 @@
 
 This is a subpackage of [Foundry](https://github.com/zenstruck/foundry). 
 
+> [!WARNING]
+> This package is experimental. It is not covered by the backward compatibility promise and may change in any
+> minor version.
+
 Please open any issue or pull request on the main repository.
 
 See docs at: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#behat-integration

--- a/src/Test/Behat/src/AssertionSteps.php
+++ b/src/Test/Behat/src/AssertionSteps.php
@@ -32,6 +32,7 @@ use function Zenstruck\Foundry\Persistence\repository;
  * injected by the HasFactoryShortNameResolver and HasObjectRegistry traits (see FoundryAssertionContext).
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 trait AssertionSteps
 {

--- a/src/Test/Behat/src/Attribute/FactoryShortName.php
+++ b/src/Test/Behat/src/Attribute/FactoryShortName.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Test\Behat\Attribute;
 
 /**
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class FactoryShortName

--- a/src/Test/Behat/src/CreationSteps.php
+++ b/src/Test/Behat/src/CreationSteps.php
@@ -22,6 +22,7 @@ use Zenstruck\Foundry\ObjectFactory;
  * injected by the HasFactoryShortNameResolver and HasObjectRegistry traits (see FoundryCreationContext).
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 trait CreationSteps
 {

--- a/src/Test/Behat/src/FoundryAssertionContext.php
+++ b/src/Test/Behat/src/FoundryAssertionContext.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Test\Behat;
  * and on the database.
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 final class FoundryAssertionContext implements FoundryContextInterface
 {

--- a/src/Test/Behat/src/FoundryContext.php
+++ b/src/Test/Behat/src/FoundryContext.php
@@ -19,6 +19,7 @@ namespace Zenstruck\Foundry\Test\Behat;
  * compose your own context from the step traits (see the documentation).
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 final class FoundryContext implements FoundryContextInterface
 {

--- a/src/Test/Behat/src/FoundryContextInterface.php
+++ b/src/Test/Behat/src/FoundryContextInterface.php
@@ -22,6 +22,7 @@ use Behat\Behat\Context\Context;
  * some built-in steps.
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 interface FoundryContextInterface extends Context
 {

--- a/src/Test/Behat/src/FoundryCreationContext.php
+++ b/src/Test/Behat/src/FoundryCreationContext.php
@@ -15,6 +15,7 @@ namespace Zenstruck\Foundry\Test\Behat;
  * Context providing only the built-in "Given" steps creating Foundry objects.
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 final class FoundryCreationContext implements FoundryContextInterface
 {

--- a/src/Test/Behat/src/FoundryExtension.php
+++ b/src/Test/Behat/src/FoundryExtension.php
@@ -25,6 +25,10 @@ use Zenstruck\Foundry\Test\Behat\Listener\BootConfigurationListener;
 use Zenstruck\Foundry\Test\Behat\Listener\DatabaseResetListener;
 use Zenstruck\Foundry\Test\Behat\Listener\LoadFixturesListener;
 
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
+ */
 final class FoundryExtension implements Extension
 {
     public function process(ContainerBuilder $container): void

--- a/src/Test/Behat/src/FoundryPlaceholderContext.php
+++ b/src/Test/Behat/src/FoundryPlaceholderContext.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Foundry\Test\Behat;
  * (<foundry:lastId(...)> and <foundry:id(...)>) in step arguments.
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 final class FoundryPlaceholderContext implements FoundryContextInterface
 {

--- a/src/Test/Behat/src/PlaceholderTransforms.php
+++ b/src/Test/Behat/src/PlaceholderTransforms.php
@@ -21,6 +21,7 @@ use Behat\Transformation\Transform;
  * injected by the HasObjectRegistry trait (see FoundryPlaceholderContext).
  *
  * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ * @experimental
  */
 trait PlaceholderTransforms
 {


### PR DESCRIPTION
## Why

Two independent gaps around the `zenstruck/foundry-behat` subpackage:

1. **No version is ever published.** The split workflow only triggers on `push: branches: [2.x]` and never passes the `tag` input to the action, so `zenstruck/foundry-behat` has **zero tag** and is **not on Packagist** — the documented `composer require --dev zenstruck/foundry-behat` cannot work today. Its `0.x` branch is also disconnected from the monorepo versioning.
2. **Nothing says the integration is experimental.** It shipped in 2.11 and is still moving, but neither the docs, the package README nor the PHPDoc mention that it is outside the backward compatibility promise.

## What

### `ci(behat)`: tags now follow foundry tags

`.github/workflows/behat-subtree-split.yaml` gains a `tags: ['v*']` trigger and splits into the two conditional steps documented by the action. Pushing `v2.12.0` on the monorepo now publishes `v2.12.0` on the subpackage.

The target branch moves `0.x` → `2.x` for consistency with the propagated tags; since the package was never published, nothing depends on `0.x`. `user_email` is corrected to `nikophil@gmail.com` so split commits are attributed properly.

Three details worth knowing, from reading the action's `entrypoint.php`:

- `tag: ${{ github.ref_name }}`, **not** the README's `tag: ${GITHUB_REF#refs/tags/}` — the latter is shell parameter expansion in a field GitHub Actions does not interpolate.
- The action tags under `execOrDie`, so **re-tagging an existing version fails the job**. Hence the `v*` filter.
- When the tagged commit was already split, `git status --porcelain` is empty, no commit is created, and the tag simply lands on the current `2.x` HEAD — the desired behaviour.

### `docs(behat)`: experimental status made explicit

- `docs/index.rst` — a `.. warning::` plus `.. versionadded:: 2.11` directly under the chapter title, wording aligned with the existing in-memory notice.
- `src/Test/Behat/README.md` — a `> [!WARNING]` block, visible on the split repository and the future Packagist page.
- `@experimental` on the **10** files of `src/Test/Behat/src/` that are not already `@internal`, following the `src/InMemory` convention (last line of the docblock, after `@author`). `FoundryExtension` had no class docblock at all and gets a full one. The 18 `@internal` files are untouched.

## Follow-up (manual, not in this PR)

1. Switch `zenstruck/foundry-behat` default branch to `2.x`, drop `0.x`.
2. Tag `v2.11.0` by hand — it predates this workflow, and `gh workflow run --ref v2.11.0` would run the *old* workflow stored in that tag.
3. Submit the package to Packagist.

From `v2.12.0` on, propagation is automatic.

## Checks

| Check | Result |
|---|---|
| `doctor-rst` | All files are valid |
| PHPStan (main + Behat config) | No errors |
| PHPUnit subpackage | 122 tests, 230 assertions |
| Behat functional | 74 scenarios, 226 steps |

Scope was verified with `diff <(grep -rL '@internal' src/Test/Behat/src) <(grep -rl '@experimental' src/Test/Behat/src)` — identical, 10 files.
