### PR TITLE
fix: hydrate snapshots with deepclone_hydrate() (requires symfony/polyfill-deepclone ^1.42)

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -2,9 +2,9 @@ name: Behat
 
 on:
   push:
-    # the Behat suite runs against the checkout's src/ (symlinked into the vendor dir by
-    # symlink-vendor.sh on post-install) and against the shared test fixtures: a change in
-    # the main package must also trigger this workflow
+    # the Behat suite runs against the checkout's zenstruck/foundry (installed from the
+    # monorepo as a composer path repository) and against the shared test fixtures:
+    # a change in the main package must also trigger this workflow
     paths: &paths
       - .github/workflows/behat.yml
       - src/**
@@ -49,6 +49,14 @@ jobs:
       - name: Pin Doctrine ORM 2 and its php80 polyfill for the lowest deps
         if: ${{ matrix.deps == 'lowest' }}
         run: composer require --dev "doctrine/orm:^2.16" symfony/polyfill-php80:^1.16 --no-update
+
+      # install zenstruck/foundry from the checkout instead of Packagist, so the suite runs
+      # the branch's code with its dependencies resolved transitively; composer refuses to
+      # install a path package inside its own source tree, hence the copy outside of it
+      - name: Install zenstruck/foundry from the checkout
+        run: |
+          rsync -a --exclude=.git --exclude=vendor ../../../ "$RUNNER_TEMP/foundry-checkout/"
+          composer config repositories.foundry "{\"type\": \"path\", \"url\": \"$RUNNER_TEMP/foundry-checkout\", \"options\": {\"versions\": {\"zenstruck/foundry\": \"2.99.0\"}}}"
 
       - name: Install dependencies
         uses: ramsey/composer-install@v2
@@ -113,6 +121,14 @@ jobs:
         if: ${{ matrix.deps == 'lowest' }}
         run: composer require --dev "doctrine/orm:^2.16" symfony/polyfill-php80:^1.16 --no-update
 
+      # install zenstruck/foundry from the checkout instead of Packagist, so the suite runs
+      # the branch's code with its dependencies resolved transitively; composer refuses to
+      # install a path package inside its own source tree, hence the copy outside of it
+      - name: Install zenstruck/foundry from the checkout
+        run: |
+          rsync -a --exclude=.git --exclude=vendor ../../../ "$RUNNER_TEMP/foundry-checkout/"
+          composer config repositories.foundry "{\"type\": \"path\", \"url\": \"$RUNNER_TEMP/foundry-checkout\", \"options\": {\"versions\": {\"zenstruck/foundry\": \"2.99.0\"}}}"
+
       - name: Install dependencies
         uses: ramsey/composer-install@v2
         with:
@@ -138,6 +154,14 @@ jobs:
           php-version: 8.5
           coverage: none
           tools: flex
+
+      # install zenstruck/foundry from the checkout instead of Packagist, so the suite runs
+      # the branch's code with its dependencies resolved transitively; composer refuses to
+      # install a path package inside its own source tree, hence the copy outside of it
+      - name: Install zenstruck/foundry from the checkout
+        run: |
+          rsync -a --exclude=.git --exclude=vendor ../../../ "$RUNNER_TEMP/foundry-checkout/"
+          composer config repositories.foundry "{\"type\": \"path\", \"url\": \"$RUNNER_TEMP/foundry-checkout\", \"options\": {\"versions\": {\"zenstruck/foundry\": \"2.99.0\"}}}"
 
       - name: Install dependencies
         uses: ramsey/composer-install@v2

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.1",
         "fakerphp/faker": "^1.24",
         "symfony/deprecation-contracts": "^2.2|^3.0",
+        "symfony/polyfill-deepclone": "^1.42",
         "symfony/polyfill-php84": "^1.32",
         "symfony/polyfill-php85": "^1.33",
         "symfony/property-access": "^6.4|^7.0|^8.0",

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
-use Symfony\Component\VarExporter\Hydrator as VarExporterHydrator;
 use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\ForceValue;
 
@@ -213,13 +212,9 @@ final class Hydrator
      */
     public static function hydrateFromSnapshot(object $object, array $snapshot): void
     {
-        if (\function_exists('deepclone_hydrate')) {
-            // VarExporter's Hydrator is deprecated since symfony/var-exporter 8.1
-            // the constant is resolved dynamically: it only exists along with the function
-            deepclone_hydrate($object, $snapshot, \constant('DEEPCLONE_HYDRATE_PRESERVE_REFS'));
-        } else {
-            VarExporterHydrator::hydrate($object, $snapshot);
-        }
+        // symfony/polyfill-deepclone >= 1.42 is required: it fixes the hydration
+        // of mangled keys pointing to the object's own scope (symfony/polyfill#643)
+        deepclone_hydrate($object, $snapshot, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
     }
 
     private static function accessibleProperty(object $object, string $name): \ReflectionProperty

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -213,8 +213,6 @@ final class Hydrator
      */
     public static function hydrateFromSnapshot(object $object, array $snapshot): void
     {
-        $snapshot = self::normalizeMangledKeys($object, $snapshot);
-
         if (\function_exists('deepclone_hydrate')) {
             // VarExporter's Hydrator is deprecated since symfony/var-exporter 8.1
             // the constant is resolved dynamically: it only exists along with the function
@@ -222,48 +220,6 @@ final class Hydrator
         } else {
             VarExporterHydrator::hydrate($object, $snapshot);
         }
-    }
-
-    /**
-     * An `(array) $object` cast mangles non-public property names ("\0Class\0name" for a private
-     * one, "\0*\0name" for a protected one), but the hydrators expect the convention built by
-     * VarExporter\Hydrator: a plain name for anything writable in the object's own scope, and
-     * "\0Scope\0name" only for a private property declared by another class.
-     *
-     * Without this translation, a snapshot whose keys all resolve to the object's own scope takes
-     * the hydrator's un-grouped fast path and the mangled name is used verbatim, which fails with
-     * `Error: Cannot access property starting with "\0"`.
-     *
-     * @param array<string, mixed> $snapshot
-     *
-     * @return array<string, mixed>
-     */
-    private static function normalizeMangledKeys(object $object, array $snapshot): array
-    {
-        $vars = [];
-
-        foreach ($snapshot as $key => $value) {
-            $parts = \explode("\0", $key);
-
-            // a mangled key is "\0", the scope, "\0" and the property name, so it explodes into at
-            // least 3 parts. Anything shorter is left untouched: "\0" alone carries the state of
-            // SplObjectStorage/ArrayObject/ArrayIterator.
-            if (\count($parts) < 3 || '' !== $parts[0]) {
-                $vars[$key] = $value;
-
-                continue;
-            }
-
-            // the property name never contains a "\0" but an anonymous class name does, so the name
-            // is the last part and everything in between belongs to the scope
-            $name = \array_pop($parts);
-            \array_shift($parts);
-            $scope = \implode("\0", $parts);
-
-            $vars['*' === $scope || $scope === $object::class ? $name : "\0{$scope}\0{$name}"] = $value;
-        }
-
-        return $vars;
     }
 
     private static function accessibleProperty(object $object, string $name): \ReflectionProperty

--- a/src/Object/Hydrator.php
+++ b/src/Object/Hydrator.php
@@ -213,6 +213,8 @@ final class Hydrator
      */
     public static function hydrateFromSnapshot(object $object, array $snapshot): void
     {
+        $snapshot = self::normalizeMangledKeys($object, $snapshot);
+
         if (\function_exists('deepclone_hydrate')) {
             // VarExporter's Hydrator is deprecated since symfony/var-exporter 8.1
             // the constant is resolved dynamically: it only exists along with the function
@@ -220,6 +222,48 @@ final class Hydrator
         } else {
             VarExporterHydrator::hydrate($object, $snapshot);
         }
+    }
+
+    /**
+     * An `(array) $object` cast mangles non-public property names ("\0Class\0name" for a private
+     * one, "\0*\0name" for a protected one), but the hydrators expect the convention built by
+     * VarExporter\Hydrator: a plain name for anything writable in the object's own scope, and
+     * "\0Scope\0name" only for a private property declared by another class.
+     *
+     * Without this translation, a snapshot whose keys all resolve to the object's own scope takes
+     * the hydrator's un-grouped fast path and the mangled name is used verbatim, which fails with
+     * `Error: Cannot access property starting with "\0"`.
+     *
+     * @param array<string, mixed> $snapshot
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeMangledKeys(object $object, array $snapshot): array
+    {
+        $vars = [];
+
+        foreach ($snapshot as $key => $value) {
+            $parts = \explode("\0", $key);
+
+            // a mangled key is "\0", the scope, "\0" and the property name, so it explodes into at
+            // least 3 parts. Anything shorter is left untouched: "\0" alone carries the state of
+            // SplObjectStorage/ArrayObject/ArrayIterator.
+            if (\count($parts) < 3 || '' !== $parts[0]) {
+                $vars[$key] = $value;
+
+                continue;
+            }
+
+            // the property name never contains a "\0" but an anonymous class name does, so the name
+            // is the last part and everything in between belongs to the scope
+            $name = \array_pop($parts);
+            \array_shift($parts);
+            $scope = \implode("\0", $parts);
+
+            $vars['*' === $scope || $scope === $object::class ? $name : "\0{$scope}\0{$name}"] = $value;
+        }
+
+        return $vars;
     }
 
     private static function accessibleProperty(object $object, string $name): \ReflectionProperty

--- a/src/Test/Behat/symlink-vendor.sh
+++ b/src/Test/Behat/symlink-vendor.sh
@@ -12,6 +12,13 @@ if ! grep -q '"name": "zenstruck/foundry"' "${MONOREPO_ROOT}/composer.json" 2>/d
     exit 0
 fi
 
+# when zenstruck/foundry is installed from a path repository (as in CI), the vendor entry
+# already points to the checkout: symlinking would destroy the real sources
+if [ -L "${SCRIPT_DIR}/vendor/zenstruck/foundry" ]; then
+    echo "vendor/zenstruck/foundry is already a symlink to the checkout: nothing to do."
+    exit 0
+fi
+
 if [ ! -d "${VENDOR_SRC}" ]; then
     echo "Directory vendor/zenstruck/foundry/src does not exist yet."
     exit 1

--- a/tests/Fixture/Document/DocumentWithOnlyPrivateProperties.php
+++ b/tests/Fixture/Document/DocumentWithOnlyPrivateProperties.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * Declares every property itself, privately: casting such an object to an array yields only mangled
+ * keys resolving to its own scope, which is the shape that breaks hydration from a snapshot. Sharing
+ * a mapped superclass would defeat the purpose, as the inherited scope makes the problem disappear.
+ */
+#[MongoDB\Document]
+class DocumentWithOnlyPrivateProperties
+{
+    #[MongoDB\Id(type: 'int', strategy: 'INCREMENT')]
+    private ?int $id = null; // @phpstan-ignore property.unusedType (assigned by the INCREMENT strategy)
+
+    #[MongoDB\Field]
+    private string $prop1 = 'default1';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProp1(): string
+    {
+        return $this->prop1;
+    }
+
+    public function setProp1(string $prop1): void
+    {
+        $this->prop1 = $prop1;
+    }
+}

--- a/tests/Fixture/Entity/EntityWithOnlyPrivateProperties.php
+++ b/tests/Fixture/Entity/EntityWithOnlyPrivateProperties.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Declares every property itself, privately: casting such an object to an array yields only mangled
+ * keys resolving to its own scope, which is the shape that breaks hydration from a snapshot. Sharing
+ * a mapped superclass would defeat the purpose, as the inherited scope makes the problem disappear.
+ */
+#[ORM\Entity]
+class EntityWithOnlyPrivateProperties
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private string $prop1 = 'default1';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProp1(): string
+    {
+        return $this->prop1;
+    }
+
+    public function setProp1(string $prop1): void
+    {
+        $this->prop1 = $prop1;
+    }
+}

--- a/tests/Fixture/SnapshotChild.php
+++ b/tests/Fixture/SnapshotChild.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class SnapshotChild extends SnapshotParent
+{
+    public string $childPublic = 'child-public';
+    private string $childPrivate = 'child-private';
+    private string $shadowed = 'child-shadowed';
+
+    public function childPrivate(): string
+    {
+        return $this->childPrivate;
+    }
+
+    public function childShadowed(): string
+    {
+        return $this->shadowed;
+    }
+}

--- a/tests/Fixture/SnapshotParent.php
+++ b/tests/Fixture/SnapshotParent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class SnapshotParent
+{
+    protected string $parentProtected = 'parent-protected';
+    private string $parentPrivate = 'parent-private';
+    private string $shadowed = 'parent-shadowed';
+
+    public function parentPrivate(): string
+    {
+        return $this->parentPrivate;
+    }
+
+    public function parentProtected(): string
+    {
+        return $this->parentProtected;
+    }
+
+    public function parentShadowed(): string
+    {
+        return $this->shadowed;
+    }
+}

--- a/tests/Integration/Mongo/AutoRefreshTest.php
+++ b/tests/Integration/Mongo/AutoRefreshTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithOnlyPrivateProperties;
 use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Document\GenericDocument;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
@@ -37,6 +38,14 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     protected static function factory(): PersistentObjectFactory
     {
         return GenericDocumentFactory::new();
+    }
+
+    /**
+     * @return PersistentObjectFactory<DocumentWithOnlyPrivateProperties>
+     */
+    protected static function factoryWithOnlyPrivateProperties(): PersistentObjectFactory
+    {
+        return persistent_factory(DocumentWithOnlyPrivateProperties::class);
     }
 
     protected function dbms(): string

--- a/tests/Integration/ORM/AutoRefreshTest.php
+++ b/tests/Integration/ORM/AutoRefreshTest.php
@@ -31,6 +31,7 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\DerivedIdentity;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithCloneMethod;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\ManyToOneWithCascade\OwningSide;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithOnlyPrivateProperties;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\AddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\CategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ContactFactory;
@@ -232,6 +233,14 @@ final class AutoRefreshTest extends AutoRefreshTestCase
     protected static function factory(): PersistentObjectFactory
     {
         return GenericEntityFactory::new();
+    }
+
+    /**
+     * @return PersistentObjectFactory<EntityWithOnlyPrivateProperties>
+     */
+    protected static function factoryWithOnlyPrivateProperties(): PersistentObjectFactory
+    {
+        return persistent_factory(EntityWithOnlyPrivateProperties::class);
     }
 
     protected function dbms(): string

--- a/tests/Integration/Persistence/AutoRefreshTestCase.php
+++ b/tests/Integration/Persistence/AutoRefreshTestCase.php
@@ -30,8 +30,10 @@ use Zenstruck\Foundry\Persistence\PersistedObjectsTracker;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithOnlyPrivateProperties;
 use Zenstruck\Foundry\Tests\Fixture\Document\DocumentWithReadonly;
 use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\EntityWithReadonly\EntityWithReadonly;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EntityWithOnlyPrivateProperties;
 use Zenstruck\Foundry\Tests\Fixture\Model\Embeddable;
 use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
 use Zenstruck\Foundry\Tests\Fixture\TestKernel;
@@ -39,6 +41,7 @@ use Zenstruck\Foundry\Tests\Fixture\TestKernel;
 use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\Persistence\assert_not_persisted;
 use function Zenstruck\Foundry\Persistence\assert_persisted;
+use function Zenstruck\Foundry\Persistence\delete;
 use function Zenstruck\Foundry\Persistence\flush_after;
 use function Zenstruck\Foundry\Persistence\refresh;
 use function Zenstruck\Foundry\Persistence\refresh_all;
@@ -218,6 +221,26 @@ abstract class AutoRefreshTestCase extends WebTestCase
         if ($clearOM) {
             $this->objectManager()->clear();
         }
+
+        self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
+        self::assertSame($prop1, $object->getProp1());
+        assert_not_persisted($object);
+    }
+
+    #[Test]
+    public function deleting_an_object_declaring_only_private_properties_does_not_create_a_refresh_error(): void
+    {
+        self::createClient();
+
+        $object = static::factoryWithOnlyPrivateProperties()->create();
+        $prop1 = $object->getProp1();
+        assert_persisted($object);
+
+        delete($object);
+
+        $objectTracker = Configuration::instance()->persistedObjectsTracker;
+        self::assertNotNull($objectTracker);
+        $objectTracker->refresh();
 
         self::assertTrue((new \ReflectionClass($object))->isUninitializedLazyObject($object));
         self::assertSame($prop1, $object->getProp1());
@@ -496,6 +519,14 @@ abstract class AutoRefreshTestCase extends WebTestCase
      * @return PersistentObjectFactory<GenericModel>
      */
     abstract protected static function factory(): PersistentObjectFactory;
+
+    /**
+     * An object declaring all of its properties itself, privately: no inherited scope and no public
+     * property, so casting it to an array yields only mangled keys resolving to its own scope.
+     *
+     * @return PersistentObjectFactory<DocumentWithOnlyPrivateProperties|EntityWithOnlyPrivateProperties>
+     */
+    abstract protected static function factoryWithOnlyPrivateProperties(): PersistentObjectFactory;
 
     abstract protected function dbms(): string;
 

--- a/tests/Unit/Object/HydratorTest.php
+++ b/tests/Unit/Object/HydratorTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\ForceValue;
 use Zenstruck\Foundry\Object\Hydrator;
 use Zenstruck\Foundry\Tests\Fixture\Object1;
+use Zenstruck\Foundry\Tests\Fixture\SnapshotChild;
 
 /**
  * @author Maarten de Boer <info@maartendeboer.net>
@@ -221,5 +222,102 @@ class HydratorTest extends TestCase
         Hydrator::forceSet($object, 'foo', new ForceValue('foo'));
 
         $this->assertSame('foo', $object->getFoo());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_hydrate_from_snapshot_with_public_property_only(): void
+    {
+        $object = new class {
+            public string $foo = 'original';
+        };
+
+        $snapshot = (array) $object;
+        $object->foo = 'overwritten';
+
+        Hydrator::hydrateFromSnapshot($object, $snapshot);
+
+        $this->assertSame('original', $object->foo);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_hydrate_from_snapshot_with_own_private_property(): void
+    {
+        $object = new class {
+            private string $foo = 'original';
+
+            public function getFoo(): string
+            {
+                return $this->foo;
+            }
+
+            public function setFoo(string $foo): void
+            {
+                $this->foo = $foo;
+            }
+        };
+
+        $snapshot = (array) $object;
+        $object->setFoo('overwritten');
+
+        Hydrator::hydrateFromSnapshot($object, $snapshot);
+
+        $this->assertSame('original', $object->getFoo());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_hydrate_from_snapshot_with_own_protected_property(): void
+    {
+        $object = new class {
+            protected string $foo = 'original';
+
+            public function getFoo(): string
+            {
+                return $this->foo;
+            }
+
+            public function setFoo(string $foo): void
+            {
+                $this->foo = $foo;
+            }
+        };
+
+        $snapshot = (array) $object;
+        $object->setFoo('overwritten');
+
+        Hydrator::hydrateFromSnapshot($object, $snapshot);
+
+        $this->assertSame('original', $object->getFoo());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_hydrate_from_snapshot_with_inherited_properties(): void
+    {
+        $object = new SnapshotChild();
+
+        $snapshot = (array) $object;
+
+        Hydrator::forceSet($object, 'childPublic', 'overwritten');
+
+        Hydrator::hydrateFromSnapshot($object, $snapshot);
+
+        $this->assertSame('child-public', $object->childPublic);
+        $this->assertSame('child-private', $object->childPrivate());
+        $this->assertSame('parent-private', $object->parentPrivate());
+        $this->assertSame('parent-protected', $object->parentProtected());
+        // a private property shadowed by a child keeps one value per declaring scope
+        $this->assertSame('child-shadowed', $object->childShadowed());
+        $this->assertSame('parent-shadowed', $object->parentShadowed());
     }
 }


### PR DESCRIPTION
Fixes #1148.

`hydrateFromSnapshot()` feeds an `(array) $object` cast straight to `deepclone_hydrate()`, but when every mangled key (`"\0Class\0name"`, `"\0*\0name"`) resolves to the object's own scope, the hydrator took its un-grouped fast path and used the mangled name verbatim, failing with `Error: Cannot access property starting with "\0"`. In practice this hits any autorefreshed object that gets deleted: `autorefresh()` then takes the "object no longer exists" branch and restores the snapshot.

The root cause was in the polyfill, and is fixed upstream in symfony/polyfill#643 (released in v1.42.0), so this PR:

- requires `symfony/polyfill-deepclone: ^1.42` — the minimal version carrying the fix;
- always hydrates snapshots with `deepclone_hydrate()`: the polyfill guarantees the function exists, so the deprecated `VarExporter\Hydrator` fallback is dropped;
- keeps the tests: 2 of the 4 unit cases fail with the pre-1.42 polyfill (own private — on an anonymous class —, own protected), the other 2 guard the paths that already worked (public-only, inherited properties including a private shadowed across scopes), plus a functional autorefresh-after-delete test on ORM and Mongo.

The Behat CI also needed a change: it installed the released `zenstruck/foundry` from Packagist and symlinked the checkout's `src/` over it, so a new dependency of the main package was never installed. It now installs the checkout itself as a composer path repository, resolving foundry's dependencies transitively from the branch's `composer.json` (composer refuses to install a path package inside its own source tree, hence the copy of the checkout outside of it).

https://claude.ai/code/session_01YKn786eyMPtirge4Jejumm
