### PR TITLE
ci: fix the BC check when a branch modifies src/Test/Behat

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -30,12 +30,19 @@ jobs:
       # via synthetic commits built with git plumbing (the working tree is left untouched).
       - name: Create Behat-stripped revisions for the BC check
         run: |
+          # propagate errexit into $(...) so a failing strip aborts the step immediately,
+          # instead of surfacing as an obscure roave crash later
+          shopt -s inherit_errexit
+
           export GIT_AUTHOR_NAME=github-actions GIT_AUTHOR_EMAIL=github-actions@github.com
           export GIT_COMMITTER_NAME=github-actions GIT_COMMITTER_EMAIL=github-actions@github.com
 
           strip_behat() {
             git read-tree "$1"
-            git rm -rq --cached --ignore-unmatch src/Test/Behat
+            # -f: when the branch modifies a file under src/Test/Behat, the index (baseline
+            # version) differs from both HEAD and the working tree, and the up-to-date safety
+            # check would refuse the removal; with --cached the working tree is never touched
+            git rm -rqf --cached --ignore-unmatch src/Test/Behat
             git commit-tree "$(git write-tree)" -p "$1" -m "Strip Behat subpackage for BC check"
           }
 


### PR DESCRIPTION
The BC check crashes on any branch that modifies a file under `src/Test/Behat` (seen on #1149):

```
Roave\BetterReflection\Reflection\ReflectionClass "Zenstruck\Foundry\Test\Behat\AssertionSteps" could not be found in the located source
```

The Behat-strip step builds its baseline commit with the index set to the last tag while the working tree holds the branch's files. When those differ for a file under `src/Test/Behat`, `git rm --cached` hits git's up-to-date safety check and refuses the whole removal; the failure is swallowed by the command substitution, so the baseline commit silently keeps the Behat sources and roave crashes on them later.

`-f` only disables that safety check — combined with `--cached` the working tree is never touched — and `shopt -s inherit_errexit` makes any future strip failure abort the step immediately with the readable git error instead.

Verified on a scratch clone of #1149's branch: without `-f` the removal is refused, with `-f` both synthetic commits contain zero `src/Test/Behat` files and the baseline matches the tag everywhere else.

https://claude.ai/code/session_01YKn786eyMPtirge4Jejumm
