### PR TITLE
minor: re-enable BC check by stripping the Behat subpackage from compared revisions

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,13 +1,15 @@
 name: "Backward Compatibility Check"
 
+# disabled until a solution is fined to work with foundry-behat subpackage
 on:
-  pull_request:
-    paths: &paths
-      - .github/workflows/bc-check.yml
-      - bin/tools/bc-check/**
-      - src/**
-  push:
-    paths: *paths
+  workflow_dispatch:
+#  pull_request:
+#    paths: &paths
+#      - .github/workflows/bc-check.yml
+#      - bin/tools/bc-check/**
+#      - src/**
+#  push:
+#    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,15 +1,13 @@
 name: "Backward Compatibility Check"
 
-# disabled until a solution is fined to work with foundry-behat subpackage
 on:
-  workflow_dispatch:
-#  pull_request:
-#    paths: &paths
-#      - .github/workflows/bc-check.yml
-#      - bin/tools/bc-check/**
-#      - src/**
-#  push:
-#    paths: *paths
+  pull_request:
+    paths: &paths
+      - .github/workflows/bc-check.yml
+      - bin/tools/bc-check/**
+      - src/**
+  push:
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -23,6 +21,36 @@ jobs:
       - uses: "actions/checkout@v5"
         with:
           fetch-depth: 0
+
+      # roave/backward-compatibility-check crashes on the foundry-behat subpackage: it scans
+      # every file under the PSR-4 "src/" dir, ignores exclude-from-classmap
+      # (https://github.com/Roave/BackwardCompatibilityCheck/issues/983) and the subpackage
+      # layout ("src/Test/Behat/src/") is not resolvable through the main autoload mapping.
+      # Workaround: compare baseline and HEAD with that directory stripped on both sides,
+      # via synthetic commits built with git plumbing (the working tree is left untouched).
+      - name: Create Behat-stripped revisions for the BC check
+        run: |
+          export GIT_AUTHOR_NAME=github-actions GIT_AUTHOR_EMAIL=github-actions@github.com
+          export GIT_COMMITTER_NAME=github-actions GIT_COMMITTER_EMAIL=github-actions@github.com
+
+          strip_behat() {
+            git read-tree "$1"
+            git rm -rq --cached --ignore-unmatch src/Test/Behat
+            git commit-tree "$(git write-tree)" -p "$1" -m "Strip Behat subpackage for BC check"
+          }
+
+          FROM_REV=$(git describe --tags --abbrev=0)
+          FROM_SHA=$(strip_behat "$FROM_REV")
+          TO_SHA=$(strip_behat HEAD)
+          git read-tree HEAD
+
+          # branch refs so the stripped commits survive the tool's internal "git clone"
+          git update-ref refs/heads/bc-check-from "$FROM_SHA"
+          git update-ref refs/heads/bc-check-to "$TO_SHA"
+
+          echo "Comparing $FROM_REV ($FROM_SHA) -> HEAD ($TO_SHA)"
+          echo "FROM_SHA=$FROM_SHA" >> "$GITHUB_ENV"
+          echo "TO_SHA=$TO_SHA" >> "$GITHUB_ENV"
 
       - name: Install PHP with extensions.
         uses: shivammathur/setup-php@v2
@@ -38,4 +66,4 @@ jobs:
         run: composer bin bc-check require roave/backward-compatibility-check
 
       - name: Run roave/backward-compatibility-check.
-        run: bin/tools/bc-check/vendor/roave/backward-compatibility-check/bin/roave-backward-compatibility-check --install-development-dependencies --format=github-actions
+        run: bin/tools/bc-check/vendor/roave/backward-compatibility-check/bin/roave-backward-compatibility-check --from="$FROM_SHA" --to="$TO_SHA" --install-development-dependencies --format=github-actions


### PR DESCRIPTION
Since the `foundry-behat` subpackage was merged (#1084), the "Roave BC Check" job crashes before producing any report:

```
Roave\BetterReflection\Reflection\ReflectionClass
"Zenstruck\Foundry\Test\Behat\FoundryContextInterface" could not be found in the located source
```

### Why it crashes

`roave/backward-compatibility-check` scans **every** PHP file under the directories declared in PSR-4 autoload (`Zenstruck\Foundry\` → `src/`), and deliberately ignores `exclude-from-classmap` and `autoload-dev` (see Roave/BackwardCompatibilityCheck#983). It then finds the subpackage files under `src/Test/Behat/src/`, tries to resolve them through the main autoload mapping (which would expect e.g. `src/Test/Behat/FoundryContextInterface.php`), fails, and aborts. The tool's `<baseline>` config can't help: it filters *reported* breaks, not crashes.

Since the latest release already ships this layout, the crash happens on both the baseline and HEAD sides — so this can't be fixed by only changing HEAD.

### Workaround

Instead of disabling the check, a new workflow step builds two synthetic commits with git plumbing (`read-tree` + `rm --cached` + `commit-tree`, the working tree is left untouched): the latest tag and HEAD, each with `src/Test/Behat` stripped. The check then runs with explicit `--from`/`--to` pointing at those commits.

Trade-off: the BC check no longer covers the Behat subpackage's API — but it currently covers nothing at all, since it always crashes.

A cleaner long-term fix would be to move the subpackage out of `src/` (e.g. `packages/behat/`), so no non-PSR-4-conforming file lives under an autoloaded directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)