### PR TITLE
minor: fix SYMFONY_REQUIRE wildcard in the code coverage job

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -338,7 +338,7 @@ jobs:
         with:
           composer-options: --prefer-dist
         env:
-          SYMFONY_REQUIRE: 8.1.x
+          SYMFONY_REQUIRE: 8.1.*
 
       - name: Test with coverage
         run: ./phpunit --coverage-text --coverage-clover coverage.xml


### PR DESCRIPTION
The code coverage job used `SYMFONY_REQUIRE: 8.1.x`. Flex rewrites a trailing `.x` to `.x-dev`, which matches no `symfony/symfony` branch, so it silently stops restricting Symfony packages: the job installed `symfony/framework-bundle` 8.0.15 and `symfony/http-kernel` 7.4.18 next to 8.1 components (see [this run](https://github.com/zenstruck/foundry/actions/runs/33464489878/job/99721408476), no "Restricting packages listed in symfony/symfony" line in the install log).

`8.1.*` is the form Flex understands as a minor, like every other job.

https://claude.ai/code/session_01LwSqtXWbThCqudR6k7C6tK
