### PR TITLE
docs: disambiguate factory "attributes" from native PHP attributes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -394,6 +394,13 @@ The attributes used to instantiate the object can be added several ways. Attribu
 that returns an array. Using a *callable* ensures random data as the callable is run for each object separately during
 instantiation.
 
+.. note::
+
+    Throughout Foundry, "attributes" refers to this array of property values used to
+    instantiate an object, a term borrowed from the classic database fixture vocabulary.
+    It is unrelated to native PHP attributes: those, like ``#[WithStory]`` or
+    ``#[AsFoundryHook]``, are always referenced with their ``#[...]`` syntax.
+
 ::
 
     use App\Entity\Category;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,6 +15,9 @@ use Faker;
 use Zenstruck\Foundry\Exception\CannotCreateFactory;
 
 /**
+ * Throughout Foundry, "attributes" refers to the property values used to instantiate
+ * an object (the classic fixture meaning), not to native PHP `#[...]` attributes.
+ *
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @immutable
@@ -35,6 +38,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values for the object(s) to create
+     *
      * @phpstan-param Attributes $attributes
      * @phpstan-return static
      */
@@ -57,6 +62,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values for the object(s) to create
+     *
      * @phpstan-param Attributes $attributes
      *
      * @return T
@@ -67,6 +74,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values for the object(s) to create
+     *
      * @phpstan-param Attributes $attributes
      *
      * @return list<T>
@@ -78,6 +87,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values for the object(s) to create
+     *
      * @phpstan-param Attributes $attributes
      *
      * @return list<T>
@@ -99,6 +110,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values for the object(s) to create
+     *
      * @phpstan-param Attributes $attributes
      *
      * @return T
@@ -147,6 +160,8 @@ abstract class Factory
     }
 
     /**
+     * @param array|callable $attributes Property values to merge with the factory's current attributes
+     *
      * @phpstan-param Attributes $attributes
      *
      * @phpstan-return static
@@ -283,6 +298,8 @@ abstract class Factory
     }
 
     /**
+     * Default property values for every object this factory creates.
+     *
      * @phpstan-return Attributes
      */
     abstract protected function defaults(): array|callable;

--- a/src/Persistence/functions.php
+++ b/src/Persistence/functions.php
@@ -49,7 +49,7 @@ function proxy_repository(string $class): ProxyRepositoryDecorator
  * @template T of object
  *
  * @param class-string<T>                                       $class
- * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes Property values for the object(s) to create
  *
  * @return PersistentObjectFactory<T>
  */
@@ -64,7 +64,7 @@ function persistent_factory(string $class, array|callable $attributes = []): Per
  * @template T of object
  *
  * @param class-string<T>                                       $class
- * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes Property values for the object(s) to create
  *
  * @return PersistentProxyObjectFactory<T>
  */
@@ -81,7 +81,7 @@ function proxy_factory(string $class, array|callable $attributes = []): Persiste
  * @template T of object
  *
  * @param class-string<T>                                       $class
- * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes Property values for the object(s) to create
  *
  * @return T
  */

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ function faker(): Faker\Generator
  * @template T of object
  *
  * @param class-string<T>                                       $class
- * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes Property values for the object(s) to create
  *
  * @return ObjectFactory<T>
  */
@@ -40,7 +40,7 @@ function factory(string $class, array|callable $attributes = []): ObjectFactory
  * @template T of object
  *
  * @param class-string<T>                                       $class
- * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes Property values for the object(s) to create
  *
  * @return T
  */


### PR DESCRIPTION
Fixes #1125

Foundry's "attributes" (the property-value arrays passed to `defaults()`, `createOne()`, ...) now collide with native PHP `#[...]` attributes in readers' minds. Both improvements suggested in the issue, with @garak's blessing:

- a terminology note at the top of the docs' "Attributes" section;
- the docblocks of the methods and functions taking `$attributes` now say what the array represents.

No API or behavior change.
