### PR TITLE
fix: prevent flushes from corrupting tracked objects reset as lazy ghosts (ORM   2 / ODM without native lazy objects).

### DIFF
--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -12,8 +12,10 @@
 namespace Zenstruck\Foundry\Mongo;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\MappingException as MongoMappingException;
 use Doctrine\Persistence\Mapping\MappingException;
+use Zenstruck\Foundry\Persistence\InitializeTrackedGhostsBeforeFlushListener;
 use Zenstruck\Foundry\Persistence\PersistenceStrategy;
 
 /**
@@ -31,6 +33,19 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
         $dm = $this->objectManagerFor($object::class);
 
         return $dm->contains($object) && !$dm->getUnitOfWork()->isScheduledForInsert($object);
+    }
+
+    public function registerPreFlushGhostInitializer(string $class): void
+    {
+        $dm = $this->objectManagerFor($class);
+
+        $config = $dm->getConfiguration();
+        if (\method_exists($config, 'isNativeLazyObjectEnabled') && $config->isNativeLazyObjectEnabled()) {
+            // ODM with native lazy objects skips uninitialized objects when computing changesets
+            return;
+        }
+
+        InitializeTrackedGhostsBeforeFlushListener::registerTo($dm->getEventManager(), Events::preFlush);
     }
 
     public function hasChanges(object $object): bool

--- a/src/ORM/AbstractORMPersistenceStrategy.php
+++ b/src/ORM/AbstractORMPersistenceStrategy.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\Persistence\Mapping\MappingException;
+use Zenstruck\Foundry\Persistence\InitializeTrackedGhostsBeforeFlushListener;
 use Zenstruck\Foundry\Persistence\PersistenceStrategy;
 
 /**
@@ -32,6 +33,19 @@ abstract class AbstractORMPersistenceStrategy extends PersistenceStrategy
         $em = $this->objectManagerFor($object::class);
 
         return $em->contains($object) && !$em->getUnitOfWork()->isScheduledForInsert($object);
+    }
+
+    final public function registerPreFlushGhostInitializer(string $class): void
+    {
+        $em = $this->objectManagerFor($class);
+
+        $config = $em->getConfiguration();
+        if (\method_exists($config, 'isNativeLazyObjectsEnabled') && $config->isNativeLazyObjectsEnabled()) {
+            // ORM >= 3.4 with native lazy objects skips uninitialized objects when computing changesets
+            return;
+        }
+
+        InitializeTrackedGhostsBeforeFlushListener::registerTo($em->getEventManager(), Events::preFlush);
     }
 
     final public function hasChanges(object $object): bool

--- a/src/Persistence/InitializeTrackedGhostsBeforeFlushListener.php
+++ b/src/Persistence/InitializeTrackedGhostsBeforeFlushListener.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Persistence;
+
+use Doctrine\Common\EventManager;
+use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use Zenstruck\Foundry\Configuration;
+
+/**
+ * Initializes the tracked lazy ghosts still managed by the flushing object manager, right
+ * before it computes changesets: ORM/ODM versions unaware of PHP native lazy objects read
+ * properties through an `(array)` cast which does not trigger the ghost initialization,
+ * and would compute an all-null changeset, erasing the object's data in the database.
+ *
+ * @see https://github.com/zenstruck/foundry/issues/1122
+ *
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
+ */
+final class InitializeTrackedGhostsBeforeFlushListener
+{
+    /**
+     * Event managers already guarded by this listener. Static on purpose: idempotence must
+     * survive strategy re-instantiation across kernel resets, while the event manager
+     * (owned by the connection) is longer-lived than the object manager itself.
+     *
+     * @var \WeakMap<EventManager, true>
+     */
+    private static \WeakMap $registeredEventManagers;
+
+    public static function registerTo(EventManager $eventManager, string $eventName): void
+    {
+        if (!isset(self::$registeredEventManagers)) {
+            /** @var \WeakMap<EventManager, true> $registeredEventManagers */
+            $registeredEventManagers = new \WeakMap();
+            self::$registeredEventManagers = $registeredEventManagers;
+        }
+
+        if (isset(self::$registeredEventManagers[$eventManager])) {
+            return;
+        }
+
+        $eventManager->addEventListener([$eventName], new self());
+        self::$registeredEventManagers[$eventManager] = true;
+    }
+
+    /**
+     * @param ManagerEventArgs<ObjectManager> $args
+     */
+    public function preFlush(ManagerEventArgs $args): void
+    {
+        if (!Configuration::isBooted()) {
+            return;
+        }
+
+        $om = $args->getObjectManager();
+
+        foreach (PersistedObjectsTracker::trackedObjects() as $object) {
+            $reflector = new \ReflectionClass($object);
+
+            if (!$reflector->isUninitializedLazyObject($object)) {
+                continue;
+            }
+
+            // contains() only checks the identity map: it does not initialize the ghost
+            if (!$om->contains($object)) {
+                continue;
+            }
+
+            $reflector->initializeLazyObject($object);
+        }
+    }
+}

--- a/src/Persistence/PersistedObjectsTracker.php
+++ b/src/Persistence/PersistedObjectsTracker.php
@@ -57,14 +57,12 @@ final class PersistedObjectsTracker
                 continue;
             }
 
+            // a flush could occur once the object is reset as an uninitialized lazy ghost:
+            // its object manager must not compute a changeset from it
+            Configuration::instance()->persistence()->registerPreFlushGhostInitializer($object::class);
+
             if (self::$trackedObjects->offsetExists($object) && self::$trackedObjects[$object]) {
-                if (DoctrineOrmVersionGuesser::isOrmV3()) {
-                    self::resetObjectAsLazyGhost($object, self::$trackedObjects[$object]);
-                } else {
-                    // refresh() would only swap a detached object for its managed instance,
-                    // leaving the tracked one stale: rehydrate it in place instead
-                    Configuration::instance()->persistence()->autorefresh($object, self::$trackedObjects[$object]);
-                }
+                self::resetObjectAsLazyGhost($object, self::$trackedObjects[$object]);
 
                 continue;
             }
@@ -81,6 +79,26 @@ final class PersistedObjectsTracker
     public static function countObjects(): int
     {
         return \count(self::$trackedObjects);
+    }
+
+    /**
+     * @return list<object>
+     */
+    public static function trackedObjects(): array
+    {
+        self::$trackedObjects ??= new \WeakMap();
+
+        // a snapshot is mandatory: initializing a ghost mutates the WeakMap being iterated
+        $objects = [];
+        foreach (self::$trackedObjects as $object => $id) {
+            if (!$id) {
+                continue;
+            }
+
+            $objects[] = $object;
+        }
+
+        return $objects;
     }
 
     private static function resetObjectsAsLazyGhosts(): void

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -463,6 +463,18 @@ class PersistenceManager implements IdentifierResolver
         }
     }
 
+    /**
+     * @param class-string $class
+     */
+    public function registerPreFlushGhostInitializer(string $class): void
+    {
+        try {
+            $this->strategyFor($class)->registerPreFlushGhostInitializer($class);
+        } catch (NoPersistenceStrategy) {
+            // ie: tracked objects in a kernel without their persistence strategy
+        }
+    }
+
     public function hasPersistenceFor(object $object): bool
     {
         try {

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -73,6 +73,16 @@ abstract class PersistenceStrategy
         return $this->objectManagerFor($class)->getClassMetadata($class);
     }
 
+    /**
+     * Guard the given class' object manager against computing changesets from
+     * uninitialized lazy ghosts, if it cannot handle them natively.
+     *
+     * @param class-string $class
+     */
+    public function registerPreFlushGhostInitializer(string $class): void
+    {
+    }
+
     abstract public function hasChanges(object $object): bool;
 
     abstract public function contains(object $object): bool;

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -460,6 +460,45 @@ abstract class AutoRefreshTestCase extends WebTestCase
     }
 
     #[Test]
+    public function saving_another_object_does_not_alter_ghost_objects(): void
+    {
+        $client = self::createClient();
+
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        // kernel.terminate resets tracked objects as lazy ghosts, but they are still managed
+        $client->request('GET', '/hello-world');
+        self::assertResponseIsSuccessful();
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+        self::assertTrue($this->objectManager()->contains($object));
+
+        // saving another object triggers a flush while the ghost is uninitialized
+        $this->factory()->create();
+
+        $this->factory()::assert()->exists(['id' => $objectId, 'prop1' => 'default1']);
+        self::assertSame('default1', $object->getProp1());
+    }
+
+    #[Test]
+    public function saving_another_object_does_not_alter_ghost_objects_after_refresh_all(): void
+    {
+        $object = $this->factory()->create();
+        $objectId = $object->id;
+
+        refresh_all();
+
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+        self::assertTrue($this->objectManager()->contains($object));
+
+        // saving another object triggers a flush while the ghost is uninitialized
+        $this->factory()->create();
+
+        $this->factory()::assert()->exists(['id' => $objectId, 'prop1' => 'default1']);
+        self::assertSame('default1', $object->getProp1());
+    }
+
+    #[Test]
     public function repository_method_returns_up_to_date_objects_with_readonly_props(): void
     {
         [$object1, $object2] = $this->objectWithReadonlyFactory()->many(2)->create([


### PR DESCRIPTION
  ## Fix #1122 — an unrelated flush corrupts tracked entities reset as lazy ghosts (ORM 2.x / ODM without native lazy objects)

  ### The bug

  After an HTTP request in a `WebTestCase`, `PersistedObjectsTracker::refresh()` (wired to
  `kernel.terminate`) resets every tracked object as an uninitialized PHP 8.4 lazy ghost —
  **while it is still managed** by its object manager. If a flush occurs afterwards (e.g.
  saving another object with a factory), Doctrine computes changesets for *all* managed
  objects, and versions unaware of PHP native lazy objects read properties through an
  `(array)` cast (`RuntimeReflectionProperty` / `RawValuePropertyAccessor`) which does
  **not** trigger the ghost initialization: every property reads `null`, and the resulting
  changeset issues an `UPDATE` erasing the row (`NotNullConstraintViolationException` on
  strict DBMS, silent data corruption on Mongo).

  #1042 guarded the `add()` re-add path only; the `refresh()` path (`kernel.terminate`,
  `kernel.reset`, `refresh_all()`) was left unguarded — that's the hole #1122 exposes.

  Affected: ORM 2.x, ORM 3.x and ODM without native lazy objects enabled.
  Not affected: ORM ≥ 3.4 and ODM ≥ 2.14 *with* native lazy objects — their `UnitOfWork`
  skips uninitialized lazy objects when computing changesets.

  ### The fix

  Keep ghosting everywhere (an eager refresh instead would break the lazy semantics: the
  whole point of the ghost is to fetch fresh data at *next access*, not at terminate time).
  Instead, a new `preFlush` listener initializes the tracked ghosts still managed by the
  flushing object manager, right before changesets are computed. Initialization goes
  through the existing autorefresh mechanism, so data and `originalEntityData` are
  refreshed together → no bogus changeset.

  - The listener is registered at runtime on the object manager's `EventManager` when an
    object gets tracked (idempotent, `WeakMap`-based), and **only** when the ORM/ODM cannot
    handle native lazy ghosts itself (`isNativeLazyObjectsEnabled()` check): on modern
    stacks nothing is registered at all.
  - `preFlush` is dispatched at the very top of `flush()`, before changeset computation and
    before the transaction, on ORM 2/3 and ODM alike — and both `PreFlushEventArgs` extend
    `Doctrine\Persistence\Event\ManagerEventArgs`, so a single listener covers ORM and ODM.

  ### Tests

  Two regression tests in the shared `AutoRefreshTestCase` (ORM + Mongo): create an object,
  ghostify it (via an HTTP request for one, `refresh_all()` for the other), save another
  object, then assert the first one's data is intact in the database.

  Verified red-then-green with `--prefer-lowest`:
  - ORM 2.16: `Integrity constraint violation: Column 'prop1' cannot be null` → green
  - ODM 2.11: silent document corruption → green

  On highest deps (ORM 3.6 / ODM 2.16 with native lazy objects on by default), the listener
  is never registered and the whole suite stays green.