### PR TITLE
Document valid string values for orm.reset.mode

### DIFF
--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -154,7 +154,10 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
                                         ->ifString()
                                         ->then(static fn(string $mode): ?ResetDatabaseMode => ResetDatabaseMode::tryFrom($mode))
                                     ->end()
-                                    ->values(ResetDatabaseMode::cases())
+                                    ->values([
+                                        ...ResetDatabaseMode::cases(),
+                                        ...array_column(ResetDatabaseMode::cases(), 'value'),
+                                    ])
                                 ->end()
                                 ->arrayNode('migrations')
                                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
Fixes #1162

The configuration key `orm.reset.mode` accepts a case of the `ResetDatabaseMode`, but also one of its backing string values. The value is normalized here:

https://github.com/zenstruck/foundry/blob/65b9f6029a7d82bdcc59aeeb784c6630356d5591/src/ZenstruckFoundryBundle.php#L155

However, we currently tell the Config component that only the actual enum cases are valid which causes tooling like PHPStan or the new `symfony lsp:check` command to flag the backing string values as invalid.

This PR fixes this issue by merging the enum cases and their backing values into a single array of valid values.