### PR TITLE
feat: add Factory::memoize() and FactoryCollection::memoize()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1146,7 +1146,7 @@ better and avoids a common mistake::
     2.13: it memoizes the *factory*, so each use of the value creates a new object, which is rarely
     what is wanted::
 
-        // deprecated: creates two different users
+        // deprecated, and an error in Foundry 3: creates two different users
         $owner = memoize(fn() => UserFactory::new());
 
         // creates a single user, shared by every use of the value

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1121,6 +1121,37 @@ the LazyValue can be `memoized <https://en.wikipedia.org/wiki/Memoization>`_ so 
     the ``lazy()`` and ``memoize()`` helper functions can also be used to create LazyValues,
     instead of ``LazyValue::new()`` and ``LazyValue::memoize()``.
 
+When the value comes from a factory, ``memoize()`` can be called on the factory itself, which reads
+better and avoids a common mistake::
+
+        protected function defaults(): array
+        {
+            $owner = UserFactory::new()->memoize();
+            // or, for several objects:
+            $reviewers = UserFactory::new()->many(2)->memoize();
+
+            return [
+                'project' => ProjectFactory::new(['users' => [$owner]]),
+                'owner'   => $owner,
+            ];
+        }
+
+.. versionadded::  2.13
+
+    ``Factory::memoize()`` and ``FactoryCollection::memoize()`` were added in Foundry 2.13.
+
+.. warning::
+
+    Passing a factory to ``memoize()`` instead of the object it creates is deprecated since Foundry
+    2.13: it memoizes the *factory*, so each use of the value creates a new object, which is rarely
+    what is wanted::
+
+        // deprecated: creates two different users
+        $owner = memoize(fn() => UserFactory::new());
+
+        // creates a single user, shared by every use of the value
+        $owner = UserFactory::new()->memoize();
+
 Factories as Services
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -110,7 +110,7 @@ abstract class Factory
      */
     final public function memoize(): LazyValue
     {
-        return LazyValue::memoizeFromFactory(fn(): static => $this);
+        return LazyValue::memoizeFromFactory($this);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -106,6 +106,14 @@ abstract class Factory
     abstract public function create(array|callable $attributes = []): mixed;
 
     /**
+     * Creates the object once, and returns the same one every time the value is used.
+     */
+    final public function memoize(): LazyValue
+    {
+        return LazyValue::memoizeFromFactory(fn(): static => $this);
+    }
+
+    /**
      * @return FactoryCollection<T, static>
      */
     final public function many(int $count): FactoryCollection

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -143,7 +143,7 @@ final class FactoryCollection implements \IteratorAggregate
      */
     public function memoize(): LazyValue
     {
-        return LazyValue::memoizeFromFactory(fn(): self => $this);
+        return LazyValue::memoizeFromFactory($this);
     }
 
     /**

--- a/src/FactoryCollection.php
+++ b/src/FactoryCollection.php
@@ -139,6 +139,14 @@ final class FactoryCollection implements \IteratorAggregate
     }
 
     /**
+     * Creates the objects once, and returns the same ones every time the value is used.
+     */
+    public function memoize(): LazyValue
+    {
+        return LazyValue::memoizeFromFactory(fn(): self => $this);
+    }
+
+    /**
      * @phpstan-param Attributes $attributes
      *
      * @return list<T>

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -23,7 +23,7 @@ final class LazyValue
     /**
      * @param callable():mixed $factory
      */
-    private function __construct(callable $factory, private bool $memoize = false)
+    private function __construct(callable $factory, private bool $memoize = false, private bool $fromFactory = false)
     {
         $this->factory = $factory(...);
     }
@@ -41,6 +41,14 @@ final class LazyValue
 
         if ($value instanceof self) {
             $value = ($value)();
+        }
+
+        if ($this->fromFactory) {
+            // the factory is created here so that the object it produces is what gets memoized:
+            // memoizing the factory itself would create a new object on each use of the value
+            $value = $value->create();
+        } elseif ($this->memoize && ($value instanceof Factory || $value instanceof FactoryCollection)) {
+            trigger_deprecation('zenstruck/foundry', '2.13', 'Passing a factory to memoize() is deprecated: it memoizes the factory and not the object it creates, so a new object is created on each use. Use Factory::memoize() instead, or create the object in the callback.');
         }
 
         if (\is_array($value)) {
@@ -67,7 +75,17 @@ final class LazyValue
      */
     public static function memoize(callable $factory): self
     {
-        return new self($factory, true);
+        return new self($factory, memoize: true);
+    }
+
+    /**
+     * @internal
+     *
+     * @param callable():(Factory<mixed>|FactoryCollection<mixed, Factory<mixed>>) $factory
+     */
+    public static function memoizeFromFactory(callable $factory): self
+    {
+        return new self($factory, memoize: true, fromFactory: true);
     }
 
     /**

--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -43,12 +43,11 @@ final class LazyValue
             $value = ($value)();
         }
 
-        if ($this->fromFactory) {
-            // the factory is created here so that the object it produces is what gets memoized:
-            // memoizing the factory itself would create a new object on each use of the value
-            $value = $value->create();
-        } elseif ($this->memoize && ($value instanceof Factory || $value instanceof FactoryCollection)) {
-            trigger_deprecation('zenstruck/foundry', '2.13', 'Passing a factory to memoize() is deprecated: it memoizes the factory and not the object it creates, so a new object is created on each use. Use Factory::memoize() instead, or create the object in the callback.');
+        // memoizeFromFactory() creates the object in its own callback, so what is memoized here is
+        // the object; a user callback returning a factory memoizes the factory instead, which
+        // creates a new object on each use of the value
+        if (!$this->fromFactory && $this->memoize && ($value instanceof Factory || $value instanceof FactoryCollection)) {
+            trigger_deprecation('zenstruck/foundry', '2.13', 'Passing a factory to memoize() is deprecated and will throw an error in Foundry 3: it memoizes the factory and not the object it creates, so a new object is created on each use. Use Factory::new()->memoize() instead, or create the object in the callback.');
         }
 
         if (\is_array($value)) {
@@ -81,11 +80,11 @@ final class LazyValue
     /**
      * @internal
      *
-     * @param callable():(Factory<mixed>|FactoryCollection<mixed, Factory<mixed>>) $factory
+     * @param Factory<mixed>|FactoryCollection<mixed, Factory<mixed>> $factory
      */
-    public static function memoizeFromFactory(callable $factory): self
+    public static function memoizeFromFactory(Factory|FactoryCollection $factory): self
     {
-        return new self($factory, memoize: true, fromFactory: true);
+        return new self(static fn() => $factory->create(), memoize: true, fromFactory: true);
     }
 
     /**

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\LazyValue;
@@ -115,9 +116,11 @@ final class LazyValueTest extends TestCase
      * @test
      *
      * @group legacy
+     * @requires PHPUnit >=11.0.0
      */
     #[Test]
     #[IgnoreDeprecations]
+    #[RequiresPhpunit('>=11.0.0')]
     public function memoizing_a_factory_creates_a_new_object_on_each_use_and_is_deprecated(): void
     {
         $this->expectUserDeprecationMessageMatches('/Passing a factory to memoize\(\) is deprecated/');

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -11,9 +11,13 @@
 
 namespace Zenstruck\Foundry\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\LazyValue;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Tests\Fixture\Factories\SimpleObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\SimpleObject;
 
 use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\memoize;
@@ -23,6 +27,8 @@ use function Zenstruck\Foundry\memoize;
  */
 final class LazyValueTest extends TestCase
 {
+    use Factories;
+
     /**
      * @test
      */
@@ -74,5 +80,50 @@ final class LazyValueTest extends TestCase
         ]);
 
         $this->assertSame([5, 'foo', 6, 'foo' => ['bar' => 7, 'baz' => 'foo'], [8, 'foo']], $value());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function factory_memoize_returns_the_same_object(): void
+    {
+        $value = SimpleObjectFactory::new()->memoize();
+
+        $object = $value();
+
+        $this->assertInstanceOf(SimpleObject::class, $object);
+        $this->assertSame($object, $value());
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function factory_collection_memoize_returns_the_same_objects(): void
+    {
+        $value = SimpleObjectFactory::new()->many(2)->memoize();
+
+        $objects = $value();
+
+        $this->assertCount(2, $objects);
+        $this->assertContainsOnlyInstancesOf(SimpleObject::class, $objects);
+        $this->assertSame($objects, $value());
+    }
+
+    /**
+     * @test
+     *
+     * @group legacy
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function memoizing_a_factory_creates_a_new_object_on_each_use_and_is_deprecated(): void
+    {
+        $this->expectUserDeprecationMessageMatches('/Passing a factory to memoize\(\) is deprecated/');
+
+        $value = memoize(static fn() => SimpleObjectFactory::new());
+
+        $this->assertSame($value(), $value());
     }
 }


### PR DESCRIPTION
Fixes #1139.

`memoize()` takes a callback, so sharing an object between attributes means remembering to create it inside that callback. Passing the factory instead is the natural thing to write, and it silently does the wrong thing: the LazyValue memoizes the factory, and `normalizeParameter()` calls `create()` on it at every use, so each attribute ends up with its own object.

`Factory::memoize()` and `FactoryCollection::memoize()` remove both the callback and the trap, and the old spelling is deprecated rather than left to surprise people.

Built on the `LazyValue::memoizeFromFactory()` named constructor you suggested. It reads well to me so I did not go looking for another design, but I have no attachment to it.
