### PR TITLE
ci: test against Symfony 8.1 instead of EOL 8.0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.5 ]
-        symfony: [ 8.0.* ]
+        symfony: [ 8.1.* ]
         database: [ mysql|mongo ]
         with-dama: [ 0 ]
     env:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.4, 8.5 ]
-        symfony: [ 6.4.*, 7.4.*, 8.0.* ]
+        symfony: [ 6.4.*, 7.4.*, 8.1.* ]
         database: [ mysql|mongo ]
         phpunit: [ 13 ]
         use-phpunit-extension: [ 1 ]
@@ -279,7 +279,7 @@ jobs:
           dependency-versions: highest
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 8.0.*
+          SYMFONY_REQUIRE: 8.1.*
 
       - name: Set up MySQL
         run: sudo /etc/init.d/mysql start
@@ -338,7 +338,7 @@ jobs:
         with:
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 8.0.x
+          SYMFONY_REQUIRE: 8.1.x
 
       - name: Test with coverage
         run: ./phpunit --coverage-text --coverage-clover coverage.xml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 8.0.*
+          SYMFONY_REQUIRE: 8.1.*
 
       - name: Install PHPStan
         run: composer bin phpstan install


### PR DESCRIPTION
Every PHPUnit job pinned to `SYMFONY_REQUIRE: 8.0.*` has been failing deterministically since August 5th (e.g. [this run](https://github.com/zenstruck/foundry/actions/runs/31683840839) on #1155) — re-runs and re-pushes can't help. Root cause chain:

1. **doctrine/orm 3.6.8** (released Aug 5th, a few hours after the last green `2.x` run — the only dependency delta) added `GenerateSchemaEventArgs::setSchema()`, which throws a `BadMethodCallException` when doctrine/dbal < 4.5: the `Schema::edit()` API it relies on is not released yet.
2. symfony/doctrine-bridge's `postGenerateSchema` listeners (e.g. `DoctrineDbalCacheAdapterSchemaListener`) call `setSchema()` behind a mere `method_exists()` check — true since orm 3.6.8 — so Foundry's database reset (`doctrine:schema:update`) blows up, cascading into ~1500 test errors per job.
3. Upstream: doctrine/orm#12553, symfony/symfony#65235 — **fixed by symfony/symfony#65169, released in Symfony 7.4.16 and 8.1.4** (Aug 7th).
4. But **Symfony 8.0 is past its bug-fix support window**: v8.0.15 (Jul 29th) was its last patch, the fix will never land there. The 8.0.* jobs would stay red forever.

This bumps every Symfony 8.0 pin in CI to 8.1 (current stable, contains the fix, already covered by the `^8.0` constraint in composer.json):

- `phpunit.yml`: test matrix, paratest job, code-coverage job
- `benchmarks.yml`: matrix (also resets the database, would fail the same way)
- `static-analysis.yml`: phpstan's `SYMFONY_REQUIRE` (not broken, but keeps CI aligned on the same stable)

`behat.yml` pins 7.4.* and is unaffected.

Once merged, #1155 just needs a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)