### PR TITLE
fix: global state should not be accessed when persistence is not available

### DIFF
--- a/src/StoryRegistry.php
+++ b/src/StoryRegistry.php
@@ -41,7 +41,9 @@ final class StoryRegistry
      */
     public function load(string $class): Story
     {
-        if (\array_key_exists($class, self::$globalInstances)) {
+        // Global stories hold objects tied to the persistence layer they were built with:
+        // when persistence is not available (ie: in a unit test), rebuild the story locally instead.
+        if (\array_key_exists($class, self::$globalInstances) && Configuration::instance()->isPersistenceAvailable()) {
             return self::$globalInstances[$class]; // @phpstan-ignore return.type
         }
 

--- a/tests/Fixture/Stories/GlobalStory.php
+++ b/tests/Fixture/Stories/GlobalStory.php
@@ -19,7 +19,8 @@ use function Zenstruck\Foundry\Persistence\persist;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- * @method static GlobalEntity globalEntity()
+ * @method static GlobalEntity   globalEntity()
+ * @method static GlobalDocument globalDocument()
  */
 final class GlobalStory extends Story
 {
@@ -31,7 +32,8 @@ final class GlobalStory extends Story
         }
 
         if (\getenv('MONGO_URL')) {
-            persist(GlobalDocument::class);
+            $globalDocument = persist(GlobalDocument::class);
+            $this->addState('globalDocument', $globalDocument);
         }
     }
 }

--- a/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceTest.php
+++ b/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ResetDatabase;
+
+use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
+use Zenstruck\Foundry\PHPUnit\FoundryExtension;
+
+#[RequiresPhpunitExtension(FoundryExtension::class)]
+final class GlobalStoryUsedWithoutPersistenceTest extends GlobalStoryUsedWithoutPersistenceTestCase
+{
+}

--- a/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceTestCase.php
+++ b/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceTestCase.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ResetDatabase;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Story;
+use Zenstruck\Foundry\StoryRegistry;
+use Zenstruck\Foundry\Tests\Fixture\FoundryTestKernel;
+use Zenstruck\Foundry\Tests\Fixture\Stories\GlobalStory;
+
+/**
+ * Tests that must NOT extend KernelTestCase: they assert global stories don't
+ * leak into tests running without persistence in the same process.
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+abstract class GlobalStoryUsedWithoutPersistenceTestCase extends TestCase
+{
+    #[Test]
+    public function global_story_is_rebuilt_locally_when_persistence_is_not_available(): void
+    {
+        /** @var array<string, Story> $globalInstancesBackup */
+        $globalInstancesBackup = self::globalInstancesProperty()->getValue();
+        $globalInstance = $globalInstancesBackup[GlobalStory::class] ?? null;
+
+        if (!$globalInstance) {
+            // when the whole "reset-database" suite runs, the global stories have already
+            // been loaded by a previous kernel test in this process. When this test runs
+            // alone (ie: with --filter), seed the registry to simulate this situation.
+            $globalInstance = new GlobalStory();
+            $globalInstance->build();
+
+            self::globalInstancesProperty()->setValue(null, [GlobalStory::class => $globalInstance] + $globalInstancesBackup);
+        }
+
+        try {
+            $story = GlobalStory::load();
+
+            self::assertNotSame($globalInstance, $story);
+            self::assertSame($story, GlobalStory::load());
+
+            if (FoundryTestKernel::hasORM()) {
+                self::assertNull(GlobalStory::globalEntity()->id, 'The story state should have been rebuilt locally, without persistence.');
+            }
+
+            if (FoundryTestKernel::hasMongo()) {
+                self::assertNull(GlobalStory::globalDocument()->id, 'The story state should have been rebuilt locally, without persistence.');
+            }
+        } finally {
+            self::globalInstancesProperty()->setValue(null, $globalInstancesBackup);
+        }
+    }
+
+    private static function globalInstancesProperty(): \ReflectionProperty
+    {
+        return new \ReflectionProperty(StoryRegistry::class, 'globalInstances');
+    }
+}

--- a/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceWithTraitsTest.php
+++ b/tests/Integration/ResetDatabase/GlobalStoryUsedWithoutPersistenceWithTraitsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\ResetDatabase;
+
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Zenstruck\Foundry\Test\Factories;
+
+#[IgnoreDeprecations]
+final class GlobalStoryUsedWithoutPersistenceWithTraitsTest extends GlobalStoryUsedWithoutPersistenceTestCase
+{
+    use Factories;
+}


### PR DESCRIPTION
If the same story is used in a unit test and as global story in kernel tests, the unit test could receive the objects created by the "kernel test".

But those kernel test transformed the entities as lazy ghost on the last `kernel.reset` :boom: 