### PR TITLE
fix(behat): pass null through by-type transforms for optional multiline arguments

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3108,6 +3108,24 @@ Accessing ids of created objects
 
 .. warning::
 
+    Inside a **quoted** step argument, write multi-word names **without** quotes: a quote inside the
+    placeholder would close the step pattern's own ``"([^"]*)"`` group prematurely, and the step would
+    no longer match. Quoted names remain valid in PyStrings and table cells, which are not captured
+    by a quoted pattern:
+
+    .. code-block:: gherkin
+
+        # inline arguments: no quotes around multi-word names
+        When I am on "/events/<foundry:id(event date, opening)>"
+
+        # PyStrings and table cells: quoted names are fine
+        Then the response should equal:
+          """
+          <foundry:id("event date", "opening")>
+          """
+
+.. warning::
+
     ``<foundry:lastId(...)>`` is resolved from the database: the row with the **highest id** is considered the
     last one. This works whoever created the row — a Foundry ``Given`` step, a fixture, or the
     application under test — but it assumes ids follow the creation order (auto-increment columns,

--- a/src/Test/Behat/features/main/id-placeholders-in-multiline-args.feature
+++ b/src/Test/Behat/features/main/id-placeholders-in-multiline-args.feature
@@ -22,6 +22,20 @@ Feature: Resolving id placeholders in PyString and table arguments
     And all cells of the following table should equal "<foundry:id("contact", "A")>":
       | <foundry:lastId(contact)> | <foundry:lastId("contact")> |
 
+  # A definition may declare its multiline argument optional (e.g. an HTTP step whose request
+  # body is not always given). By-type transformations match on the parameter's TYPE, so they
+  # also run when the step is called WITHOUT the multiline argument — they must pass null through.
+  Scenario: Optional multiline arguments may be omitted
+    Given there is a contact named A
+    Then the value "<foundry:id(contact, A)>" should not contain an unresolved placeholder
+    And no cell of the optional table should contain an unresolved placeholder for "<foundry:id(contact, A)>"
+    And the value "<foundry:id(contact, A)>" should not contain an unresolved placeholder:
+      """
+      <foundry:lastId(contact)>
+      """
+    And no cell of the optional table should contain an unresolved placeholder for "<foundry:id(contact, A)>":
+      | <foundry:lastId(contact)> |
+
   # The creation and assertion tables use different placeholders resolving to the same value:
   # if resolution silently stopped on either side, the literals would no longer match.
   Scenario: Id placeholders are resolved in the tables of the built-in steps

--- a/src/Test/Behat/src/PlaceholderTransforms.php
+++ b/src/Test/Behat/src/PlaceholderTransforms.php
@@ -42,12 +42,17 @@ trait PlaceholderTransforms
     }
 
     /**
-     * By-type transformation (no pattern): applied to every PyString argument of a step
-     * definition whose parameter is type-hinted PyStringNode.
+     * By-type transformation (no pattern): applied to every argument of a step definition
+     * whose parameter is type-hinted PyStringNode — matching is based on the parameter's
+     * TYPE, so it also runs with null when an optional multiline argument is omitted.
      */
     #[Transform]
-    public function transformIdPlaceholdersInPyStrings(PyStringNode $pyString): PyStringNode
+    public function transformIdPlaceholdersInPyStrings(?PyStringNode $pyString): ?PyStringNode
     {
+        if (null === $pyString) {
+            return null;
+        }
+
         $strings = $pyString->getStrings();
         $resolved = \array_map($this->objectRegistry->resolveIdPlaceholders(...), $strings);
 
@@ -55,12 +60,17 @@ trait PlaceholderTransforms
     }
 
     /**
-     * By-type transformation (no pattern): applied to every table argument of a step
-     * definition whose parameter is type-hinted TableNode.
+     * By-type transformation (no pattern): applied to every argument of a step definition
+     * whose parameter is type-hinted TableNode — matching is based on the parameter's
+     * TYPE, so it also runs with null when an optional multiline argument is omitted.
      */
     #[Transform]
-    public function transformIdPlaceholdersInTables(TableNode $table): TableNode
+    public function transformIdPlaceholdersInTables(?TableNode $table): ?TableNode
     {
+        if (null === $table) {
+            return null;
+        }
+
         $rows = $table->getTable();
         $resolved = \array_map(
             fn(array $row) => \array_map($this->objectRegistry->resolveIdPlaceholders(...), $row),

--- a/src/Test/Behat/tests/Fixture/TestFoundryContext.php
+++ b/src/Test/Behat/tests/Fixture/TestFoundryContext.php
@@ -54,4 +54,31 @@ final class TestFoundryContext implements Context
             }
         }
     }
+
+    /**
+     * Mirrors the common real-world shape of an HTTP step (`iSendARequestTo($url, PyStringNode $body = null)`):
+     * the multiline argument is optional. Behat matches by-type transformations on the parameter's TYPE,
+     * so they also run — with null — when the step is called without the multiline argument.
+     */
+    #[Then('/^the value "(.*)" should not contain an unresolved placeholder:?$/')]
+    public function assertValueAndOptionalPyStringResolved(string $value, ?PyStringNode $body = null): void
+    {
+        Assert::that($value)->doesNotContain('<foundry:');
+
+        foreach ($body?->getStrings() ?? [] as $line) {
+            Assert::that($line)->doesNotContain('<foundry:');
+        }
+    }
+
+    #[Then('/^no cell of the optional table should contain an unresolved placeholder for "(.*)":?$/')]
+    public function assertValueAndOptionalTableResolved(string $value, ?TableNode $table = null): void
+    {
+        Assert::that($value)->doesNotContain('<foundry:');
+
+        foreach ($table?->getRows() ?? [] as $row) {
+            foreach ($row as $cell) {
+                Assert::that($cell)->doesNotContain('<foundry:');
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes a fatal regression introduced in v2.11.3 by #1152.

## The bug

Behat matches by-type transformations (`#[Transform]` without pattern) on the **declared type of the step definition's parameter** — never on the actual argument value (`ReturnTypeTransformation::supportsDefinitionAndArgument()` receives the value but never consults it).

So a step declaring an *optional* multiline argument — the standard shape of any HTTP context:

```php
#[When('/^I send a "([^"]*)" request to "([^"]*)"$/')]
public function iSendARequestTo(string $method, string $url, PyStringNode $body = null): void
```

called *without* a body (`When I send a "GET" request to "/v1/carts/1"`) still triggers the transformation, with `null`:

```
Type error: FoundryContext::transformIdPlaceholdersInPyStrings(): Argument #1 ($pyString)
must be of type Behat\Gherkin\Node\PyStringNode, null given
```

The crash does not depend on placeholders being used: **any** suite registering `FoundryContext` with a step declaring an optional `PyStringNode`/`TableNode` parameter breaks when upgrading 2.11.2 → 2.11.3 — typically every GET/DELETE step of an API suite.

## The fix

Nullable parameters and return types + `null` passthrough in both transforms. By-type matching is unaffected: `ReturnTypeTransformation::getReturnClass()` reads the return type via `ReflectionNamedType`, and `?PyStringNode` still is one (only union types are discarded).

The reproducer was written first and confirmed red (exact `TypeError` above), then the fix turned it green. The fix has also been validated in real conditions: a ~600-feature Behat suite runs with the vendor hot-patched exactly like this.

Also adds a doc note (annex): inside a quoted inline step argument, multi-word placeholder names must be written **unquoted** (`<foundry:id(event date, x)>`) — a quote inside the placeholder closes the step pattern's own `"([^"]*)"` group. Quoted names remain valid in PyStrings and table cells.

## Checks

- Behat suite of the subpackage: 78 scenarios green (new scenario also green with `main-no-dama` profile)
- PHPUnit: 103 tests OK
- phpstan (subpackage config): no errors
- php-cs-fixer: clean

This should be released as **v2.11.4** — 2.11.3 is unusable for any project with an optional multiline step argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)