### PR TITLE
feat(behat): resolve id placeholders in PyString and table arguments

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3020,9 +3020,9 @@ application under test — like ``<foundry:lastId(type)>`` below. It comes in ha
 
 .. note::
 
-    ``<foundry:object(...)>`` and ``<foundry:lastObject(...)>`` only work inside table cells. Behat never
-    applies ``#[Transform]`` to the content of tables: the id placeholders described below are only
-    resolved in plain step arguments.
+    ``<foundry:object(...)>`` and ``<foundry:lastObject(...)>`` resolve to **objects**: they only work
+    inside the property tables of the built-in steps. The id placeholders described below resolve to
+    **scalar** values and also work in PyStrings and in the table cells of any step.
 
 .. note::
 
@@ -3126,8 +3126,9 @@ Accessing ids of created objects
     accessed until the next database reset occurs, and they are cleared after each feature.
     ``<foundry:lastId(factory)>`` only relies on the database content.
 
-To sum up — Behat resolves the id placeholders with ``#[Transform]``, which is applied to plain step
-arguments but never to table cells, hence the two families of placeholders:
+To sum up — the object placeholders resolve to objects, so they can only live in the property
+tables the built-in steps normalize, while the id placeholders resolve to scalar values with
+``#[Transform]``, applied to plain step arguments, PyStrings and tables alike:
 
 .. list-table::
     :header-rows: 1
@@ -3136,16 +3137,16 @@ arguments but never to table cells, hence the two families of placeholders:
       - Works in
       - Resolved from
     * - ``<foundry:object(type, name)>``
-      - Table cells only
+      - Property tables of the built-in steps
       - Object registry
     * - ``<foundry:lastObject(type)>``
-      - Table cells only
+      - Property tables of the built-in steps
       - Database (row with the highest id)
     * - ``<foundry:id(type, name)>``
-      - Plain step arguments only
+      - Any step argument (plain, PyString, table cell)
       - Object registry
     * - ``<foundry:lastId(type)>``
-      - Plain step arguments only
+      - Any step argument (plain, PyString, table cell)
       - Database (row with the highest id)
 
 Overriding built-in step definitions

--- a/src/Test/Behat/features/granular-contexts/granular-contexts.feature
+++ b/src/Test/Behat/features/granular-contexts/granular-contexts.feature
@@ -7,6 +7,17 @@ Feature: Using a subset of the built-in contexts
     When I am on "/orm/update/<foundry:id(generic entity, the object)>/bar"
     Then the response status code should be 200
 
+  Scenario: Id placeholders are resolved in PyStrings and tables with the placeholder context alone
+    Given there is a "generic entity" named "the object" with:
+      | prop1 |
+      | foo   |
+    Then each line of the following text should equal "<foundry:lastId(generic entity)>":
+      """
+      <foundry:id(generic entity, the object)>
+      """
+    And all cells of the following table should equal "<foundry:id(generic entity, the object)>":
+      | <foundry:lastId(generic entity)> |
+
   Scenario: The assertion wording is free for the user's own definition (!)
     Given there is a contact
     Then 1 "contact" should exist

--- a/src/Test/Behat/features/main/id-placeholders-in-multiline-args.feature
+++ b/src/Test/Behat/features/main/id-placeholders-in-multiline-args.feature
@@ -1,0 +1,39 @@
+Feature: Resolving id placeholders in PyString and table arguments
+
+  # The inline argument and the multiline one always carry DIFFERENT placeholders resolving
+  # to the same value (id() reads the object registry, lastId() queries the database): equal
+  # results prove both sides were actually resolved, not merely substituted the same way.
+  Scenario: Id placeholders are resolved in PyString arguments
+    Given there is a contact named A
+    Then each line of the following text should equal "<foundry:lastId(contact)>":
+      """
+      <foundry:id(contact, A)>
+      """
+    And each line of the following text should equal "id=<foundry:id(contact, A)>":
+      """
+      id=<foundry:lastId(contact)>
+      id=<foundry:lastId("contact")>
+      """
+
+  Scenario: Id placeholders are resolved in the table arguments of custom steps
+    Given there is a contact named A
+    Then all cells of the following table should equal "<foundry:lastId(contact)>":
+      | <foundry:id(contact, A)> | <foundry:id("contact", "A")> |
+    And all cells of the following table should equal "<foundry:id("contact", "A")>":
+      | <foundry:lastId(contact)> | <foundry:lastId("contact")> |
+
+  # The creation and assertion tables use different placeholders resolving to the same value:
+  # if resolution silently stopped on either side, the literals would no longer match.
+  Scenario: Id placeholders are resolved in the tables of the built-in steps
+    Given there is a contact named A with:
+      | name |
+      | John |
+    And there is a category named C with:
+      | name                         |
+      | cat-<foundry:id(contact, A)> |
+    Then the category named C should have properties:
+      | name                          |
+      | cat-<foundry:lastId(contact)> |
+    And a category should exist with:
+      | name                          |
+      | cat-<foundry:lastId(contact)> |

--- a/src/Test/Behat/src/PlaceholderTransforms.php
+++ b/src/Test/Behat/src/PlaceholderTransforms.php
@@ -11,11 +11,13 @@
 
 namespace Zenstruck\Foundry\Test\Behat;
 
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
 use Behat\Transformation\Transform;
 
 /**
  * Built-in transformations resolving <foundry:lastId(...)> and <foundry:id(...)>
- * placeholders in step arguments.
+ * placeholders in step arguments, including PyString and table arguments.
  *
  * The composing class only needs to implement FoundryContextInterface; the ObjectRegistry is
  * injected by the HasObjectRegistry trait (see FoundryPlaceholderContext).
@@ -37,5 +39,34 @@ trait PlaceholderTransforms
     public function transformIdForSpecificObject(string $before, string $factoryShortName, string $objectName, string $after): string
     {
         return $this->objectRegistry->resolveIdPlaceholders("{$before}<foundry:id({$factoryShortName}, {$objectName})>{$after}");
+    }
+
+    /**
+     * By-type transformation (no pattern): applied to every PyString argument of a step
+     * definition whose parameter is type-hinted PyStringNode.
+     */
+    #[Transform]
+    public function transformIdPlaceholdersInPyStrings(PyStringNode $pyString): PyStringNode
+    {
+        $strings = $pyString->getStrings();
+        $resolved = \array_map($this->objectRegistry->resolveIdPlaceholders(...), $strings);
+
+        return $resolved === $strings ? $pyString : new PyStringNode($resolved, $pyString->getLine());
+    }
+
+    /**
+     * By-type transformation (no pattern): applied to every table argument of a step
+     * definition whose parameter is type-hinted TableNode.
+     */
+    #[Transform]
+    public function transformIdPlaceholdersInTables(TableNode $table): TableNode
+    {
+        $rows = $table->getTable();
+        $resolved = \array_map(
+            fn(array $row) => \array_map($this->objectRegistry->resolveIdPlaceholders(...), $row),
+            $rows,
+        );
+
+        return $resolved === $rows ? $table : new TableNode($resolved);
     }
 }

--- a/src/Test/Behat/tests/Fixture/TestFoundryContext.php
+++ b/src/Test/Behat/tests/Fixture/TestFoundryContext.php
@@ -12,7 +12,11 @@
 namespace Zenstruck\Foundry\Test\Behat\Tests\Fixture;
 
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Then;
 use Yceruto\BehatExtension\Context\ExceptionAssertionTrait;
+use Zenstruck\Assert;
 
 /**
  * Provides the exception assertion steps alongside the built-in FoundryContext.
@@ -20,4 +24,34 @@ use Yceruto\BehatExtension\Context\ExceptionAssertionTrait;
 final class TestFoundryContext implements Context
 {
     use ExceptionAssertionTrait;
+
+    /**
+     * The inline argument is resolved by the pattern-based transformation, the PyString by the
+     * by-type one: comparing them proves multiline arguments get the same placeholder resolution.
+     * Both sides stay equal when NO transformation runs at all, so also assert the placeholders
+     * are really gone.
+     */
+    #[Then('/^each line of the following text should equal "(.*)":$/')]
+    public function assertEachPyStringLineEquals(PyStringNode $pyString, string $expected): void
+    {
+        Assert::that($pyString->getStrings())->isNot([], 'The PyString is empty.');
+
+        foreach ($pyString->getStrings() as $line) {
+            Assert::that($line)->doesNotContain('<foundry:');
+            Assert::that($line)->is($expected);
+        }
+    }
+
+    #[Then('/^all cells of the following table should equal "(.*)":$/')]
+    public function assertAllTableCellsEqual(TableNode $table, string $expected): void
+    {
+        foreach ($table->getRows() as $row) {
+            Assert::that($row)->isNot([], 'The table row is empty.');
+
+            foreach ($row as $cell) {
+                Assert::that($cell)->doesNotContain('<foundry:');
+                Assert::that($cell)->is($expected);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Now `<foundry:id()>` and `<foundryu:lastId()>` are also available through PyString and table cells
