### PR TITLE
minor: remove clone in autorefresh() and fix stale tracked objects with ORM 2

### DIFF
--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\VarExporter\Hydrator as VarExporterHydrator;
 use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\ForceValue;
 
@@ -201,6 +202,22 @@ final class Hydrator
 
         foreach ($properties as $property) {
             self::forceSet($object, $property, self::get($other, $property), catchErrors: true);
+        }
+    }
+
+    /**
+     * Restores properties captured with an `(array) $object` cast (mangled keys),
+     * without invoking __clone() nor the constructor.
+     *
+     * @param array<string, mixed> $snapshot
+     */
+    public static function hydrateFromSnapshot(object $object, array $snapshot): void
+    {
+        if (\function_exists('deepclone_hydrate')) {
+            // VarExporter's Hydrator is deprecated since symfony/var-exporter 8.1
+            deepclone_hydrate($object, $snapshot, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
+        } else {
+            VarExporterHydrator::hydrate($object, $snapshot);
         }
     }
 

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -215,7 +215,8 @@ final class Hydrator
     {
         if (\function_exists('deepclone_hydrate')) {
             // VarExporter's Hydrator is deprecated since symfony/var-exporter 8.1
-            deepclone_hydrate($object, $snapshot, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
+            // the constant is resolved dynamically: it only exists along with the function
+            deepclone_hydrate($object, $snapshot, \constant('DEEPCLONE_HYDRATE_PRESERVE_REFS'));
         } else {
             VarExporterHydrator::hydrate($object, $snapshot);
         }

--- a/src/Persistence/Exception/ObjectNoLongerExist.php
+++ b/src/Persistence/Exception/ObjectNoLongerExist.php
@@ -17,6 +17,6 @@ final class ObjectNoLongerExist extends RefreshObjectFailed
 {
     public function __construct(public readonly object $originalObject)
     {
-        parent::__construct('object no longer exists...');
+        parent::__construct(\sprintf('Object "%s" no longer exists in the database: it was deleted or rolled back.', $originalObject::class));
     }
 }

--- a/src/Persistence/PersistedObjectsTracker.php
+++ b/src/Persistence/PersistedObjectsTracker.php
@@ -61,7 +61,9 @@ final class PersistedObjectsTracker
                 if (DoctrineOrmVersionGuesser::isOrmV3()) {
                     self::resetObjectAsLazyGhost($object, self::$trackedObjects[$object]);
                 } else {
-                    Configuration::instance()->persistence()->refresh($object, canThrow: false);
+                    // refresh() would only swap a detached object for its managed instance,
+                    // leaving the tracked one stale: rehydrate it in place instead
+                    Configuration::instance()->persistence()->autorefresh($object, self::$trackedObjects[$object]);
                 }
 
                 continue;
@@ -107,12 +109,14 @@ final class PersistedObjectsTracker
             return;
         }
 
-        $clone = clone $object;
-        $reflector->resetAsLazyGhost($object, static function($object) use ($clone, $id) {
+        // resetAsLazyGhost() destroys the object's state: capture it so it can be
+        // restored if the database row no longer exists when the ghost initializes
+        $snapshot = (array) $object;
+        $reflector->resetAsLazyGhost($object, static function($object) use ($snapshot, $id) {
             // prevent some weird recursion in some edge cases, caused by kernel.reset
             unset(self::$trackedObjects[$object]);
 
-            Configuration::instance()->persistence()->autorefresh($object, $id, $clone);
+            Configuration::instance()->persistence()->autorefresh($object, $id, $snapshot);
 
             self::$trackedObjects[$object] = $id;
         });

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -173,10 +173,12 @@ class PersistenceManager implements IdentifierResolver
     /**
      * @template T of object
      *
-     * @param T                    $object
-     * @param array<string, mixed> $id
+     * @param T                         $object
+     * @param array<string, mixed>      $id
+     * @param array<string, mixed>|null $snapshot properties captured with an `(array)` cast before the
+     *                                            object's state was destroyed by resetAsLazyGhost()
      */
-    public function autorefresh(object $object, array $id, object $clone): void
+    public function autorefresh(object $object, array $id, ?array $snapshot = null): void
     {
         $strategy = $this->strategyFor($object::class);
         $om = $strategy->objectManagerFor($object::class);
@@ -205,9 +207,13 @@ class PersistenceManager implements IdentifierResolver
             }
         }
 
-        // the object no longer exists
-        Hydrator::hydrateFromOtherObject($object, $clone);
+        // the object no longer exists in the database: it was deleted or rolled back
         $om->detach($object);
+
+        if (null !== $snapshot) {
+            // the object's state was destroyed by resetAsLazyGhost(): restore its previous values
+            Hydrator::hydrateFromSnapshot($object, $snapshot);
+        }
     }
 
     /**

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -247,6 +247,23 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
+    public function it_refreshes_a_detached_object_when_tracked_again(): void
+    {
+        $object = $this->factory()->create();
+
+        $this->updateObject($object->id);
+        $this->objectManager()->clear(); // $object is now detached and stale
+
+        $objectTracker = Configuration::instance()->persistedObjectsTracker;
+        self::assertNotNull($objectTracker);
+
+        // ie: what RepositoryDecorator does with the objects it returns
+        $objectTracker->add($object);
+
+        self::assertSame('foo', $object->getProp1());
+    }
+
+    #[Test]
     public function it_can_refresh_after_command_terminated(): void
     {
         $object = $this->factory()->create();


### PR DESCRIPTION
## Remove the `clone` in `autorefresh()`

`PersistedObjectsTracker` cloned every tracked object before ghosting it, as a safety net to restore its state when the database row no longer exists (deleted or rolled back): `resetAsLazyGhost()` destroys the object's state, so without a backup there would be nothing left to restore.

But `clone $entity` invokes the user's `__clone()` method, which is surprising and can corrupt the safety net — e.g. an entity resetting its id in `__clone()` (like the `EntityWithCloneMethod` fixture) would lose its id on restore.

The clone is replaced with an `(array) $object` snapshot:
- engine-level cast, as fast as a clone, never invokes `__clone()`, skips uninitialized properties, produces the mangled-keys format (`"\0Class\0prop"`) with proper per-class scoping;
- restored with symfony/var-exporter (already a direct dependency): `deepclone_hydrate()` on var-exporter 8.1+ (where `VarExporter\Hydrator` is deprecated), `VarExporter\Hydrator::hydrate()` on 6.4/7.x.

No behavior change: the existing `deleting_an_object_does_not_create_a_refresh_error` test (4 variants, including raw-SQL DELETE) still passes — pre-deletion values are restored, no exception thrown.

## Fix stale tracked objects when re-added with ORM 2

Reworked from #1145 (closed in favor of this PR). When an already-tracked object is added again to `PersistedObjectsTracker` (ie: by `RepositoryDecorator` with the objects it returns), the ORM 2 branch called `refresh()`, which only swaps a detached object for its managed instance through its by-ref parameter — a silent no-op for the tracked instance, left stale. Use `autorefresh()` instead, the in-place rehydration the ORM 3 lazy-ghost initializer already relies on. No snapshot is needed in that path: the object's state is never destroyed there.

Covered by the new `it_refreshes_a_detached_object_when_tracked_again` test, verified red-then-green with `--prefer-lowest` (ORM 2.16, var-exporter 6.4.9 — which also exercises the non-deprecated hydration branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)