### PR TITLE
fix: introduce `PersistenceManager::reattach()`

### DIFF
--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -210,6 +210,28 @@ class PersistenceManager implements IdentifierResolver
     }
 
     /**
+     * Swap a detached object for its managed instance. A managed object is returned as-is.
+     *
+     * @template T of object
+     *
+     * @param T $object
+     *
+     * @return T
+     */
+    public function reattach(object $object): object
+    {
+        $strategy = $this->strategyFor($object::class);
+
+        if ($strategy->contains($object)) {
+            return $object;
+        }
+
+        $id = $strategy->getIdentifierValues($object);
+
+        return ($id ? $strategy->objectManagerFor($object::class)->find($object::class, $id) : null) ?? $object;
+    }
+
+    /**
      * @template T of object
      *
      * @param T $object

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -12,7 +12,6 @@
 namespace Zenstruck\Foundry\Persistence;
 
 use Doctrine\Persistence\ObjectRepository;
-use Symfony\Component\VarExporter\Exception\LogicException as VarExportLogicException;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\FoundryNotBooted;
 use Zenstruck\Foundry\Exception\PersistenceDisabled;
@@ -23,7 +22,6 @@ use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\ObjectFactory;
 use Zenstruck\Foundry\Persistence\Event\AfterPersist;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
-use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 use Zenstruck\Foundry\Persistence\Relationship\ManyToOneRelationship;
 use Zenstruck\Foundry\Persistence\Relationship\OneToManyRelationship;
 use Zenstruck\Foundry\Persistence\Relationship\OneToOneRelationship;
@@ -572,11 +570,10 @@ abstract class PersistentObjectFactory extends ObjectFactory
             return $object;
         }
 
-        try {
-            return $configuration->persistence()->refresh($object);
-        } catch (RefreshObjectFailed|VarExportLogicException) { // @phpstan-ignore catch.neverThrown (thrown by var exporter)
-            return $object;
-        }
+        // swap a detached object for its managed instance; a managed one is used as-is:
+        // refreshing it here would discard in-memory state (unsaved changes, wired inverse
+        // collections) and its dirty-check would fire lifecycle events on scheduled objects
+        return $persistenceManager->reattach($object);
     }
 
     /**

--- a/tests/Fixture/Entity/EdgeCases/SharedManagedParent/ChildEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/SharedManagedParent/ChildEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\SharedManagedParent;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('shared_managed_parent_child')]
+#[ORM\HasLifecycleCallbacks]
+class ChildEntity extends Base
+{
+    #[ORM\Column]
+    public int $prePersistCount = 0;
+
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: ParentEntity::class, inversedBy: 'children')]
+        public ?ParentEntity $parent = null,
+        #[ORM\ManyToOne(targetEntity: RootEntity::class, inversedBy: 'items')]
+        public ?RootEntity $root = null,
+    ) {
+    }
+
+    #[ORM\PrePersist]
+    public function onPrePersist(): void
+    {
+        ++$this->prePersistCount;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/SharedManagedParent/ParentEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/SharedManagedParent/ParentEntity.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\SharedManagedParent;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('shared_managed_parent_parent')]
+class ParentEntity extends Base
+{
+    /** @var Collection<int, ChildEntity> */
+    #[ORM\OneToMany(targetEntity: ChildEntity::class, mappedBy: 'parent', cascade: ['persist'])]
+    private Collection $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    public function addChild(ChildEntity $child): void
+    {
+        if (!$this->children->contains($child)) {
+            $this->children->add($child);
+            $child->parent = $this;
+        }
+    }
+
+    public function removeChild(ChildEntity $child): void
+    {
+        if ($this->children->removeElement($child) && $child->parent === $this) {
+            $child->parent = null;
+        }
+    }
+
+    /**
+     * @return Collection<int, ChildEntity>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/SharedManagedParent/RootEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/SharedManagedParent/RootEntity.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\SharedManagedParent;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table('shared_managed_parent_root')]
+class RootEntity extends Base
+{
+    /** @var Collection<int, ChildEntity> */
+    #[ORM\OneToMany(targetEntity: ChildEntity::class, mappedBy: 'root', cascade: ['persist'])]
+    private Collection $items;
+
+    public function __construct()
+    {
+        $this->items = new ArrayCollection();
+    }
+
+    public function addItem(ChildEntity $item): void
+    {
+        if (!$this->items->contains($item)) {
+            $this->items->add($item);
+            $item->root = $this;
+        }
+    }
+
+    public function removeItem(ChildEntity $item): void
+    {
+        if ($this->items->removeElement($item) && $item->root === $this) {
+            $item->root = null;
+        }
+    }
+
+    /**
+     * @return Collection<int, ChildEntity>
+     */
+    public function getItems(): Collection
+    {
+        return $this->items;
+    }
+}

--- a/tests/Integration/ORM/DeferredPersistTest.php
+++ b/tests/Integration/ORM/DeferredPersistTest.php
@@ -23,6 +23,7 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadeCtorRequiredParent;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\CascadePersistChain;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\OrphanRemoval;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\SharedManagedParent;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
 use function Zenstruck\Foundry\Persistence\persistent_factory;
@@ -176,6 +177,32 @@ final class DeferredPersistTest extends KernelTestCase
             ->create(['bs' => $bFactory->many(1)]);
 
         self::assertTrue($hasAAtPrePersist);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function refreshing_managed_attribute_does_not_fire_lifecycle_events_on_scheduled_objects(): void
+    {
+        $parentFactory = persistent_factory(SharedManagedParent\ParentEntity::class);
+        $childFactory = persistent_factory(SharedManagedParent\ChildEntity::class);
+        $rootFactory = persistent_factory(SharedManagedParent\RootEntity::class);
+
+        // a flushed, managed entity, shared by the two children created below
+        $parent = $parentFactory->create();
+
+        // both children are scheduled until the root create completes; normalizing the second
+        // child's "parent" attribute must not fire prePersist on the first (still scheduled) one
+        $root = $rootFactory->create([
+            'items' => $childFactory->with(['parent' => $parent])->many(2),
+        ]);
+
+        self::assertCount(2, $root->getItems());
+
+        foreach ($root->getItems() as $item) {
+            self::assertSame(1, $item->prePersistCount);
+        }
     }
 
     /** @test */

--- a/tests/Integration/ORM/RefreshDirtyCheckTest.php
+++ b/tests/Integration/ORM/RefreshDirtyCheckTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+use function Zenstruck\Foundry\Persistence\persistent_factory;
+use function Zenstruck\Foundry\Persistence\refresh;
+
+/**
+ * The dirty-check of refresh() must not leave side effects in the UnitOfWork: computing
+ * a change set on the real UOW overwrites the original-data snapshot, silently losing
+ * any modification made before a refused refresh on the next flush.
+ */
+final class RefreshDirtyCheckTest extends KernelTestCase
+{
+    use Factories, RequiresORM, ResetDatabase;
+
+    /** @test */
+    #[Test]
+    public function modifications_before_and_after_a_dirty_refresh_are_all_flushed(): void
+    {
+        $factory = persistent_factory(GenericEntity::class);
+        $object = $factory->create(['prop1' => 'original', 'bool' => false]);
+
+        $object->setProp1('changed');
+
+        try {
+            refresh($object);
+            self::fail('refresh() should have refused: there are unsaved changes');
+        } catch (RefreshObjectFailed) {
+        }
+
+        $object->bool = true;
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush(); // @phpstan-ignore method.notFound
+
+        $factory::assert()->exists(['prop1' => 'changed', 'bool' => true]);
+    }
+}


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/zenstruck/foundry/releases/tag/v2.10.3

this new method will be used instead of `refresh()` in `PersistenceObjectFactory::normalizeObject()`. The refresh was problematic in some edge cases