### PR TITLE
fix: stale tracked objects when re-added with ORM 2

### DIFF
--- a/src/Persistence/PersistedObjectsTracker.php
+++ b/src/Persistence/PersistedObjectsTracker.php
@@ -61,7 +61,9 @@ final class PersistedObjectsTracker
                 if (DoctrineOrmVersionGuesser::isOrmV3()) {
                     self::resetObjectAsLazyGhost($object, self::$trackedObjects[$object]);
                 } else {
-                    Configuration::instance()->persistence()->refresh($object, canThrow: false);
+                    // refresh() would only swap a detached object for its managed instance,
+                    // leaving the tracked one stale: rehydrate it in place instead
+                    Configuration::instance()->persistence()->autorefresh($object, self::$trackedObjects[$object], clone $object);
                 }
 
                 continue;

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -247,6 +247,23 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
+    public function it_refreshes_a_detached_object_when_tracked_again(): void
+    {
+        $object = $this->factory()->create();
+
+        $this->updateObject($object->id);
+        $this->objectManager()->clear(); // $object is now detached and stale
+
+        $objectTracker = Configuration::instance()->persistedObjectsTracker;
+        self::assertNotNull($objectTracker);
+
+        // ie: what RepositoryDecorator does with the objects it returns
+        $objectTracker->add($object);
+
+        self::assertSame('foo', $object->getProp1());
+    }
+
+    #[Test]
     public function it_can_refresh_after_command_terminated(): void
     {
         $object = $this->factory()->create();


### PR DESCRIPTION
Follow-up of #1143: now that the "lowest deps + PHP 8.4 & lazy objects" CI job really enables lazy objects (hence ORM 2.16 + the `PersistedObjectsTracker`), the ORM 2 branch of `PersistedObjectsTracker::add()` is finally exercised — and it was a silent no-op for detached objects.

## The bug

When an already-tracked object is added again (ie: what `RepositoryDecorator` does with the objects it returns):
- **ORM 3**: the object is reset as a lazy ghost and rehydrated in place on next access ✅
- **ORM 2** (which cannot use `resetAsLazyGhost()`): `refresh($object, canThrow: false)` was called — but for a *detached* object, `refresh()` swaps in the managed instance through its **by-ref parameter**, which only rebinds the local `foreach` variable. The instance everyone holds stayed stale ❌

## The fix

Use `autorefresh($object, $id, clone $object)` instead — the in-place rehydration primitive the ORM 3 lazy-ghost initializer already relies on: the same PHP instance gets the fresh data, whether it is managed or detached.

## Test

`AutoRefreshTestCase::it_refreshes_a_detached_object_when_tracked_again` (ORM + Mongo variants): create a tracked object, update its row with raw SQL, `clear()` the object manager, re-`add()` it to the tracker — the object must expose the fresh data. Red before the fix on ORM 2.16 (full `--prefer-lowest` install, the object stayed `'default1'` instead of `'foo'`), green after; green on ORM 3 before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)