### PR TITLE
feat: honor factory state when a create helper is called on an instance

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -11,5 +11,7 @@
         <ignored-regex>#\[BC\] CHANGED: Method getIdentifierValues\(\) of class Zenstruck\\Foundry\\Persistence\\PersistenceStrategy became final#</ignored-regex>
         <ignored-regex>#"Zenstruck\\Foundry\\Test\\(CommonResetDatabase|CommonFactories)" could not be found in the located source(.*)#</ignored-regex>
         <ignored-regex>#Method Zenstruck\\Foundry\\ORM\\AbstractORMPersistenceStrategy\#withoutDoctrineEvents\(\) was removed#</ignored-regex>
+        <ignored-regex>#Method Zenstruck\\Foundry\\Factory::create(One|Many|Range|Sequence)\(\) was removed#</ignored-regex>
+        <ignored-regex>#Method Zenstruck\\Foundry\\Persistence\\PersistentProxyObjectFactory::createOne\(\) was removed#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,10 +27,20 @@ use Zenstruck\Foundry\Exception\CannotCreateFactory;
  * @phpstan-type Attributes = Parameters|callable(int):Parameters
  * @phpstan-type Sequence = iterable<Parameters>|callable(): iterable<Parameters>
  *
- * @method static T createOne(Attributes $attributes = [])
- * @method static ($number is positive-int ? non-empty-list<T> : list<T>) createMany(int $number, Attributes $attributes = [])
- * @method static ($min is positive-int ? non-empty-list<T> : list<T>) createRange(int $min, int $max, Attributes $attributes = [])
- * @method static list<T> createSequence(Sequence $sequence)
+ * The create helpers are routed through __callStatic(), so they are declared here. Psalm reads
+ * the "@method" tags but does not expand the aliases above inside them, it reads them as class
+ * names, hence the plain signatures; PHPStan reads the "@phpstan-method" ones. The return types
+ * Psalm uses come from FixCreateHelpersReturnType, not from the tags.
+ *
+ * @method static T createOne(array|callable $attributes = [])
+ * @method static list<T> createMany(int $number, array|callable $attributes = [])
+ * @method static list<T> createRange(int $min, int $max, array|callable $attributes = [])
+ * @method static list<T> createSequence(iterable|callable $sequence)
+ *
+ * @phpstan-method static T createOne(Attributes $attributes = [])
+ * @phpstan-method static ($number is positive-int ? non-empty-list<T> : list<T>) createMany(int $number, Attributes $attributes = [])
+ * @phpstan-method static ($min is positive-int ? non-empty-list<T> : list<T>) createRange(int $min, int $max, Attributes $attributes = [])
+ * @phpstan-method static list<T> createSequence(Sequence $sequence)
  */
 abstract class Factory
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -26,9 +26,16 @@ use Zenstruck\Foundry\Exception\CannotCreateFactory;
  * @phpstan-type Parameters = array<string,mixed>
  * @phpstan-type Attributes = Parameters|callable(int):Parameters
  * @phpstan-type Sequence = iterable<Parameters>|callable(): iterable<Parameters>
+ *
+ * @method static T createOne(Attributes $attributes = [])
+ * @method static ($number is positive-int ? non-empty-list<T> : list<T>) createMany(int $number, Attributes $attributes = [])
+ * @method static ($min is positive-int ? non-empty-list<T> : list<T>) createRange(int $min, int $max, Attributes $attributes = [])
+ * @method static list<T> createSequence(Sequence $sequence)
  */
 abstract class Factory
 {
+    private const CREATE_HELPERS = ['createOne', 'createMany', 'createRange', 'createSequence'];
+
     /** @phpstan-var Attributes[] */
     private array $attributes = [];
 
@@ -68,7 +75,7 @@ abstract class Factory
      *
      * @return T
      */
-    public static function createOne(array|callable $attributes = []): mixed
+    protected static function doCreateOne(array|callable $attributes = []): mixed
     {
         return static::new()->create($attributes);
     }
@@ -81,7 +88,7 @@ abstract class Factory
      * @return list<T>
      * @phpstan-return ($number is positive-int ? non-empty-list<T> : list<T>)
      */
-    final public static function createMany(int $number, array|callable $attributes = []): array
+    final protected static function doCreateMany(int $number, array|callable $attributes = []): array
     {
         return static::new()->many($number)->create($attributes);
     }
@@ -94,7 +101,7 @@ abstract class Factory
      * @return list<T>
      * @phpstan-return ($min is positive-int ? non-empty-list<T> : list<T>)
      */
-    final public static function createRange(int $min, int $max, array|callable $attributes = []): array
+    final protected static function doCreateRange(int $min, int $max, array|callable $attributes = []): array
     {
         return static::new()->range($min, $max)->create($attributes);
     }
@@ -104,9 +111,56 @@ abstract class Factory
      *
      * @return list<T>
      */
-    final public static function createSequence(iterable|callable $sequence): array
+    final protected static function doCreateSequence(iterable|callable $sequence): array
     {
         return static::new()->sequence($sequence)->create();
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     */
+    final public static function __callStatic(string $name, array $arguments): mixed
+    {
+        if (!\in_array($name, self::CREATE_HELPERS, true)) {
+            throw new \BadMethodCallException(\sprintf('Call to undefined method %s::%s().', static::class, $name));
+        }
+
+        return static::{'do'.\ucfirst($name)}(...$arguments);
+    }
+
+    /**
+     * The create helpers are static, so calling one on an instance used to silently discard
+     * everything set on that instance: `Factory::new()->someState()->createMany(2)` created
+     * two objects without the state. Routing them through __callStatic makes the instance
+     * call land here instead, where the state can be honored.
+     *
+     * @param array<mixed> $arguments
+     */
+    final public function __call(string $name, array $arguments): mixed
+    {
+        if (!\in_array($name, self::CREATE_HELPERS, true)) {
+            throw new \BadMethodCallException(\sprintf('Call to undefined method %s::%s().', static::class, $name));
+        }
+
+        trigger_deprecation('zenstruck/foundry', '2.13', 'Calling "%s()" on a factory instance is deprecated and will throw in Foundry 3. Use "%s" instead.', $name, self::instanceEquivalent($name));
+
+        return match ($name) {
+            'createOne' => $this->create(...$arguments),
+            'createMany' => $this->many($arguments[0])->create($arguments[1] ?? []),
+            'createRange' => $this->range($arguments[0], $arguments[1])->create($arguments[2] ?? []),
+            'createSequence' => $this->sequence($arguments[0])->create(),
+        };
+    }
+
+    private static function instanceEquivalent(string $name): string
+    {
+        return match ($name) {
+            'createOne' => 'create()',
+            'createMany' => 'many()->create()',
+            'createRange' => 'range()->create()',
+            'createSequence' => 'sequence()->create()',
+            default => throw new \LogicException(\sprintf('Unhandled create helper "%s".', $name)),
+        };
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,15 +27,20 @@ use Zenstruck\Foundry\Exception\CannotCreateFactory;
  * @phpstan-type Attributes = Parameters|callable(int):Parameters
  * @phpstan-type Sequence = iterable<Parameters>|callable(): iterable<Parameters>
  *
- * The create helpers are routed through __callStatic(), so they are declared here. Psalm reads
- * the "@method" tags but does not expand the aliases above inside them, it reads them as class
- * names, hence the plain signatures; PHPStan reads the "@phpstan-method" ones. The return types
- * Psalm uses come from FixCreateHelpersReturnType, not from the tags.
+ * The create helpers go through __callStatic(). One block per reader: PHPStorm and PHPStan get
+ * the real signatures, Psalm gets plain ones because it reads the aliases above as class names
+ * inside a "@method" tag, and inlining them makes it drop the tags entirely. Its return types
+ * come from FixCreateHelpersReturnType anyway.
  *
- * @method static T createOne(array|callable $attributes = [])
- * @method static list<T> createMany(int $number, array|callable $attributes = [])
- * @method static list<T> createRange(int $min, int $max, array|callable $attributes = [])
- * @method static list<T> createSequence(iterable|callable $sequence)
+ * @psalm-method static T createOne(array|callable $attributes = [])
+ * @psalm-method static list<T> createMany(int $number, array|callable $attributes = [])
+ * @psalm-method static list<T> createRange(int $min, int $max, array|callable $attributes = [])
+ * @psalm-method static list<T> createSequence(iterable|callable $sequence)
+ *
+ * @method static T createOne(Attributes $attributes = [])
+ * @method static ($number is positive-int ? non-empty-list<T> : list<T>) createMany(int $number, Attributes $attributes = [])
+ * @method static ($min is positive-int ? non-empty-list<T> : list<T>) createRange(int $min, int $max, Attributes $attributes = [])
+ * @method static list<T> createSequence(Sequence $sequence)
  *
  * @phpstan-method static T createOne(Attributes $attributes = [])
  * @phpstan-method static ($number is positive-int ? non-empty-list<T> : list<T>) createMany(int $number, Attributes $attributes = [])
@@ -85,7 +90,7 @@ abstract class Factory
      *
      * @return T
      */
-    protected static function doCreateOne(array|callable $attributes = []): mixed
+    private static function doCreateOne(array|callable $attributes = []): mixed
     {
         return static::new()->create($attributes);
     }
@@ -98,7 +103,7 @@ abstract class Factory
      * @return list<T>
      * @phpstan-return ($number is positive-int ? non-empty-list<T> : list<T>)
      */
-    final protected static function doCreateMany(int $number, array|callable $attributes = []): array
+    private static function doCreateMany(int $number, array|callable $attributes = []): array
     {
         return static::new()->many($number)->create($attributes);
     }
@@ -111,7 +116,7 @@ abstract class Factory
      * @return list<T>
      * @phpstan-return ($min is positive-int ? non-empty-list<T> : list<T>)
      */
-    final protected static function doCreateRange(int $min, int $max, array|callable $attributes = []): array
+    private static function doCreateRange(int $min, int $max, array|callable $attributes = []): array
     {
         return static::new()->range($min, $max)->create($attributes);
     }
@@ -121,7 +126,7 @@ abstract class Factory
      *
      * @return list<T>
      */
-    final protected static function doCreateSequence(iterable|callable $sequence): array
+    private static function doCreateSequence(iterable|callable $sequence): array
     {
         return static::new()->sequence($sequence)->create();
     }

--- a/src/Persistence/PersistentProxyObjectFactory.php
+++ b/src/Persistence/PersistentProxyObjectFactory.php
@@ -51,9 +51,9 @@ abstract class PersistentProxyObjectFactory extends PersistentObjectFactory
      * @return T|Proxy<T>
      * @phpstan-return T&Proxy<T>
      */
-    final public static function createOne(array|callable $attributes = []): mixed
+    final protected static function doCreateOne(array|callable $attributes = []): mixed
     {
-        return proxy(parent::createOne($attributes)); // @phpstan-ignore function.unresolvableReturnType
+        return proxy(parent::doCreateOne($attributes)); // @phpstan-ignore function.unresolvableReturnType
     }
 
     /**

--- a/src/Persistence/PersistentProxyObjectFactory.php
+++ b/src/Persistence/PersistentProxyObjectFactory.php
@@ -51,15 +51,6 @@ abstract class PersistentProxyObjectFactory extends PersistentObjectFactory
      * @return T|Proxy<T>
      * @phpstan-return T&Proxy<T>
      */
-    final protected static function doCreateOne(array|callable $attributes = []): mixed
-    {
-        return proxy(parent::doCreateOne($attributes)); // @phpstan-ignore function.unresolvableReturnType
-    }
-
-    /**
-     * @return T|Proxy<T>
-     * @phpstan-return T&Proxy<T>
-     */
     final public static function find(mixed $criteriaOrId): object
     {
         return proxy(parent::find($criteriaOrId)); // @phpstan-ignore function.unresolvableReturnType

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -196,7 +196,7 @@ abstract class GenericFactoryTestCase extends KernelTestCase
     #[Test]
     public function create_many(): void
     {
-        $models = static::factory()->createMany(3, static fn(int $i) => ['prop1' => "value{$i}"]);
+        $models = static::factory()->many(3)->create(static fn(int $i) => ['prop1' => "value{$i}"]);
 
         static::factory()::repository()->assert()->count(3);
 

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -12,6 +12,8 @@
 namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Foundry\Factory;
@@ -524,5 +526,68 @@ final class ObjectFactoryTest extends TestCase
     public function as_data_provider(): void
     {
         $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    #[Test]
+    #[IgnoreDeprecations]
+    public function create_helpers_called_on_an_instance_keep_the_state(): void
+    {
+        $factory = SimpleObjectFactory::new()->with(['prop1' => 'from-state']);
+
+        self::assertSame('from-state', $factory->createOne()->prop1);
+        self::assertSame(['from-state', 'from-state'], \array_column($factory->createMany(2), 'prop1'));
+        self::assertSame(['from-state', 'from-state'], \array_column($factory->createRange(2, 2), 'prop1'));
+        self::assertSame(['from-state'], \array_column($factory->createSequence([[]]), 'prop1'));
+    }
+
+    /**
+     * @test
+     * @group legacy
+     */
+    #[Test]
+    #[RequiresPhpunit('>=11.0.0')]
+    public function create_helpers_called_on_an_instance_are_deprecated(): void
+    {
+        $this->expectUserDeprecationMessageMatches('/Calling "createMany\(\)" on a factory instance is deprecated and will throw in Foundry 3\. Use "many\(\)->create\(\)" instead\./');
+
+        SimpleObjectFactory::new()->createMany(1);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function create_helpers_still_ignore_nothing_when_called_statically(): void
+    {
+        self::assertCount(2, SimpleObjectFactory::createMany(2, ['prop1' => 'static']));
+        self::assertSame('static', SimpleObjectFactory::createOne(['prop1' => 'static'])->prop1);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function calling_an_undefined_method_statically_throws(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(\sprintf('Call to undefined method %s::doesNotExist().', SimpleObjectFactory::class));
+
+        SimpleObjectFactory::doesNotExist(); // @phpstan-ignore staticMethod.notFound
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function calling_an_undefined_method_on_an_instance_throws(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(\sprintf('Call to undefined method %s::doesNotExist().', SimpleObjectFactory::class));
+
+        SimpleObjectFactory::new()->doesNotExist(); // @phpstan-ignore method.notFound
     }
 }

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -530,10 +530,13 @@ final class ObjectFactoryTest extends TestCase
 
     /**
      * @test
+     *
      * @group legacy
+     * @requires PHPUnit >=11.0.0
      */
     #[Test]
     #[IgnoreDeprecations]
+    #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_keep_the_state(): void
     {
         $factory = SimpleObjectFactory::new()->with(['prop1' => 'from-state']);
@@ -546,7 +549,9 @@ final class ObjectFactoryTest extends TestCase
 
     /**
      * @test
+     *
      * @group legacy
+     * @requires PHPUnit >=11.0.0
      */
     #[Test]
     #[IgnoreDeprecations]

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -535,7 +535,7 @@ final class ObjectFactoryTest extends TestCase
      * @requires PHPUnit >=11.0.0
      */
     #[Test]
-    #[IgnoreDeprecations('on a factory instance is deprecated')]
+    #[IgnoreDeprecations]
     #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_keep_the_state(): void
     {
@@ -554,7 +554,7 @@ final class ObjectFactoryTest extends TestCase
      * @requires PHPUnit >=11.0.0
      */
     #[Test]
-    #[IgnoreDeprecations('on a factory instance is deprecated')]
+    #[IgnoreDeprecations]
     #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_are_deprecated(): void
     {

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -549,6 +549,7 @@ final class ObjectFactoryTest extends TestCase
      * @group legacy
      */
     #[Test]
+    #[IgnoreDeprecations]
     #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_are_deprecated(): void
     {

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -535,7 +535,7 @@ final class ObjectFactoryTest extends TestCase
      * @requires PHPUnit >=11.0.0
      */
     #[Test]
-    #[IgnoreDeprecations]
+    #[IgnoreDeprecations('on a factory instance is deprecated')]
     #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_keep_the_state(): void
     {
@@ -554,7 +554,7 @@ final class ObjectFactoryTest extends TestCase
      * @requires PHPUnit >=11.0.0
      */
     #[Test]
-    #[IgnoreDeprecations]
+    #[IgnoreDeprecations('on a factory instance is deprecated')]
     #[RequiresPhpunit('>=11.0.0')]
     public function create_helpers_called_on_an_instance_are_deprecated(): void
     {

--- a/utils/psalm/FixCreateHelpersReturnType.php
+++ b/utils/psalm/FixCreateHelpersReturnType.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Psalm;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\StatementsSource;
+use Psalm\Type;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TLiteralInt;
+use Zenstruck\Foundry\Factory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+/**
+ * The create helpers are declared with "@method static" tags on Factory, and Psalm does not
+ * bind the class template when it resolves a pseudo method: it expands the return type with
+ * the declaring class as "self", so "T" stays "T:Zenstruck\Foundry\Factory as mixed".
+ *
+ * The return type is therefore rebuilt here, once the call has been analyzed. This also
+ * covers the proxy factories, which FixProxyFactoryMethodsReturnType cannot reach: it hooks
+ * AfterMethodCallAnalysisInterface, and that never fires for a magic static call.
+ */
+final class FixCreateHelpersReturnType implements AfterExpressionAnalysisInterface
+{
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof StaticCall
+            || !$expr->name instanceof Identifier
+            || !$expr->class instanceof Name
+        ) {
+            return null;
+        }
+
+        $method = \strtolower($expr->name->name);
+
+        if (!\in_array($method, ['createone', 'createmany', 'createrange', 'createsequence'], true)) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+        $class = ClassLikeAnalyzer::getFQCLNFromNameObject($expr->class, $source->getAliases());
+        $codebase = $event->getCodebase();
+
+        if (!$codebase->classExtends($class, Factory::class)) {
+            return null;
+        }
+
+        $storage = $codebase->classlikes->getStorageFor($class);
+
+        if (!$storage) {
+            return null;
+        }
+
+        $isProxy = $codebase->classExtends($class, PersistentProxyObjectFactory::class);
+        $templateType = $storage->template_extended_params[$isProxy ? PersistentProxyObjectFactory::class : Factory::class]['T'] ?? null;
+
+        if (!$templateType) {
+            return null;
+        }
+
+        $type = $templateType->getId();
+
+        if ($isProxy) {
+            $proxyClass = Proxy::class;
+            $type = "{$type}&{$proxyClass}<{$type}>";
+        }
+
+        $source->getNodeTypeProvider()->setType(
+            $expr,
+            Type::parseString(self::returnType($method, $type, $expr, $source, $isProxy)),
+        );
+
+        return null;
+    }
+
+    /**
+     * The list helpers are declared with a conditional return type, which Psalm does not
+     * evaluate for a pseudo method either, so the argument is read here. Proxy factories
+     * never had the conditional type, FixProxyFactoryMethodsReturnType always widened them
+     * to a plain list, and that is kept.
+     */
+    private static function returnType(
+        string $method,
+        string $type,
+        StaticCall $expr,
+        StatementsSource $source,
+        bool $isProxy,
+    ): string {
+        if ('createone' === $method) {
+            return $type;
+        }
+
+        if ('createsequence' === $method || $isProxy) {
+            return "list<{$type}>";
+        }
+
+        // createMany() is driven by its first argument, createRange() by its lowest bound
+        $argument = $expr->getArgs()[0]->value ?? null;
+
+        return $argument && self::isPositiveInt($argument, $source)
+            ? "non-empty-list<{$type}>"
+            : "list<{$type}>";
+    }
+
+    private static function isPositiveInt(Expr $expr, StatementsSource $source): bool
+    {
+        $type = $source->getNodeTypeProvider()->getType($expr);
+
+        if (!$type || !$type->isSingle()) {
+            return false;
+        }
+
+        $atomic = $type->getSingleAtomic();
+
+        if ($atomic instanceof TLiteralInt) {
+            return $atomic->value > 0;
+        }
+
+        return $atomic instanceof TIntRange && null !== $atomic->min_bound && $atomic->min_bound > 0;
+    }
+}

--- a/utils/psalm/FoundryPlugin.php
+++ b/utils/psalm/FoundryPlugin.php
@@ -20,5 +20,8 @@ final class FoundryPlugin implements PluginEntryPointInterface
     {
         \class_exists(FixProxyFactoryMethodsReturnType::class, true);
         $registration->registerHooksFromClass(FixProxyFactoryMethodsReturnType::class);
+
+        \class_exists(FixCreateHelpersReturnType::class, true);
+        $registration->registerHooksFromClass(FixCreateHelpersReturnType::class);
     }
 }


### PR DESCRIPTION
Fixes #799

## The bug

`SomeFactory::new()->someState()->createMany(2)` silently threw the state away. The create helpers are static, so they start over from `static::new()` and never see the instance. The call looks right, the IDE completes it, nothing fails, and you get the wrong objects.

## The fix

The four helpers now go through `__callStatic`, so a call made on an instance lands in `__call` instead, where `$this` is available and the state can be honored.

This is the route you suggested in the issue. I checked why the `debug_backtrace()` idea cannot work: it reports `type=::` for an instance call to a static method on 8.2, 8.4 and 8.5 alike, so there is no signal to read inside the method.

`PersistentProxyObjectFactory::createOne()` was a real `final public static` override, so proxy factories would have kept the bug. It is now `doCreateOne()` like the others.

## Deprecate now, throw in 3

The issue title asks for an exception. Your comment on it says something slightly different:

> Even if it makes the code crappier, those problems are really hard to detect, so I'd be OK to do this (but not document `UserFactory::new()->blocked()->createMany(3);`)

That reads as "let the call work, just do not advertise it", rather than "make it throw". Since 2.x cannot break in a minor, I went for the middle: deprecate in 2.13, honor the state meanwhile so nobody gets wrong objects, throw in 3. Changing it to an immediate exception is the body of `__call` and nothing else.

## Notes

- The signatures live in tags now, split per analyzer. `@phpstan-method` keeps the conditional return types and the aliases, and the assertions in `stubs/phpstan` still pass: without them PHPStan reports 17 errors, with them it is back to the one that already existed. `@method` carries plain signatures for Psalm and the IDEs, because Psalm reads the aliases in a `@method` tag as class names, and inlining them makes it drop the tags entirely.
- Psalm needed a plugin handler of its own, `FixCreateHelpersReturnType`. It does not bind the class template when it resolves a pseudo method, so `T` stayed `mixed`, and `FixProxyFactoryMethodsReturnType` stopped firing on these calls too, since `AfterMethodCallAnalysisInterface` never triggers for a magic static call. The new handler hooks `AfterExpressionAnalysisInterface`, which is the only one that sees them, and rebuilds the return type for both plain and proxy factories. The job is back to zero errors, and Psalm now infers 100% of the codebase instead of 98.5%.
- The PHPStan job is red on a file this pull request does not touch. `doctrine/orm` 3.7.0, released the day before that run, retyped `getEventManager()` to return `EventManagerInterface`, while `registerTo()` expects the concrete class. It reproduces on the base commit after a plain `composer update`, so I opened #1166 for it.
- The legacy proxy job was failing on `#[IgnoreDeprecations('...')]`: the attribute takes no argument, and PHPUnit 10 rejects it while analyzing the attribute. Dropped.
- The BC check reports the four helpers and the proxy override as removed, which is what this pull request does on purpose, so they join the baseline.
- `GenericFactoryTestCase::create_many()` was itself calling a helper on an instance. It now uses `many(3)->create()`.
- No `UPGRADE-2.13.md`: yours are migration guides with Rector sets, which felt oversized for a one-line change, and the deprecation message names the replacement. Happy to add one.
- I still cannot run the persistence suites here. Thanks for the sqlite tip, but this machine has neither `pdo_sqlite` nor `ext-mongodb`, so the kernel does not boot for those tests. Unit tests and PHPStan are what I can verify locally.