### PR TITLE
feat: load multiple groups/stories with foundry:load-fixtures

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1696,6 +1696,19 @@ You can also load stories by group, by using the ``groups`` option:
 
 ``bin/console foundry:load-fixtures all`` will load both stories ``CategoryStory`` and ``PostStory``.
 
+.. versionadded:: 2.12
+
+    The ability to load several stories or groups at once was added in 2.12.
+
+Several names can be passed at once, and story names and group names can be mixed:
+
+.. code-block:: terminal
+
+    $ php bin/console foundry:load-fixtures category post
+    $ php bin/console foundry:load-fixtures all other-group category
+
+The database is only reset once, and a story belonging to several of the given groups is only loaded once.
+
 .. tip::
 
     It is possible to call a story inside another story, by using ``OtherStory::load();``. Because the stories are only

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1696,10 +1696,6 @@ You can also load stories by group, by using the ``groups`` option:
 
 ``bin/console foundry:load-fixtures all`` will load both stories ``CategoryStory`` and ``PostStory``.
 
-.. versionadded:: 2.12
-
-    The ability to load several stories or groups at once was added in 2.12.
-
 Several names can be passed at once, and story names and group names can be mixed:
 
 .. code-block:: terminal
@@ -1708,6 +1704,10 @@ Several names can be passed at once, and story names and group names can be mixe
     $ php bin/console foundry:load-fixtures all other-group category
 
 The database is only reset once, and a story belonging to several of the given groups is only loaded once.
+
+.. versionadded:: 2.12
+
+    The ability to load several stories or groups at once was added in 2.12.
 
 .. tip::
 

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -65,10 +65,16 @@ final class LoadFixturesCommand extends Command
             $this->resetDatabase();
         }
 
-        /** @var array<string> $fixtureNamesOrGroups */
+        /** @var array<string>|string|null $fixtureNamesOrGroups */
         $fixtureNamesOrGroups = $input->getArgument('name');
 
-        if ([] === $fixtureNamesOrGroups) {
+        if (\is_string($fixtureNamesOrGroups)) {
+            trigger_deprecation('zenstruck/foundry', '2.12', 'Passing a string as the "name" argument of the "foundry:load-fixtures" command is deprecated and will throw an error in Foundry 3: pass an array of names instead.');
+
+            $fixtureNamesOrGroups = [$fixtureNamesOrGroups];
+        }
+
+        if (!$fixtureNamesOrGroups) {
             $fixtureNamesOrGroups = [$this->getNameWhenNotProvided($io)];
         }
 

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -80,10 +80,13 @@ final class LoadFixturesCommand extends Command
 
         $resolvedStories = [];
         foreach (\array_unique($fixtureNamesOrGroups) as $fixtureNameOrGroup) {
-            $resolvedStories[] = [$fixtureNameOrGroup, $this->fixtureStoryResolver->resolve($fixtureNameOrGroup)];
+            $resolvedStories[$fixtureNameOrGroup] = $this->fixtureStoryResolver->resolve($fixtureNameOrGroup);
         }
 
-        foreach ($resolvedStories as [$fixtureNameOrGroup, $stories]) {
+        $loadedStoryClasses = [];
+        foreach ($resolvedStories as $fixtureNameOrGroup => $stories) {
+            $fixtureNameOrGroup = (string) $fixtureNameOrGroup;
+
             if ($this->fixtureStoryResolver->hasFixture($fixtureNameOrGroup)) {
                 $io->comment("Loading story with name \"{$fixtureNameOrGroup}\"...");
             } else {
@@ -91,7 +94,14 @@ final class LoadFixturesCommand extends Command
             }
 
             foreach ($stories as $name => $storyClass) {
+                if (isset($loadedStoryClasses[$storyClass])) {
+                    $io->warning("Story \"{$storyClass}\" (name: {$name}) already loaded. Skipping...");
+
+                    continue;
+                }
+
                 $storyClass::load();
+                $loadedStoryClasses[$storyClass] = true;
 
                 if ($io->isVerbose()) {
                     $io->info("Story \"{$storyClass}\" loaded (name: {$name}).");

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -42,7 +42,7 @@ final class LoadFixturesCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('name', InputArgument::OPTIONAL, "Story's name or stories group's name to load.")
+            ->addArgument('name', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "Stories' names or stories groups' names to load.")
             ->addOption('append', 'a', InputOption::VALUE_NONE, 'Skip resetting database and append data to the existing database.')
         ;
     }
@@ -65,21 +65,31 @@ final class LoadFixturesCommand extends Command
             $this->resetDatabase();
         }
 
-        $fixtureNameOrGroup = $input->getArgument('name') ?? $this->getNameWhenNotProvided($io);
+        /** @var array<string> $fixtureNamesOrGroups */
+        $fixtureNamesOrGroups = $input->getArgument('name');
 
-        $stories = $this->fixtureStoryResolver->resolve($fixtureNameOrGroup);
-
-        if ($this->fixtureStoryResolver->hasFixture($fixtureNameOrGroup)) {
-            $io->comment("Loading story with name \"{$fixtureNameOrGroup}\"...");
-        } else {
-            $io->comment("Loading stories group \"{$fixtureNameOrGroup}\"...");
+        if ([] === $fixtureNamesOrGroups) {
+            $fixtureNamesOrGroups = [$this->getNameWhenNotProvided($io)];
         }
 
-        foreach ($stories as $name => $storyClass) {
-            $storyClass::load();
+        $resolvedStories = [];
+        foreach (\array_unique($fixtureNamesOrGroups) as $fixtureNameOrGroup) {
+            $resolvedStories[] = [$fixtureNameOrGroup, $this->fixtureStoryResolver->resolve($fixtureNameOrGroup)];
+        }
 
-            if ($io->isVerbose()) {
-                $io->info("Story \"{$storyClass}\" loaded (name: {$name}).");
+        foreach ($resolvedStories as [$fixtureNameOrGroup, $stories]) {
+            if ($this->fixtureStoryResolver->hasFixture($fixtureNameOrGroup)) {
+                $io->comment("Loading story with name \"{$fixtureNameOrGroup}\"...");
+            } else {
+                $io->comment("Loading stories group \"{$fixtureNameOrGroup}\"...");
+            }
+
+            foreach ($stories as $name => $storyClass) {
+                $storyClass::load();
+
+                if ($io->isVerbose()) {
+                    $io->info("Story \"{$storyClass}\" loaded (name: {$name}).");
+                }
             }
         }
 

--- a/tests/Integration/Command/LoadFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadFixturesCommandTest.php
@@ -120,11 +120,19 @@ final class LoadFixturesCommandTest extends KernelTestCase
     #[Test]
     public function it_can_load_multiple_groups(): void
     {
-        $this->commandTester(['environment' => 'stories_as_fixtures'])
-            ->execute(['name' => ['single-fixture-in-group', 'multiple-fixtures-in-group'], '--append' => true]);
+        $commandTester = $this->commandTester(['environment' => 'stories_as_fixtures']);
+        $commandTester->execute(
+            ['name' => ['single-fixture-in-group', 'multiple-fixtures-in-group'], '--append' => true],
+            ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]
+        );
 
         // "fixture-story" belongs to both groups, but is only loaded once
         GenericEntityFactory::assert()->count(2);
+
+        // SymfonyStyle wraps long lines, so words may be split by whitespace across lines
+        $display = \preg_replace('/\s+/', ' ', $commandTester->getDisplay()) ?? $commandTester->getDisplay();
+        self::assertStringContainsString('loaded (name: fixture-story)', $display);
+        self::assertStringContainsString('Story "'.FixtureStory::class.'" (name: fixture-story) already loaded. Skipping...', $display);
     }
 
     /**

--- a/tests/Integration/Command/LoadFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadFixturesCommandTest.php
@@ -43,7 +43,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No story as fixture available');
 
-        $this->commandTester()->execute(['name' => 'foo']);
+        $this->commandTester()->execute(['name' => ['foo']]);
     }
 
     /**
@@ -55,7 +55,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
         $this->expectException(FixtureStoryNotFound::class);
         $this->expectExceptionMessage('Fixture story with name or group "invalid-name" not found');
 
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'invalid-name', '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['invalid-name'], '--append' => true]);
     }
 
     /**
@@ -64,7 +64,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
     #[Test]
     public function it_can_load_a_story(): void
     {
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'fixture-story', '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['fixture-story'], '--append' => true]);
 
         GenericEntityFactory::assert()->count(1);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
@@ -77,12 +77,72 @@ final class LoadFixturesCommandTest extends KernelTestCase
     public function it_can_load_a_story_with_verbose_mode(): void
     {
         $commandTester = $this->commandTester(['environment' => 'stories_as_fixtures']);
-        $commandTester->execute(['name' => 'fixture-story', '--append' => true], ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]);
+        $commandTester->execute(['name' => ['fixture-story'], '--append' => true], ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]);
 
         GenericEntityFactory::assert()->count(1);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
 
         self::assertStringContainsString('loaded (name: fixture-story)', $commandTester->getDisplay());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_load_multiple_stories(): void
+    {
+        $this->commandTester(['environment' => 'stories_as_fixtures'])
+            ->execute(['name' => ['fixture-story', 'fixture-story-for-group'], '--append' => true]);
+
+        GenericEntityFactory::assert()->count(2);
+        GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
+        GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story-for-group']);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_load_multiple_groups(): void
+    {
+        $this->commandTester(['environment' => 'stories_as_fixtures'])
+            ->execute(['name' => ['single-fixture-in-group', 'multiple-fixtures-in-group'], '--append' => true]);
+
+        // "fixture-story" belongs to both groups, but is only loaded once
+        GenericEntityFactory::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_can_load_a_mix_of_stories_and_groups(): void
+    {
+        $commandTester = $this->commandTester(['environment' => 'stories_as_fixtures']);
+        $commandTester->execute(['name' => ['fixture-story', 'multiple-fixtures-in-group'], '--append' => true]);
+
+        GenericEntityFactory::assert()->count(2);
+
+        self::assertStringContainsString('Loading story with name "fixture-story"', $commandTester->getDisplay());
+        self::assertStringContainsString('Loading stories group "multiple-fixtures-in-group"', $commandTester->getDisplay());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function it_does_not_load_anything_if_one_of_the_names_is_invalid(): void
+    {
+        $this->expectException(FixtureStoryNotFound::class);
+        $this->expectExceptionMessage('Fixture story with name or group "invalid-name" not found');
+
+        try {
+            $this->commandTester(['environment' => 'stories_as_fixtures'])
+                ->execute(['name' => ['fixture-story', 'invalid-name'], '--append' => true]);
+        } finally {
+            // "fixture-story" is valid, but must not have been loaded
+            GenericEntityFactory::assert()->count(0);
+        }
     }
 
     /**
@@ -100,7 +160,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
             )
         );
 
-        $this->commandTester(['environment' => 'story_fixture_with_name_collision'])->execute(['name' => 'fixture-story', '--append' => true]);
+        $this->commandTester(['environment' => 'story_fixture_with_name_collision'])->execute(['name' => ['fixture-story'], '--append' => true]);
     }
 
     /**
@@ -112,7 +172,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot use #[AsFixture] group(s) "fixture-story", they collide with fixture names.');
 
-        $this->commandTester(['environment' => 'story_fixture_with_group_name_collision'])->execute(['name' => 'fixture-story', '--append' => true]);
+        $this->commandTester(['environment' => 'story_fixture_with_group_name_collision'])->execute(['name' => ['fixture-story'], '--append' => true]);
     }
 
     /**
@@ -121,7 +181,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
     #[Test]
     public function it_can_load_one_single_story_based_on_its_group_name(): void
     {
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'single-fixture-in-group', '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['single-fixture-in-group'], '--append' => true]);
 
         GenericEntityFactory::assert()->count(1);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
@@ -133,7 +193,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
     #[Test]
     public function it_can_load_multiple_stories_based_on_their_group_name(): void
     {
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'multiple-fixtures-in-group', '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['multiple-fixtures-in-group'], '--append' => true]);
 
         GenericEntityFactory::assert()->count(2);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
@@ -148,7 +208,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
     #[DataProvider('provideFixturesWhichLoadAnotherFixtureCases')]
     public function it_can_load_fixture_which_loads_another_fixture(string $name): void
     {
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => $name, '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => [$name], '--append' => true]);
 
         GenericEntityFactory::assert()->count(2);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-using-another-fixture']);
@@ -173,7 +233,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
 
         GenericEntityFactory::createMany(5);
 
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'fixture-story']);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['fixture-story']]);
 
         GenericEntityFactory::assert()->count(1);
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
@@ -187,7 +247,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
     {
         $commandTester = $this->commandTester(['environment' => 'stories_as_fixtures']);
         $commandTester->setInputs(['no']);
-        $commandTester->execute(['name' => 'fixture-story']);
+        $commandTester->execute(['name' => ['fixture-story']]);
 
         self::assertStringContainsString('[WARNING] Aborting command execution', $commandTester->getDisplay());
 
@@ -206,7 +266,7 @@ final class LoadFixturesCommandTest extends KernelTestCase
 
         GenericEntityFactory::createMany(5);
 
-        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'fixture-story', '--append' => true]);
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => ['fixture-story'], '--append' => true]);
 
         GenericEntityFactory::assert()->count(6);
     }

--- a/tests/Integration/Command/LoadFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadFixturesCommandTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Integration\Command;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -83,6 +84,20 @@ final class LoadFixturesCommandTest extends KernelTestCase
         GenericEntityFactory::assert()->count(1, ['prop1' => 'fixture-story']);
 
         self::assertStringContainsString('loaded (name: fixture-story)', $commandTester->getDisplay());
+    }
+
+    /**
+     * @test
+     *
+     * @group legacy
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function it_can_still_load_a_story_when_the_name_argument_is_a_string(): void
+    {
+        $this->commandTester(['environment' => 'stories_as_fixtures'])->execute(['name' => 'fixture-story', '--append' => true]);
+
+        GenericEntityFactory::assert()->count(1);
     }
 
     /**


### PR DESCRIPTION
## Why

When setting up an environment, one might need to load multiple stories or groups of stories. It might not be possible to create a "meta-story" with all the stories needed for a specific test case and calling the command multiple times with `--append` might lead to duplicates if two of the stories depend on a common third one. 

## What 

I figured out `LoadFixturesCommand` alreay had all the elements needed to load multiple stories so I made the "name" argument an `array<string>`

The same system that prevents a story to be called multiple times in a process allows us to load multiple groups without having the stories present in multiple groups being called multiple times.