### PR TITLE
minor: reuse PersistenceManager::reattach() and clean up refresh()/autorefresh()

### DIFF
--- a/src/Persistence/PersistedObjectsTracker.php
+++ b/src/Persistence/PersistedObjectsTracker.php
@@ -91,7 +91,10 @@ final class PersistedObjectsTracker
         }
     }
 
-    private static function resetObjectAsLazyGhost(object $object, mixed $id): void
+    /**
+     * @param array<string, mixed> $id
+     */
+    private static function resetObjectAsLazyGhost(object $object, array $id): void
     {
         $reflector = new \ReflectionClass($object);
 

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -173,9 +173,10 @@ class PersistenceManager implements IdentifierResolver
     /**
      * @template T of object
      *
-     * @param T $object
+     * @param T                    $object
+     * @param array<string, mixed> $id
      */
-    public function autorefresh(object $object, mixed $id, object $clone): void
+    public function autorefresh(object $object, array $id, object $clone): void
     {
         $strategy = $this->strategyFor($object::class);
         $om = $strategy->objectManagerFor($object::class);
@@ -188,7 +189,7 @@ class PersistenceManager implements IdentifierResolver
                     // no identifier values means the object no longer exists
                     return;
                 }
-            } catch (\Throwable $e) {
+            } catch (\Throwable) {
             }
 
             // let's detach the object, in order to prevent Doctrine cache
@@ -240,9 +241,9 @@ class PersistenceManager implements IdentifierResolver
      *
      * @throws RefreshObjectFailed
      */
-    public function refresh(object &$object, bool $force = false, bool $canThrow = true): object
+    public function refresh(object &$object, bool $canThrow = true): object
     {
-        if (!$this->flush && !$force) {
+        if (!$this->flush) {
             return $object;
         }
 
@@ -286,9 +287,10 @@ class PersistenceManager implements IdentifierResolver
             return $object;
         }
 
-        $id = $strategy->getIdentifierValues($object);
+        $objectFromDB = $this->reattach($object);
 
-        if (!$id || !($objectFromDB = $om->find($object::class, $id))) {
+        if ($objectFromDB === $object) {
+            // reattach() could not find a managed instance: the object no longer exists
             if (!$canThrow) {
                 return $object;
             }
@@ -296,9 +298,7 @@ class PersistenceManager implements IdentifierResolver
             throw new ObjectNoLongerExist($object);
         }
 
-        $object = $objectFromDB;
-
-        return $object;
+        return $object = $objectFromDB;
     }
 
     public function isPersisted(object $object): bool
@@ -352,6 +352,9 @@ class PersistenceManager implements IdentifierResolver
             /** @var T $object */
             $object = $reflector->initializeLazyObject($object);
         }
+
+        // Doctrine cannot remove a detached object
+        $object = $this->reattach($object);
 
         $om = $this->strategyFor($object::class)->objectManagerFor($object::class);
         $om->remove($object);

--- a/tests/Integration/Mongo/GenericDocumentFactoryTest.php
+++ b/tests/Integration/Mongo/GenericDocumentFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\Mongo;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\ObjectManager;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
 use Zenstruck\Foundry\Tests\Integration\Persistence\GenericFactoryTestCase;
 use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
@@ -25,5 +27,10 @@ final class GenericDocumentFactoryTest extends GenericFactoryTestCase
     protected static function factory(): GenericDocumentFactory
     {
         return GenericDocumentFactory::new();
+    }
+
+    protected function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(DocumentManager::class); // @phpstan-ignore return.type
     }
 }

--- a/tests/Integration/Mongo/GenericDocumentProxyFactoryTest.php
+++ b/tests/Integration/Mongo/GenericDocumentProxyFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\Mongo;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
@@ -41,5 +43,10 @@ final class GenericDocumentProxyFactoryTest extends GenericProxyFactoryTestCase
     protected function objectWithReadonlyFactory(): PersistentProxyObjectFactory // @phpstan-ignore method.childReturnType
     {
         return proxy_factory(DocumentWithReadonly::class);
+    }
+
+    protected function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(DocumentManager::class); // @phpstan-ignore return.type
     }
 }

--- a/tests/Integration/ORM/GenericEntityFactoryTest.php
+++ b/tests/Integration/ORM/GenericEntityFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EmptyConstructorFactory;
@@ -132,5 +134,10 @@ final class GenericEntityFactoryTest extends GenericFactoryTestCase
     protected static function factory(): GenericEntityFactory
     {
         return GenericEntityFactory::new();
+    }
+
+    protected function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
     }
 }

--- a/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
+++ b/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\ORM;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
@@ -43,5 +45,10 @@ final class GenericEntityProxyFactoryTest extends GenericProxyFactoryTestCase
     protected function objectWithReadonlyFactory(): PersistentProxyObjectFactory // @phpstan-ignore method.childReturnType
     {
         return proxy_factory(EntityWithReadonly::class);
+    }
+
+    protected function objectManager(): ObjectManager
+    {
+        return self::getContainer()->get(EntityManagerInterface::class); // @phpstan-ignore return.type
     }
 }

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -167,7 +167,7 @@ abstract class GenericFactoryTestCase extends KernelTestCase
     {
         $object = static::factory()->create();
 
-        self::objectManagerFor(ProxyGenerator::unwrap($object))->clear();
+        $this->objectManager()->clear();
 
         delete($object);
 
@@ -779,14 +779,5 @@ abstract class GenericFactoryTestCase extends KernelTestCase
      */
     abstract protected static function factory(): PersistentObjectFactory;
 
-    private static function objectManagerFor(object $object): ObjectManager
-    {
-        foreach (['doctrine', 'doctrine_mongodb'] as $registry) {
-            if (self::getContainer()->has($registry) && ($om = self::getContainer()->get($registry)->getManagerForClass($object::class))) { // @phpstan-ignore method.notFound
-                return $om;
-            }
-        }
-
-        self::fail(\sprintf('No object manager found for "%s".', $object::class));
-    }
+    abstract protected function objectManager(): ObjectManager;
 }

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Foundry\Tests\Integration\Persistence;
 
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -152,6 +153,21 @@ abstract class GenericFactoryTestCase extends KernelTestCase
         $object = static::factory()->create();
 
         static::factory()->repository()->assert()->exists(['prop1' => 'default1']);
+
+        delete($object);
+
+        static::factory()->repository()->assert()->empty();
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_delete_a_detached_object(): void
+    {
+        $object = static::factory()->create();
+
+        self::objectManagerFor(ProxyGenerator::unwrap($object))->clear();
 
         delete($object);
 
@@ -762,4 +778,15 @@ abstract class GenericFactoryTestCase extends KernelTestCase
      * @return PersistentObjectFactory<GenericModel>
      */
     abstract protected static function factory(): PersistentObjectFactory;
+
+    private static function objectManagerFor(object $object): ObjectManager
+    {
+        foreach (['doctrine', 'doctrine_mongodb'] as $registry) {
+            if (self::getContainer()->has($registry) && ($om = self::getContainer()->get($registry)->getManagerForClass($object::class))) { // @phpstan-ignore method.notFound
+                return $om;
+            }
+        }
+
+        self::fail(\sprintf('No object manager found for "%s".', $object::class));
+    }
 }


### PR DESCRIPTION
Follow-up of #1140 / #1142: now that `reattach()` exists, reuse it where the same logic was duplicated, and clean up what became dead code.

## Changes

- **`refresh()`**: the "detached object" tail duplicated `reattach()`'s id + `find()` logic — it now delegates to `reattach()` and detects the not-found case by identity (`ObjectNoLongerExist` and `canThrow` behaviors are preserved).
- **`refresh()`**: drop the `$force` parameter — its last caller was `Story::getState()`, which uses `reattach()` since #1142. The `!$this->flush` early return is unchanged for the remaining callers.
- **`delete()`**: reattach the object first, so deleting an object detached from its object manager works instead of throwing `ORMInvalidArgumentException: Detached entity cannot be removed`. Covered by a new `can_delete_a_detached_object` test in `GenericFactoryTestCase` (ORM/Mongo × plain/proxy).
- **`autorefresh()`**: drop the unused caught-exception variable and tighten the `$id` parameter to `array` (all callers pass identifier values arrays; same for `PersistedObjectsTracker::resetObjectAsLazyGhost()`).

## Deliberately left untouched

- `functions.php` `refresh()` and `IsProxy::_refresh()` / `_autoRefresh()`: their semantic *is* refresh, not reattach.
- `PersistedObjectsTracker::add()` ORM v2 branch: `refresh(canThrow: false)` on a detached object is a silent no-op (the by-ref only replaces the local loop variable) — `autorefresh()` is probably the right tool there, but that path needs ORM v2 + lazy objects, a combination the CI only exercises once #1143 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)